### PR TITLE
Use stable inference service hostname

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,13 @@ export GE_FIRESTORE_PROJECT="demo-no-project"
 
 ########## Inference Variables ##########
 
-export GE_INFERENCE_BASE_URL="https://engagement-prediction-inference-url.run.app"
+# Optional explicit override. In stage/prod Cloud Run deploys, the API deploy script
+# now defaults to mapped domains when this is unset:
+#   stage -> https://inference-stage.greenearth.social
+#   prod  -> https://inference.greenearth.social
+# Keep this set in local development when you want to call a local inference service.
+export GE_INFERENCE_BASE_URL=""
+export GE_INFERENCE_DOMAIN="inference-stage.greenearth.social"
+export GE_ENABLE_INFERENCE_DOMAIN_MAPPING=true
 export GE_INFERENCE_API_KEY="inference-service-api-key-here"
 export GE_INFERENCE_MAX_HISTORY_LEN=128

--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ This script will:
 - Configure the Elasticsearch connection using `GE_ELASTICSEARCH_URL` as non-secret config and `GE_ELASTICSEARCH_API_KEY` as a Secret Manager secret
 - Verify VPC connector for internal network access
 
+Before API deployment in stage/prod, run the inference setup script so domain mapping
+and DNS are in place for stable inference hostnames:
+
+```bash
+# stage
+cd ../engagement-prediction/inference_service
+GE_ENVIRONMENT=stage ./gcp_setup.sh
+
+# prod
+GE_ENVIRONMENT=prod ./gcp_setup.sh
+```
+
 > **Note**: The API uses a separate readonly Elasticsearch API key (`elasticsearch-api-key-readonly`)
 > that only has read access. This key is created by running `scripts/k8s_recreate_api_key.sh` in the
 > ingex/ingest directory, which creates both the ingest (read/write) and API (readonly) keys.
@@ -199,6 +211,17 @@ The deployment script will:
 - Build the container using Google Cloud buildpacks
 - Deploy to Cloud Run with proper environment variables and secrets
 
+Inference endpoint resolution order during deploy:
+
+1. Explicit `GE_INFERENCE_BASE_URL` / `--inference-base-url` (best for local overrides)
+2. Mapped domain from `GE_INFERENCE_DOMAIN` (or env default)
+3. If mapping is disabled and no base URL is provided, two_tower calls will fail
+
+Default mapped inference domains:
+
+- stage: `https://inference-stage.greenearth.social`
+- prod: `https://inference.greenearth.social`
+
 ### Configuration Options
 
 You can override deployment defaults using environment variables or command-line flags:
@@ -227,8 +250,17 @@ Available configuration inputs across `gcp_setup.sh` and `deploy.sh`:
 - `ENVIRONMENT` - Environment name (default: stage)
 - `GE_ELASTICSEARCH_URL` - Elasticsearch endpoint (auto-detected by `deploy.sh` if not set)
 - `GE_ELASTICSEARCH_API_KEY` - Elasticsearch readonly API key (accepted by `gcp_setup.sh`, then stored in Secret Manager for deploys)
+- `GE_INFERENCE_BASE_URL` - Explicit inference endpoint override (highest priority)
+- `GE_INFERENCE_DOMAIN` - Domain-mapped inference host used when base URL override is not set
+- `GE_ENABLE_INFERENCE_DOMAIN_MAPPING` - Toggle mapped-domain resolution in `deploy.sh` (default: true)
 - `API_INSTANCES_MIN` - Minimum instances (default: 1)
 - `API_INSTANCES_MAX` - Maximum instances (default: 10)
+
+For occasional local inference development while keeping stage/prod defaults:
+
+```bash
+GE_INFERENCE_BASE_URL="http://127.0.0.1:8001" ./scripts/deploy.sh --environment stage
+```
 
 ### Accessing the Deployed Service
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,6 +19,8 @@ GE_ELASTICSEARCH_URL="INTERNAL_LB_PLACEHOLDER"
 
 # Inference configuration
 GE_INFERENCE_BASE_URL="${GE_INFERENCE_BASE_URL:-}"
+GE_INFERENCE_DOMAIN="${GE_INFERENCE_DOMAIN:-}"
+GE_ENABLE_INFERENCE_DOMAIN_MAPPING="${GE_ENABLE_INFERENCE_DOMAIN_MAPPING:-true}"
 GE_INFERENCE_MAX_HISTORY_LEN="128"
 
 # Service configuration
@@ -49,6 +51,33 @@ log_build() {
     echo -e "${BLUE}[BUILD]${NC} $1"
 }
 
+default_inference_domain() {
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        echo "inference.greenearth.social"
+    else
+        echo "inference-stage.greenearth.social"
+    fi
+}
+
+resolve_inference_base_url() {
+    if [ -n "$GE_INFERENCE_BASE_URL" ]; then
+        log_info "Using explicit inference base URL override: $GE_INFERENCE_BASE_URL"
+        return
+    fi
+
+    if [ "$GE_ENABLE_INFERENCE_DOMAIN_MAPPING" != "true" ]; then
+        log_warn "Inference domain mapping disabled and GE_INFERENCE_BASE_URL is empty"
+        return
+    fi
+
+    if [ -z "$GE_INFERENCE_DOMAIN" ]; then
+        GE_INFERENCE_DOMAIN="$(default_inference_domain)"
+    fi
+
+    GE_INFERENCE_BASE_URL="https://$GE_INFERENCE_DOMAIN"
+    log_info "Using mapped inference URL: $GE_INFERENCE_BASE_URL"
+}
+
 validate_config() {
     log_info "Validating configuration..."
 
@@ -65,9 +94,9 @@ validate_config() {
         exit 1
     fi
 
-    if [ -n "$GE_INFERENCE_BASE_URL" ]; then
-        log_info "Using inference base URL: $GE_INFERENCE_BASE_URL"
-    else
+    resolve_inference_base_url
+
+    if [ -z "$GE_INFERENCE_BASE_URL" ]; then
         log_warn "GE_INFERENCE_BASE_URL not provided - two_tower ranker will fail if invoked"
     fi
 
@@ -397,6 +426,14 @@ while [[ $# -gt 0 ]]; do
             GE_INFERENCE_BASE_URL="$2"
             shift 2
             ;;
+        --inference-domain)
+            GE_INFERENCE_DOMAIN="$2"
+            shift 2
+            ;;
+        --disable-inference-domain-mapping)
+            GE_ENABLE_INFERENCE_DOMAIN_MAPPING="false"
+            shift
+            ;;
         --inference-max-history-len)
             GE_INFERENCE_MAX_HISTORY_LEN="$2"
             shift 2
@@ -422,6 +459,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --environment ENV        Environment name (default: stage)"
             echo "  --elasticsearch-url URL  Elasticsearch URL (default: INTERNAL_LB_PLACEHOLDER)"
             echo "  --inference-base-url URL Inference service base URL (required for two_tower)"
+            echo "  --inference-domain DOMAIN"
+            echo "                           Mapped inference domain (default: env-based)"
+            echo "  --disable-inference-domain-mapping"
+            echo "                           Require explicit --inference-base-url"
             echo "  --inference-max-history-len N"
             echo "                           Inference history length (default: 128)"
             echo "  --min-instances N        Minimum instances (default: 1)"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,9 +18,7 @@ ENVIRONMENT="stage"
 GE_ELASTICSEARCH_URL="INTERNAL_LB_PLACEHOLDER"
 
 # Inference configuration
-GE_INFERENCE_BASE_URL="${GE_INFERENCE_BASE_URL:-}"
-GE_INFERENCE_DOMAIN="${GE_INFERENCE_DOMAIN:-}"
-GE_ENABLE_INFERENCE_DOMAIN_MAPPING="${GE_ENABLE_INFERENCE_DOMAIN_MAPPING:-true}"
+GE_INFERENCE_BASE_URL=""
 GE_INFERENCE_MAX_HISTORY_LEN="128"
 
 # Service configuration
@@ -60,21 +58,9 @@ default_inference_domain() {
 }
 
 resolve_inference_base_url() {
-    if [ -n "$GE_INFERENCE_BASE_URL" ]; then
-        log_info "Using explicit inference base URL override: $GE_INFERENCE_BASE_URL"
-        return
-    fi
-
-    if [ "$GE_ENABLE_INFERENCE_DOMAIN_MAPPING" != "true" ]; then
-        log_warn "Inference domain mapping disabled and GE_INFERENCE_BASE_URL is empty"
-        return
-    fi
-
-    if [ -z "$GE_INFERENCE_DOMAIN" ]; then
-        GE_INFERENCE_DOMAIN="$(default_inference_domain)"
-    fi
-
-    GE_INFERENCE_BASE_URL="https://$GE_INFERENCE_DOMAIN"
+    local inference_domain
+    inference_domain="$(default_inference_domain)"
+    GE_INFERENCE_BASE_URL="https://$inference_domain"
     log_info "Using mapped inference URL: $GE_INFERENCE_BASE_URL"
 }
 
@@ -95,10 +81,6 @@ validate_config() {
     fi
 
     resolve_inference_base_url
-
-    if [ -z "$GE_INFERENCE_BASE_URL" ]; then
-        log_warn "GE_INFERENCE_BASE_URL not provided - two_tower ranker will fail if invoked"
-    fi
 
     log_info "Configuration validation complete."
 }
@@ -422,18 +404,6 @@ while [[ $# -gt 0 ]]; do
             GE_ELASTICSEARCH_URL="$2"
             shift 2
             ;;
-        --inference-base-url)
-            GE_INFERENCE_BASE_URL="$2"
-            shift 2
-            ;;
-        --inference-domain)
-            GE_INFERENCE_DOMAIN="$2"
-            shift 2
-            ;;
-        --disable-inference-domain-mapping)
-            GE_ENABLE_INFERENCE_DOMAIN_MAPPING="false"
-            shift
-            ;;
         --inference-max-history-len)
             GE_INFERENCE_MAX_HISTORY_LEN="$2"
             shift 2
@@ -458,11 +428,6 @@ while [[ $# -gt 0 ]]; do
             echo "  --region REGION          GCP region (default: us-east1)"
             echo "  --environment ENV        Environment name (default: stage)"
             echo "  --elasticsearch-url URL  Elasticsearch URL (default: INTERNAL_LB_PLACEHOLDER)"
-            echo "  --inference-base-url URL Inference service base URL (required for two_tower)"
-            echo "  --inference-domain DOMAIN"
-            echo "                           Mapped inference domain (default: env-based)"
-            echo "  --disable-inference-domain-mapping"
-            echo "                           Require explicit --inference-base-url"
             echo "  --inference-max-history-len N"
             echo "                           Inference history length (default: 128)"
             echo "  --min-instances N        Minimum instances (default: 1)"

--- a/scripts/e2e-rank-test.sh
+++ b/scripts/e2e-rank-test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-greenearth-471522}"
+REGION="${REGION:-us-east1}"
+RAW_ENVIRONMENT="${E2E_ENVIRONMENT:-${ENVIRONMENT:-stage}}"
+if [[ "$RAW_ENVIRONMENT" == "stage" || "$RAW_ENVIRONMENT" == "prod" ]]; then
+  ENVIRONMENT="$RAW_ENVIRONMENT"
+else
+  ENVIRONMENT="stage"
+fi
+MODEL="${MODEL:-two_tower}"
+NUM_CANDIDATES="${NUM_CANDIDATES:-5}"
+MAX_USERS_TO_TRY="${MAX_USERS_TO_TRY:-25}"
+CANDIDATE_GENERATOR="${CANDIDATE_GENERATOR:-post_similarity}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() {
+  echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $1"
+}
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --project-id ID        GCP project ID (default: $PROJECT_ID)
+  --region REGION        GCP region (default: $REGION)
+  --environment ENV      Environment: stage|prod (default: $ENVIRONMENT)
+  --api-url URL          API base URL (default: discovered from Cloud Run)
+  --model NAME           Ranking model (default: $MODEL)
+  --num-candidates N     Candidates to request (default: $NUM_CANDIDATES)
+  --max-users N          Max user_dids to try from likes agg (default: $MAX_USERS_TO_TRY)
+  --generator NAME       Candidate generator to use (default: $CANDIDATE_GENERATOR)
+  --help                 Show this help
+
+Environment variable overrides:
+  PROJECT_ID REGION E2E_ENVIRONMENT (or ENVIRONMENT) API_URL MODEL NUM_CANDIDATES MAX_USERS_TO_TRY CANDIDATE_GENERATOR
+
+What this script does:
+  1) Discovers an API URL (if not provided)
+  2) Fetches API auth key from Secret Manager
+  3) Connects to stage/prod GKE and reads Elasticsearch password
+  4) Finds users with likes from Elasticsearch
+  5) Finds a user that yields non-empty candidates
+  6) Calls /rank/predict with that user + candidates
+  7) Fails if ranking output is empty
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log_error "Missing required command: $1"
+    exit 1
+  fi
+}
+
+API_URL="${API_URL:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-id)
+      PROJECT_ID="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --environment)
+      ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --api-url)
+      API_URL="$2"
+      shift 2
+      ;;
+    --model)
+      MODEL="$2"
+      shift 2
+      ;;
+    --num-candidates)
+      NUM_CANDIDATES="$2"
+      shift 2
+      ;;
+    --max-users)
+      MAX_USERS_TO_TRY="$2"
+      shift 2
+      ;;
+    --generator)
+      CANDIDATE_GENERATOR="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      log_error "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$ENVIRONMENT" != "stage" && "$ENVIRONMENT" != "prod" ]]; then
+  log_error "ENVIRONMENT must be stage or prod"
+  exit 1
+fi
+
+require_cmd gcloud
+require_cmd kubectl
+require_cmd curl
+require_cmd jq
+
+if [[ -z "$API_URL" ]]; then
+  SERVICE_NAME="greenearth-api-$ENVIRONMENT"
+  API_URL=$(gcloud run services describe "$SERVICE_NAME" \
+    --platform=managed \
+    --region="$REGION" \
+    --project="$PROJECT_ID" \
+    --format='value(status.url)')
+  if [[ -z "$API_URL" ]]; then
+    log_error "Could not discover API URL for service $SERVICE_NAME"
+    exit 1
+  fi
+fi
+
+if [[ "$ENVIRONMENT" == "prod" ]]; then
+  API_KEY_SECRET="api-key-prod"
+else
+  API_KEY_SECRET="api-key"
+fi
+
+log_info "Using API URL: $API_URL"
+log_info "Using project: $PROJECT_ID, region: $REGION, environment: $ENVIRONMENT"
+
+API_KEY=$(gcloud secrets versions access latest --secret="$API_KEY_SECRET" --project="$PROJECT_ID")
+if [[ -z "$API_KEY" ]]; then
+  log_error "Failed to fetch API key from secret $API_KEY_SECRET"
+  exit 1
+fi
+
+CLUSTER_NAME="greenearth-${ENVIRONMENT}-cluster"
+NAMESPACE="greenearth-${ENVIRONMENT}"
+
+log_info "Configuring kubectl context for $CLUSTER_NAME"
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  --location="$REGION" \
+  --project="$PROJECT_ID" >/dev/null
+
+ELASTIC_PASSWORD=$(kubectl get secret greenearth-es-elastic-user -n "$NAMESPACE" -o go-template='{{.data.elastic | base64decode}}')
+if [[ -z "$ELASTIC_PASSWORD" ]]; then
+  log_error "Failed to fetch elastic password from greenearth-es-elastic-user in $NAMESPACE"
+  exit 1
+fi
+
+PORT_FORWARD_LOG=$(mktemp)
+cleanup() {
+  if [[ -n "${PF_PID:-}" ]] && kill -0 "$PF_PID" >/dev/null 2>&1; then
+    kill "$PF_PID" >/dev/null 2>&1 || true
+    wait "$PF_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$PORT_FORWARD_LOG"
+}
+trap cleanup EXIT
+
+log_info "Starting temporary port-forward to Elasticsearch"
+kubectl port-forward service/greenearth-es-http 9200:9200 -n "$NAMESPACE" >"$PORT_FORWARD_LOG" 2>&1 &
+PF_PID=$!
+
+for _ in $(seq 1 20); do
+  if curl -sk --max-time 2 https://localhost:9200 >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! curl -sk --max-time 2 https://localhost:9200 >/dev/null 2>&1; then
+  log_error "Elasticsearch port-forward did not become ready"
+  cat "$PORT_FORWARD_LOG"
+  exit 1
+fi
+
+log_info "Fetching top users with likes from Elasticsearch"
+TOP_USERS_JSON=$(curl -sk -u "elastic:$ELASTIC_PASSWORD" \
+  'https://localhost:9200/likes/_search' \
+  -H 'Content-Type: application/json' \
+  -d "{\"size\":0,\"aggs\":{\"top_users\":{\"terms\":{\"field\":\"author_did\",\"size\":$MAX_USERS_TO_TRY,\"order\":{\"_count\":\"desc\"}}}}}")
+
+USER_DIDS=$(echo "$TOP_USERS_JSON" | jq -r '.aggregations.top_users.buckets[].key')
+if [[ -z "$USER_DIDS" ]]; then
+  log_error "No user_dids found in likes index"
+  exit 1
+fi
+
+FOUND_USER=""
+FOUND_CANDIDATES=""
+
+for USER_DID in $USER_DIDS; do
+  log_info "Trying user_did: $USER_DID"
+
+  GEN_PAYLOAD=$(jq -n \
+    --arg gen "$CANDIDATE_GENERATOR" \
+    --arg did "$USER_DID" \
+    --argjson n "$NUM_CANDIDATES" \
+    '{generators:[{name:$gen,weight:1}],user_did:$did,num_candidates:$n}')
+
+  GEN_RESPONSE=$(curl -sS \
+    -H "X-API-Key: $API_KEY" \
+    -H 'Content-Type: application/json' \
+    "$API_URL/candidates/generate" \
+    -d "$GEN_PAYLOAD")
+
+  CAND_COUNT=$(echo "$GEN_RESPONSE" | jq '.candidates | length' 2>/dev/null || echo 0)
+  if [[ "$CAND_COUNT" -gt 0 ]]; then
+    FOUND_USER="$USER_DID"
+    FOUND_CANDIDATES="$GEN_RESPONSE"
+    log_info "Found usable user with $CAND_COUNT candidates: $FOUND_USER"
+    break
+  fi
+
+done
+
+if [[ -z "$FOUND_USER" ]]; then
+  log_error "Could not find any user producing non-empty candidates with generator '$CANDIDATE_GENERATOR'"
+  exit 1
+fi
+
+RANK_PAYLOAD=$(echo "$FOUND_CANDIDATES" | jq -c \
+  --arg model "$MODEL" \
+  --arg did "$FOUND_USER" \
+  '{model:$model,user_did:$did,candidates:.candidates}')
+
+log_info "Calling /rank/predict for user $FOUND_USER with model $MODEL"
+RANK_RESPONSE=$(curl -sS \
+  -H "X-API-Key: $API_KEY" \
+  -H 'Content-Type: application/json' \
+  "$API_URL/rank/predict" \
+  -d "$RANK_PAYLOAD")
+
+RANK_COUNT=$(echo "$RANK_RESPONSE" | jq '.rankings | length' 2>/dev/null || echo 0)
+
+if [[ "$RANK_COUNT" -le 0 ]]; then
+  log_error "Rank response was empty"
+  echo "$RANK_RESPONSE" | jq . || echo "$RANK_RESPONSE"
+  exit 1
+fi
+
+log_info "E2E rank test passed"
+log_info "Selected user_did: $FOUND_USER"
+log_info "Candidates: $(echo "$FOUND_CANDIDATES" | jq '.candidates | length')"
+log_info "Rankings: $RANK_COUNT"
+
+echo
+jq -n \
+  --arg api_url "$API_URL" \
+  --arg env "$ENVIRONMENT" \
+  --arg user_did "$FOUND_USER" \
+  --arg model "$MODEL" \
+  --argjson num_candidates "$NUM_CANDIDATES" \
+  --argjson rankings "$RANK_COUNT" \
+  '{status:"ok",environment:$env,api_url:$api_url,user_did:$user_did,model:$model,num_candidates:$num_candidates,rankings:$rankings}'

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -520,7 +520,9 @@ main() {
     echo ""
     log_info "Next steps:"
     log_info "  1. Review and configure secrets in Secret Manager if needed"
-    log_info "  2. Run ./scripts/deploy.sh to deploy the API to Cloud Run"
+    log_info "  2. Ensure inference domain mapping is set up (inference-stage/inference)"
+    log_info "     via ../engagement-prediction/inference_service/gcp_setup.sh"
+    log_info "  3. Run ./scripts/deploy.sh to deploy the API to Cloud Run"
     echo ""
 }
 


### PR DESCRIPTION
This PR uses the stable inference service hostname to call the inference service. It also includes a new script for testing the rank endpoint end-to-end to make sure the connection between services is functioning properly.