### PR TITLE
Keep track of which of our feeds a user has loaded, and when

### DIFF
--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -45,3 +45,9 @@ class FeedCacheDocument(BaseModel):
 
     items: list[str] = Field(default_factory=list, description="Cached AT URI list")
     expires_at: datetime = Field(..., description="UTC expiration timestamp for this cache entry")
+
+
+class FeedActivityDocument(BaseModel):
+    feed_name: str = Field(..., description="AT Protocol rkey of the feed (also the document ID)")
+    first_seen_at: datetime = Field(default_factory=_utcnow, description="When the user first loaded this feed")
+    last_seen_at: datetime = Field(default_factory=_utcnow, description="Most recent time the user loaded this feed")

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -13,11 +13,12 @@ from datetime import datetime, timezone
 
 from google.cloud.firestore import AsyncClient  # type: ignore[import-untyped]
 
-from ..documents import UserDocument
+from ..documents import FeedActivityDocument, UserDocument
 
 logger = logging.getLogger(__name__)
 
 USERS_COLLECTION = "users"
+FEED_ACTIVITY_COLLECTION = "feed_activity"
 
 
 def init_firestore_client() -> AsyncClient:
@@ -101,3 +102,61 @@ async def upsert_user(db: AsyncClient, user_did: str, username: str) -> UserDocu
     )
     await ref.set(user.model_dump())
     return user
+
+
+# ---------------------------------------------------------------------------
+# Feed activity
+# ---------------------------------------------------------------------------
+
+
+async def get_feed_activity(db: AsyncClient, user_did: str, feed_name: str) -> FeedActivityDocument | None:
+    """Fetch a feed activity document, or return ``None`` if not found."""
+    doc = await (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(FEED_ACTIVITY_COLLECTION)
+        .document(feed_name)
+        .get()
+    )
+    if not doc.exists:
+        return None
+    data = doc.to_dict()
+    if data is None:
+        return None
+    return FeedActivityDocument.model_validate(data)
+
+
+async def upsert_feed_activity(db: AsyncClient, user_did: str, feed_name: str) -> FeedActivityDocument:
+    """Record that a user loaded a feed.
+
+    On first visit creates the document with both timestamps set to now.
+    On subsequent visits updates only ``last_seen_at``; ``first_seen_at`` is
+    never overwritten.
+    """
+    ref = (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(FEED_ACTIVITY_COLLECTION)
+        .document(feed_name)
+    )
+    doc = await ref.get()
+
+    now = datetime.now(timezone.utc)
+
+    if doc.exists:
+        data = doc.to_dict()
+        if data is None:
+            raise ValueError(
+                f"Firestore feed_activity document exists but to_dict() returned None for {user_did}/{feed_name}"
+            )
+        await ref.update({"last_seen_at": now})
+        data["last_seen_at"] = now
+        return FeedActivityDocument.model_validate(data)
+
+    activity = FeedActivityDocument(
+        feed_name=feed_name,
+        first_seen_at=now,
+        last_seen_at=now,
+    )
+    await ref.set(activity.model_dump())
+    return activity

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -10,8 +10,10 @@ import pytest
 from ..documents import UserDocument
 from ..lib.firestore import (
     USERS_COLLECTION,
+    get_feed_activity,
     get_user,
     init_firestore_client,
+    upsert_feed_activity,
     upsert_user,
 )
 
@@ -22,6 +24,14 @@ from ..lib.firestore import (
 
 USER_DID = "did:plc:testuser123"
 USERNAME = "testuser.bsky.app"
+FEED_NAME = "basic-similarity"
+
+
+def _mock_feed_activity_client():
+    db = MagicMock()
+    doc_ref = AsyncMock()
+    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    return db, doc_ref
 
 
 def _mock_doc_snapshot(exists: bool, data: dict | None = None) -> MagicMock:
@@ -210,3 +220,92 @@ class TestUpsertUser:
         update_fields = doc_ref.update.call_args[0][0]
         assert update_fields["username"] == USERNAME
         assert "updated_at" in update_fields
+
+
+# ---------------------------------------------------------------------------
+# get_feed_activity
+# ---------------------------------------------------------------------------
+
+
+class TestGetFeedActivity:
+    @pytest.mark.asyncio
+    async def test_returns_doc_when_exists(self):
+        db, doc_ref = _mock_feed_activity_client()
+        now = datetime.now(timezone.utc)
+        doc_ref.get.return_value = _mock_doc_snapshot(True, {
+            "feed_name": FEED_NAME,
+            "first_seen_at": now,
+            "last_seen_at": now,
+        })
+
+        activity = await get_feed_activity(db, USER_DID, FEED_NAME)
+
+        assert activity is not None
+        assert activity.feed_name == FEED_NAME
+        assert activity.first_seen_at == now
+        assert activity.last_seen_at == now
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self):
+        db, doc_ref = _mock_feed_activity_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        activity = await get_feed_activity(db, USER_DID, FEED_NAME)
+
+        assert activity is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_feed_activity
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertFeedActivity:
+    @pytest.mark.asyncio
+    async def test_creates_new_doc_on_first_visit(self):
+        db, doc_ref = _mock_feed_activity_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
+
+        assert activity.feed_name == FEED_NAME
+        assert isinstance(activity.first_seen_at, datetime)
+        assert isinstance(activity.last_seen_at, datetime)
+        doc_ref.set.assert_called_once()
+        written = doc_ref.set.call_args[0][0]
+        assert written["feed_name"] == FEED_NAME
+        assert "first_seen_at" in written
+        assert "last_seen_at" in written
+
+    @pytest.mark.asyncio
+    async def test_updates_only_last_seen_at_on_revisit(self):
+        db, doc_ref = _mock_feed_activity_client()
+        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        doc_ref.get.return_value = _mock_doc_snapshot(True, {
+            "feed_name": FEED_NAME,
+            "first_seen_at": original_time,
+            "last_seen_at": original_time,
+        })
+
+        activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
+
+        assert activity.last_seen_at > original_time
+        doc_ref.update.assert_called_once()
+        update_fields = doc_ref.update.call_args[0][0]
+        assert "last_seen_at" in update_fields
+        assert "first_seen_at" not in update_fields
+        doc_ref.set.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_first_seen_at(self):
+        db, doc_ref = _mock_feed_activity_client()
+        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        doc_ref.get.return_value = _mock_doc_snapshot(True, {
+            "feed_name": FEED_NAME,
+            "first_seen_at": original_time,
+            "last_seen_at": original_time,
+        })
+
+        activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
+
+        assert activity.first_seen_at == original_time

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -23,7 +23,7 @@ from ..lib.candidates import run_generate
 from ..lib.feed_cache import FeedCache, FirestoreFeedCache, DEFAULT_TTL_SECONDS
 from ..models import CandidateGenerateRequest, FeedCursor, GeneratorSpec
 from ..lib.atproto_auth import verify_auth_header
-from ..lib.firestore import upsert_user
+from ..lib.firestore import upsert_feed_activity, upsert_user
 from ..feeds import FEEDS
 
 logger = logging.getLogger(__name__)
@@ -243,6 +243,12 @@ async def get_feed_skeleton(
         await upsert_user(db, user_did, username)
     except Exception:
         logger.exception("Failed to upsert user '%s' in Firestore", user_did)
+        raise HTTPException(status_code=500, detail="Firestore write failed")
+
+    try:
+        await upsert_feed_activity(db, user_did, feed_name)
+    except Exception:
+        logger.exception("Failed to record feed activity for user '%s', feed '%s'", user_did, feed_name)
         raise HTTPException(status_code=500, detail="Firestore write failed")
 
     feed_cache = _get_feed_cache(request)

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -177,7 +177,8 @@ class TestGetFeedSkeleton:
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Keep Firestore I/O out of generic feed skeleton tests."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -386,7 +387,8 @@ class TestFeedSkeletonCursor:
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -724,7 +726,8 @@ class TestGetFeedSkeletonAuth:
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Avoid real Firestore interactions unless a test explicitly patches it."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
             yield
 
     def test_authenticated_user_did_passed_to_generator(self):
@@ -898,6 +901,56 @@ class TestGetFeedSkeletonAuth:
 
         assert resp.status_code == 401
         mock_upsert.assert_not_awaited()
+
+    def test_authenticated_request_records_feed_activity(self):
+        """Authenticated requests should record feed activity in Firestore."""
+        mock_payload = MagicMock()
+        mock_payload.iss = "did:plc:autheduser"
+
+        with (
+            self._patch_generators(_make_candidates("p", 2)),
+            patch(
+                "app.lib.atproto_auth.verify_jwt_async",
+                new_callable=AsyncMock,
+                return_value=mock_payload,
+            ),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock) as mock_activity,
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI},
+                headers={"Authorization": "Bearer valid.jwt.token"},
+            )
+
+        assert resp.status_code == 200
+        mock_activity.assert_awaited_once_with(app.state.firestore, "did:plc:autheduser", FEED_RKEY)
+
+    def test_feed_activity_failure_is_fatal(self):
+        """Feed activity write errors should fail the request."""
+        mock_payload = MagicMock()
+        mock_payload.iss = "did:plc:autheduser"
+
+        with (
+            self._patch_generators(_make_candidates("p", 2)),
+            patch(
+                "app.lib.atproto_auth.verify_jwt_async",
+                new_callable=AsyncMock,
+                return_value=mock_payload,
+            ),
+            patch(
+                "app.routers.xrpc.upsert_feed_activity",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("firestore down"),
+            ),
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI},
+                headers={"Authorization": "Bearer valid.jwt.token"},
+            )
+
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Firestore write failed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #36

Adds per-user feed activity tracking to Firestore. Each time an authenticated user calls `getFeedSkeleton`, the backend records which feed they loaded and when, storing a `first_seen_at` timestamp (set once) and a `last_seen_at` timestamp (updated on every visit) in a `users/{user_did}/feed_activity/{feed_name}` subcollection.

We are intentionally introducing a per-feed subcollection (instead of stuffing this into the existing user collection) in anticipation of storing user interaction data per feed: greenearth-social/ingex#89, greenearth-social/ingex#214.

# This PR

- Adds `FeedActivityDocument` Pydantic model to `documents.py`
- Adds `FEED_ACTIVITY_COLLECTION`, `get_feed_activity`, and `upsert_feed_activity` helpers to `firestore.py`, mirroring the existing `get_user`/`upsert_user` pattern
- Calls `upsert_feed_activity` in the XRPC router immediately after `upsert_user` on every authenticated `getFeedSkeleton` request, with identical fatal error handling
- Adds `TestGetFeedActivity` (2 tests) and `TestUpsertFeedActivity` (3 tests) to `firestore_test.py`
- Updates the three `_mock_firestore_upsert` autouse fixtures in `xrpc_test.py` to also patch `upsert_feed_activity`, and adds two new auth tests verifying the call and fatal failure behavior

# Testing

- `pipenv run pytest` — all 222 tests pass

# Deploy & Verify

## Deployment

No schema migrations are required. Firestore creates the `feed_activity` subcollection lazily on first write. Deploy the updated API server normally.

## Local verification (Firestore emulator)

```bash
# Start the Firestore emulator
GE_FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 pipenv run uvicorn src.app.main:app --reload

# In a separate terminal, make an authenticated getFeedSkeleton request for any feed:
curl -H "Authorization: Bearer <valid_jwt>" \
  "http://localhost:8000/xrpc/app.bsky.feed.getFeedSkeleton?feed=<feed_at_uri>"
```

After the request, open the emulator UI at `http://localhost:4000/firestore` and confirm:

- A document exists at `users/{user_did}/feed_activity/{feed_name}`
- It contains `feed_name`, `first_seen_at`, and `last_seen_at` fields
- Making the same request again updates `last_seen_at` but leaves `first_seen_at` unchanged

## Production spot-check

After deploying, inspect Firestore in the GCP console under the `users` collection. Within a few minutes of live traffic, `feed_activity` subcollections should appear on user documents.