### PR TITLE
Switch KNN searches to `posts_recent` index and add timing telemetry

### DIFF
--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -5,15 +5,16 @@ Generates candidates by finding posts similar to a user's recent likes:
 1. Query the ``likes`` index for the user's most recent liked posts.
 2. Fetch those posts from the ``posts`` index to retrieve MiniLM L12 embeddings.
 3. Average the embeddings into a single query vector.
-4. Run a kNN nearest-neighbours search against the ``posts`` index.
+4. Run a kNN nearest-neighbours search against the ``posts_recent`` index.
 """
 
 import logging
 
 from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
-from ..elasticsearch import unwrap_es_response, fetch_recent_liked_post_uris, fetch_post_embeddings
+from ..elasticsearch import unwrap_es_response, fetch_recent_liked_post_uris, fetch_post_embeddings, POSTS_KNN_INDEX
 from ..embeddings import encode_float32_b64
+from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ async def knn_search_posts(
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
 ) -> list[CandidatePost]:
-    """Run a kNN search against the ``posts`` index and return candidate posts.
+    """Run a kNN search against the ``posts_recent`` index and return candidate posts.
 
     Uses the ``embeddings.all_MiniLM_L12_v2`` field for nearest-neighbour
     matching.  Each hit is converted to a :class:`CandidatePost` with the ES
@@ -69,7 +70,8 @@ async def knn_search_posts(
         }
     }
 
-    resp = await es.search(index="posts", query=knn_query, size=num_candidates, request_timeout=60)
+    async with timed(logger, "knn_search_posts", index=POSTS_KNN_INDEX, num_candidates=num_candidates):
+        resp = await es.search(index=POSTS_KNN_INDEX, query=knn_query, size=num_candidates, request_timeout=60)
     data = unwrap_es_response(resp)
 
     candidates: list[CandidatePost] = []

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -171,7 +171,7 @@ class TestKnnSearchPosts:
     @pytest.mark.asyncio
     async def test_returns_candidates_with_scores(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -197,7 +197,7 @@ class TestKnnSearchPosts:
     @pytest.mark.asyncio
     async def test_passes_generator_name(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -220,7 +220,7 @@ class TestKnnSearchPosts:
     @pytest.mark.asyncio
     async def test_video_only_true_includes_filter(self):
         es = FakeEs(responses={
-            "posts": {"hits": {"hits": []}}
+            "posts_recent": {"hits": {"hits": []}}
         })
         await knn_search_posts(es, [0.1, 0.2], num_candidates=5, video_only=True)
         query = es.calls[0]["query"]
@@ -229,7 +229,7 @@ class TestKnnSearchPosts:
     @pytest.mark.asyncio
     async def test_video_only_false_omits_filter(self):
         es = FakeEs(responses={
-            "posts": {"hits": {"hits": []}}
+            "posts_recent": {"hits": {"hits": []}}
         })
         await knn_search_posts(es, [0.1, 0.2], num_candidates=5, video_only=False)
         query = es.calls[0]["query"]
@@ -261,26 +261,26 @@ class TestPostSimilarityGenerator:
                         }
                     }
                 if index == "posts":
-                    # Check if this is the embedding lookup or the knn search
-                    if isinstance(query, dict) and "terms" in query:
-                        return {
-                            "hits": {
-                                "hits": [
-                                    {
-                                        "_source": {
-                                            "at_uri": "at://post/2",
-                                            "embeddings": {"all_MiniLM_L12_v2": [0.0, 1.0]},
-                                        }
-                                    },
-                                    {
-                                        "_source": {
-                                            "at_uri": "at://post/1",
-                                            "embeddings": {"all_MiniLM_L12_v2": [1.0, 0.0]},
-                                        }
-                                    },
-                                ]
-                            }
+                    # Embedding lookup by URI
+                    return {
+                        "hits": {
+                            "hits": [
+                                {
+                                    "_source": {
+                                        "at_uri": "at://post/2",
+                                        "embeddings": {"all_MiniLM_L12_v2": [0.0, 1.0]},
+                                    }
+                                },
+                                {
+                                    "_source": {
+                                        "at_uri": "at://post/1",
+                                        "embeddings": {"all_MiniLM_L12_v2": [1.0, 0.0]},
+                                    }
+                                },
+                            ]
                         }
+                    }
+                if index == "posts_recent":
                     # kNN search
                     return {
                         "hits": {

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 # How many recent likes to consider when building the query vector.
 DEFAULT_LIKED_POSTS_LIMIT = 50
 
+# Index alias for KNN searches — targets only the last ~1 week of posts for speed.
+POSTS_KNN_INDEX = "posts_recent"
+
 
 def unwrap_es_response(resp) -> dict:
     """Unwrap an Elasticsearch response, handling both ObjectApiResponse and dict.

--- a/src/app/lib/telemetry.py
+++ b/src/app/lib/telemetry.py
@@ -1,0 +1,27 @@
+"""Telemetry helpers for timing API and Elasticsearch operations."""
+
+import logging
+import time
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def timed(logger: logging.Logger, label: str, **extra: object):
+    """Async context manager that logs elapsed time for a labelled operation.
+
+    Usage::
+
+        async with timed(logger, "knn_search", index="posts_recent"):
+            resp = await es.search(...)
+    """
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.monotonic() - start) * 1000
+        logger.info(
+            "%s elapsed_ms=%.1f",
+            label,
+            elapsed_ms,
+            extra={"elapsed_ms": elapsed_ms, **extra},
+        )

--- a/src/app/routers/candidates_test.py
+++ b/src/app/routers/candidates_test.py
@@ -47,31 +47,31 @@ def fake_app_es():
                             ]
                         }
                     }
-                # function_score (popularity) or kNN (post_similarity)
-                if isinstance(query, dict) and "function_score" in query:
-                    return {
-                        "hits": {
-                            "hits": [
-                                {
-                                    "_score": 12.5,
-                                    "_source": {
-                                        "at_uri": "at://popular/1",
-                                        "content": "trending post",
-                                        "embeddings": {"all_MiniLM_L12_v2": [0.5, 0.6]},
-                                    },
+                # function_score (popularity or random_posts)
+                return {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 12.5,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "trending post",
+                                    "embeddings": {"all_MiniLM_L12_v2": [0.5, 0.6]},
                                 },
-                                {
-                                    "_score": 10.0,
-                                    "_source": {
-                                        "at_uri": "at://popular/2",
-                                        "content": "also trending",
-                                        "embeddings": {},
-                                    },
+                            },
+                            {
+                                "_score": 10.0,
+                                "_source": {
+                                    "at_uri": "at://popular/2",
+                                    "content": "also trending",
+                                    "embeddings": {},
                                 },
-                            ]
-                        }
+                            },
+                        ]
                     }
-                # kNN search result
+                }
+            if index == "posts_recent":
+                # kNN search result (post_similarity)
                 return {
                     "hits": {
                         "hits": [

--- a/src/app/routers/skylight.py
+++ b/src/app/routers/skylight.py
@@ -8,7 +8,8 @@ from ..security import verify_api_key
 from pydantic import BaseModel
 from ..models import CandidatePost
 from ..lib.embeddings import encode_float32_b64, decode_float32_b64
-from ..lib.elasticsearch import unwrap_es_response
+from ..lib.elasticsearch import unwrap_es_response, POSTS_KNN_INDEX
+from ..lib.telemetry import timed
 
 router = APIRouter(tags=["skylight"], dependencies=[Depends(verify_api_key)])
 
@@ -189,7 +190,8 @@ async def skylight_similar(request: Request, payload: SkylightSimilarRequest):
     }
 
     try:
-        resp = await request.app.state.es.search(index="posts", query=knn_q, size=payload.size)
+        async with timed(logger, "skylight_similar_knn", index=POSTS_KNN_INDEX, size=payload.size):
+            resp = await request.app.state.es.search(index=POSTS_KNN_INDEX, query=knn_q, size=payload.size)
     except Exception as exc:
         logger.exception("Elasticsearch similar search failed")
         raise HTTPException(status_code=502, detail="Elasticsearch request failed") from exc


### PR DESCRIPTION
The production feed was effectively broken for users relying on KNN-based ranking because all KNN queries were hitting the full `posts` index alias, which is extremely slow for nearest-neighbour search. This switches both KNN call sites to the `posts_recent` alias (last ~1 week of posts), which was created in greenearth-social/ingex#315 specifically for this purpose.

Note: embedding lookups by URI (to build the query vector from a user's liked posts) intentionally remain on the full `posts` index, since liked posts may be older than a week.

A `POSTS_KNN_INDEX` constant is introduced in `lib/elasticsearch.py` as the single source of truth for the KNN index name, so future callers can't accidentally use the wrong index.

A reusable `timed` async context manager is added in `lib/telemetry.py` and applied to both KNN call sites, so we can observe actual latency in production logs and verify the improvement.

Closes #59 