### PR TITLE
Diversification pass on generated feeds

### DIFF
--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -140,6 +140,7 @@ async def popularity_search(
                 minilm_l12_embedding=encoded,
                 score=hit.get("_score"),
                 generator_name=generator_name,
+                author_did=src.get("author_did"),
             )
         )
     return candidates

--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -97,6 +97,7 @@ async def knn_search_posts(
                 minilm_l12_embedding=encoded,
                 score=hit.get("_score"),
                 generator_name=generator_name,
+                author_did=src.get("author_did"),
             )
         )
     return candidates

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -68,6 +68,7 @@ async def random_posts_search(
                 minilm_l12_embedding=encoded,
                 score=hit.get("_score"),
                 generator_name=generator_name,
+                author_did=src.get("author_did"),
             )
         )
 

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -8,53 +8,88 @@ from ..models import CandidatePost
 BETA = 0.5
 AUTHOR_WEIGHT = 0.75
 
+
 def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     if len(candidates) <= 1:
         return list(candidates)
 
+    n = len(candidates)
     max_score = max((c.score or 0.0) for c in candidates)
-    if max_score > 0.0:
-        norm_scores = [(c.score or 0.0) / max_score for c in candidates]
-    else:
-        norm_scores = [0.0] * len(candidates)
+    norm_scores = (
+        [(c.score or 0.0) / max_score for c in candidates]
+        if max_score > 0.0
+        else [0.0] * n
+    )
 
+    # Pre-decode embeddings once so the inner loop never repeats base64 work.
+    vecs: list[list[float] | None] = []
+    for c in candidates:
+        if c.minilm_l12_embedding is not None:
+            try:
+                vecs.append(decode_float32_b64(c.minilm_l12_embedding))
+            except Exception:
+                vecs.append(None)
+        else:
+            vecs.append(None)
+
+    author_dids = [c.author_did for c in candidates]
+    remaining = list(range(n))
     selected: list[int] = []
-    remaining: list[int] = list(range(len(candidates)))
+    # max_sim[i] tracks the highest similarity candidate i has to any selected
+    # candidate so far. Updated incrementally — one new comparison per remaining
+    # item each round instead of recomputing the full max from scratch.
+    max_sim = [0.0] * n
 
     while remaining:
         if not selected:
             best = max(remaining, key=lambda i: norm_scores[i])
         else:
-            def mmr_score(i: int) -> float:
-                rel = (1 - BETA) * norm_scores[i]
-                sim = BETA * max(_similarity(candidates[i], candidates[j]) for j in selected)
-                return rel - sim
-            best = max(remaining, key=mmr_score)
+            best = max(
+                remaining,
+                key=lambda i: (1 - BETA) * norm_scores[i] - BETA * max_sim[i],
+            )
 
         selected.append(best)
         remaining.remove(best)
 
+        for i in remaining:
+            s = _raw_similarity(author_dids[i], author_dids[best], vecs[i], vecs[best])
+            if s > max_sim[i]:
+                max_sim[i] = s
+
     return [candidates[i] for i in selected]
 
 
-def _similarity(a: CandidatePost, b: CandidatePost) -> float:
-    if a.author_did is not None and a.author_did == b.author_did:
-        author_match = 1.0
-    else:
-        author_match = 0.0
-
-    if (
-        AUTHOR_WEIGHT < 1.0
-        and a.minilm_l12_embedding is not None
-        and b.minilm_l12_embedding is not None
-    ):
-        vec_a = decode_float32_b64(a.minilm_l12_embedding)
-        vec_b = decode_float32_b64(b.minilm_l12_embedding)
+def _raw_similarity(
+    author_a: str | None,
+    author_b: str | None,
+    vec_a: list[float] | None,
+    vec_b: list[float] | None,
+) -> float:
+    """Compute similarity from pre-decoded components; no CandidatePost needed."""
+    author_match = 1.0 if (author_a is not None and author_a == author_b) else 0.0
+    if AUTHOR_WEIGHT < 1.0 and vec_a is not None and vec_b is not None:
         cosine = _cosine_similarity(vec_a, vec_b)
     else:
         cosine = 0.0
-
     return AUTHOR_WEIGHT * author_match + (1 - AUTHOR_WEIGHT) * cosine
+
+
+def _similarity(a: CandidatePost, b: CandidatePost) -> float:
+    """Public similarity helper used by tests; decodes embeddings on each call."""
+    vec_a = None
+    vec_b = None
+    if a.minilm_l12_embedding is not None:
+        try:
+            vec_a = decode_float32_b64(a.minilm_l12_embedding)
+        except Exception:
+            pass
+    if b.minilm_l12_embedding is not None:
+        try:
+            vec_b = decode_float32_b64(b.minilm_l12_embedding)
+        except Exception:
+            pass
+    return _raw_similarity(a.author_did, b.author_did, vec_a, vec_b)
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -6,8 +6,7 @@ from .embeddings import decode_float32_b64
 from ..models import CandidatePost
 
 BETA = 0.5
-AUTHOR_WEIGHT = 1.0
-
+AUTHOR_WEIGHT = 0.75
 
 def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     if len(candidates) <= 1:

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -1,0 +1,67 @@
+"""MMR-based feed diversification."""
+
+import math
+
+from .embeddings import decode_float32_b64
+from ..models import CandidatePost
+
+BETA = 0.5
+AUTHOR_WEIGHT = 1.0
+
+
+def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
+    if len(candidates) <= 1:
+        return list(candidates)
+
+    max_score = max((c.score or 0.0) for c in candidates)
+    if max_score > 0.0:
+        norm_scores = [(c.score or 0.0) / max_score for c in candidates]
+    else:
+        norm_scores = [0.0] * len(candidates)
+
+    selected: list[int] = []
+    remaining: list[int] = list(range(len(candidates)))
+
+    while remaining:
+        if not selected:
+            best = max(remaining, key=lambda i: norm_scores[i])
+        else:
+            def mmr_score(i: int) -> float:
+                rel = (1 - BETA) * norm_scores[i]
+                sim = BETA * max(_similarity(candidates[i], candidates[j]) for j in selected)
+                return rel - sim
+            best = max(remaining, key=mmr_score)
+
+        selected.append(best)
+        remaining.remove(best)
+
+    return [candidates[i] for i in selected]
+
+
+def _similarity(a: CandidatePost, b: CandidatePost) -> float:
+    if a.author_did is not None and a.author_did == b.author_did:
+        author_match = 1.0
+    else:
+        author_match = 0.0
+
+    if (
+        AUTHOR_WEIGHT < 1.0
+        and a.minilm_l12_embedding is not None
+        and b.minilm_l12_embedding is not None
+    ):
+        vec_a = decode_float32_b64(a.minilm_l12_embedding)
+        vec_b = decode_float32_b64(b.minilm_l12_embedding)
+        cosine = _cosine_similarity(vec_a, vec_b)
+    else:
+        cosine = 0.0
+
+    return AUTHOR_WEIGHT * author_match + (1 - AUTHOR_WEIGHT) * cosine
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -14,11 +14,14 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
         return list(candidates)
 
     n = len(candidates)
-    max_score = max((c.score or 0.0) for c in candidates)
+    raw_scores = [c.score or 0.0 for c in candidates]
+    shift = min(0.0, min(raw_scores))
+    shifted_scores = [s - shift for s in raw_scores]
+    shifted_max = max(shifted_scores)
     norm_scores = (
-        [(c.score or 0.0) / max_score for c in candidates]
-        if max_score > 0.0
-        else [0.0] * n
+        [s / shifted_max for s in shifted_scores]
+        if shifted_max > 0.0
+        else [1.0] * n
     )
 
     # Pre-decode embeddings once so the inner loop never repeats base64 work.
@@ -38,7 +41,7 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     # max_sim[i] tracks the highest similarity candidate i has to any selected
     # candidate so far. Updated incrementally — one new comparison per remaining
     # item each round instead of recomputing the full max from scratch.
-    max_sim = [0.0] * n
+    max_sim = [-math.inf] * n
 
     while remaining:
         if not selected:

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -3,11 +3,21 @@
 import pytest
 
 from ..models import CandidatePost
-from .diversify import mmr_rerank
+from .diversify import AUTHOR_WEIGHT, _cosine_similarity, _similarity, mmr_rerank
+from .embeddings import encode_float32_b64
 
 
 def _post(uri: str, score: float, author_did: str | None = None) -> CandidatePost:
     return CandidatePost(at_uri=uri, score=score, author_did=author_did)
+
+
+def _post_with_embed(uri: str, score: float, author_did: str, vec: list[float]) -> CandidatePost:
+    return CandidatePost(
+        at_uri=uri,
+        score=score,
+        author_did=author_did,
+        minilm_l12_embedding=encode_float32_b64(vec),
+    )
 
 
 def test_empty_input_returns_empty():
@@ -46,3 +56,91 @@ def test_all_different_authors_order_preserved_by_relevance():
     result = mmr_rerank(posts)
     uris = [c.at_uri for c in result]
     assert uris == ["at://a/1", "at://b/1", "at://c/1", "at://d/1"]
+
+
+# ---------------------------------------------------------------------------
+# _cosine_similarity unit tests
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical_vectors():
+    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal_vectors():
+    assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_cosine_opposite_vectors():
+    assert _cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+
+def test_cosine_zero_vector_a_returns_zero():
+    assert _cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+def test_cosine_zero_vector_b_returns_zero():
+    assert _cosine_similarity([1.0, 0.0], [0.0, 0.0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _similarity with embeddings (AUTHOR_WEIGHT < 1.0 path)
+# ---------------------------------------------------------------------------
+
+def test_similarity_different_authors_identical_embeddings():
+    """Cosine=1.0 for identical vecs; no author match → similarity = (1-AUTHOR_WEIGHT)."""
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", [1.0, 0.0])
+    b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", [1.0, 0.0])
+    assert _similarity(a, b) == pytest.approx((1 - AUTHOR_WEIGHT) * 1.0)
+
+
+def test_similarity_different_authors_orthogonal_embeddings():
+    """Cosine=0 for orthogonal vecs; no author match → similarity = 0."""
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", [1.0, 0.0])
+    b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", [0.0, 1.0])
+    assert _similarity(a, b) == pytest.approx(0.0)
+
+
+def test_similarity_same_author_with_embeddings():
+    """Same author contributes AUTHOR_WEIGHT; cosine contributes (1-AUTHOR_WEIGHT)."""
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", [1.0, 0.0])
+    b = _post_with_embed("at://a/2", 0.9, "did:plc:alice", [1.0, 0.0])
+    expected = AUTHOR_WEIGHT * 1.0 + (1 - AUTHOR_WEIGHT) * 1.0
+    assert _similarity(a, b) == pytest.approx(expected)
+
+
+def test_similarity_missing_one_embedding_skips_cosine():
+    """If one post has no embedding, cosine is 0 and only author_match counts."""
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", [1.0, 0.0])
+    b = CandidatePost(at_uri="at://b/1", score=0.9, author_did="did:plc:bob")
+    assert _similarity(a, b) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# mmr_rerank with cosine similarity active
+# ---------------------------------------------------------------------------
+
+def test_cosine_penalizes_topically_similar_cross_author_post():
+    """A post from a different author but with an identical embedding is penalized
+    by the cosine term, causing a topically-distinct post to rank ahead of it."""
+    p1 = _post_with_embed("at://alice/1", score=1.0, author_did="did:plc:alice", vec=[1.0, 0.0])
+    p2 = _post_with_embed("at://bob/1", score=0.9, author_did="did:plc:bob", vec=[1.0, 0.0])
+    p3 = _post_with_embed("at://carol/1", score=0.8, author_did="did:plc:carol", vec=[0.0, 1.0])
+
+    result = mmr_rerank([p1, p2, p3])
+    uris = [c.at_uri for c in result]
+
+    assert uris[0] == "at://alice/1"
+    # p2 shares p1's topic; p3 is orthogonal — cosine pushes p3 ahead of p2
+    assert uris.index("at://carol/1") < uris.index("at://bob/1")
+
+
+def test_cosine_similarity_value_matches_manual_calculation():
+    """Verify the combined similarity formula: AUTHOR_WEIGHT*author + (1-AUTHOR_WEIGHT)*cosine."""
+    vec_a = [3.0, 4.0]
+    vec_b = [4.0, 3.0]
+    # cosine([3,4],[4,3]) = (12+12)/(5*5) = 24/25
+    expected_cosine = 24 / 25
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", vec_a)
+    b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", vec_b)
+    expected = (1 - AUTHOR_WEIGHT) * expected_cosine
+    assert _similarity(a, b) == pytest.approx(expected, rel=1e-5)

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -1,0 +1,48 @@
+"""Tests for MMR-based feed diversification."""
+
+import pytest
+
+from ..models import CandidatePost
+from .diversify import mmr_rerank
+
+
+def _post(uri: str, score: float, author_did: str | None = None) -> CandidatePost:
+    return CandidatePost(at_uri=uri, score=score, author_did=author_did)
+
+
+def test_empty_input_returns_empty():
+    assert mmr_rerank([]) == []
+
+
+def test_single_candidate_unchanged():
+    c = _post("at://x/1", score=1.0, author_did="did:plc:alice")
+    result = mmr_rerank([c])
+    assert result == [c]
+
+
+def test_same_author_posts_spread_apart():
+    """b1 (lower score, different author) should precede a2 (same author as a1)."""
+    a1 = _post("at://alice/1", score=1.0, author_did="did:plc:alice")
+    a2 = _post("at://alice/2", score=0.9, author_did="did:plc:alice")
+    a3 = _post("at://alice/3", score=0.8, author_did="did:plc:alice")
+    b1 = _post("at://bob/1", score=0.5, author_did="did:plc:bob")
+
+    result = mmr_rerank([a1, a2, a3, b1])
+    uris = [c.at_uri for c in result]
+
+    assert uris[0] == "at://alice/1"
+    assert uris.index("at://bob/1") < uris.index("at://alice/2")
+
+
+def test_all_different_authors_order_preserved_by_relevance():
+    """With no author overlap, MMR reduces to relevance order."""
+    posts = [
+        _post("at://a/1", score=0.9, author_did="did:plc:a"),
+        _post("at://b/1", score=0.7, author_did="did:plc:b"),
+        _post("at://c/1", score=0.5, author_did="did:plc:c"),
+        _post("at://d/1", score=0.3, author_did="did:plc:d"),
+    ]
+
+    result = mmr_rerank(posts)
+    uris = [c.at_uri for c in result]
+    assert uris == ["at://a/1", "at://b/1", "at://c/1", "at://d/1"]

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from ..models import CandidatePost
-from .diversify import AUTHOR_WEIGHT, _cosine_similarity, _similarity, mmr_rerank
+from .diversify import AUTHOR_WEIGHT, _cosine_similarity, _raw_similarity, _similarity, mmr_rerank
 from .embeddings import encode_float32_b64
 
 
@@ -144,3 +144,51 @@ def test_cosine_similarity_value_matches_manual_calculation():
     b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", vec_b)
     expected = (1 - AUTHOR_WEIGHT) * expected_cosine
     assert _similarity(a, b) == pytest.approx(expected, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# _raw_similarity — same logic as _similarity but accepts pre-decoded vectors
+# ---------------------------------------------------------------------------
+
+def test_raw_similarity_matches_similarity_different_authors_identical_embeddings():
+    vec = [1.0, 0.0]
+    result = _raw_similarity("did:plc:alice", "did:plc:bob", vec, vec)
+    assert result == pytest.approx((1 - AUTHOR_WEIGHT) * 1.0)
+
+
+def test_raw_similarity_matches_similarity_orthogonal_embeddings():
+    result = _raw_similarity("did:plc:alice", "did:plc:bob", [1.0, 0.0], [0.0, 1.0])
+    assert result == pytest.approx(0.0)
+
+
+def test_raw_similarity_same_author_full_score():
+    vec = [1.0, 0.0]
+    result = _raw_similarity("did:plc:alice", "did:plc:alice", vec, vec)
+    expected = AUTHOR_WEIGHT * 1.0 + (1 - AUTHOR_WEIGHT) * 1.0
+    assert result == pytest.approx(expected)
+
+
+def test_raw_similarity_none_vec_skips_cosine():
+    result = _raw_similarity("did:plc:alice", "did:plc:bob", None, [1.0, 0.0])
+    assert result == pytest.approx(0.0)
+
+
+def test_raw_similarity_none_author_no_match():
+    vec = [1.0, 0.0]
+    result = _raw_similarity(None, None, vec, vec)
+    # author_did=None on both — treated as no match; cosine still applies
+    assert result == pytest.approx((1 - AUTHOR_WEIGHT) * 1.0)
+
+
+def test_raw_similarity_agrees_with_similarity_for_same_inputs():
+    """_raw_similarity and _similarity must return the same value for equivalent inputs."""
+    vec_a = [3.0, 4.0]
+    vec_b = [4.0, 3.0]
+    a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", vec_a)
+    b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", vec_b)
+    from .embeddings import decode_float32_b64
+    assert _raw_similarity(
+        a.author_did, b.author_did,
+        decode_float32_b64(a.minilm_l12_embedding),
+        decode_float32_b64(b.minilm_l12_embedding),
+    ) == pytest.approx(_similarity(a, b), rel=1e-6)

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -58,6 +58,39 @@ def test_all_different_authors_order_preserved_by_relevance():
     assert uris == ["at://a/1", "at://b/1", "at://c/1", "at://d/1"]
 
 
+def test_mixed_positive_and_negative_scores_ranked_by_relevance():
+    """Scores crossing zero should still rank highest-to-lowest with distinct authors."""
+    posts = [
+        _post("at://a/1", score=0.5, author_did="did:plc:a"),
+        _post("at://b/1", score=0.0, author_did="did:plc:b"),
+        _post("at://c/1", score=-0.5, author_did="did:plc:c"),
+    ]
+    result = mmr_rerank(posts)
+    assert [c.at_uri for c in result] == ["at://a/1", "at://b/1", "at://c/1"]
+
+
+def test_all_negative_scores_ranked_by_relevance():
+    """All-negative scores should still rank highest-to-lowest with distinct authors."""
+    posts = [
+        _post("at://a/1", score=-0.1, author_did="did:plc:a"),
+        _post("at://b/1", score=-0.5, author_did="did:plc:b"),
+        _post("at://c/1", score=-1.0, author_did="did:plc:c"),
+    ]
+    result = mmr_rerank(posts)
+    assert [c.at_uri for c in result] == ["at://a/1", "at://b/1", "at://c/1"]
+
+
+def test_equal_scores_diversity_drives_selection():
+    """When all scores are equal, author diversity should determine ordering."""
+    a1 = _post("at://alice/1", score=1.0, author_did="did:plc:alice")
+    a2 = _post("at://alice/2", score=1.0, author_did="did:plc:alice")
+    b1 = _post("at://bob/1", score=1.0, author_did="did:plc:bob")
+
+    result = mmr_rerank([a1, a2, b1])
+    uris = [c.at_uri for c in result]
+    assert uris.index("at://bob/1") < uris.index("at://alice/2")
+
+
 # ---------------------------------------------------------------------------
 # _cosine_similarity unit tests
 # ---------------------------------------------------------------------------

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from .routers import candidates, health, rank, skylight, xrpc
+from .routers import candidates, diversify, health, rank, skylight, xrpc
 from .security import RequireApiKey
 from .lib.atproto_auth import init_id_resolver
 from .lib.feed_cache import FirestoreFeedCache
@@ -63,6 +63,7 @@ app = FastAPI(
 
 
 app.include_router(candidates.router)
+app.include_router(diversify.router)
 app.include_router(health.router)
 app.include_router(rank.router)
 app.include_router(skylight.router)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -50,6 +50,9 @@ class CandidatePost(BaseModel):
     generator_name: str | None = Field(
         None, description="Name of the candidate generator that produced this post"
     )
+    author_did: str | None = Field(
+        None, description="AT Protocol DID of the post author"
+    )
 
 
 class GeneratorSpec(BaseModel):

--- a/src/app/routers/diversify.py
+++ b/src/app/routers/diversify.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..lib.diversify import mmr_rerank
+from ..models import CandidatePost
+from ..security import verify_api_key
+
+router = APIRouter(tags=["diversify"], dependencies=[Depends(verify_api_key)])
+
+
+class DiversifyRequest(BaseModel):
+    candidates: list[CandidatePost]
+
+
+class DiversifyResponse(BaseModel):
+    candidates: list[CandidatePost]
+
+
+@router.post("/diversify", response_model=DiversifyResponse)
+async def diversify(payload: DiversifyRequest) -> DiversifyResponse:
+    return DiversifyResponse(candidates=mmr_rerank(payload.candidates))

--- a/src/app/routers/diversify_test.py
+++ b/src/app/routers/diversify_test.py
@@ -1,0 +1,62 @@
+"""Tests for the /diversify endpoint."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ..main import app
+
+HEADERS = {"X-API-Key": "testkey"}
+
+
+@pytest.fixture(autouse=True)
+def set_api_key():
+    prev = os.environ.get("API_KEY")
+    os.environ["API_KEY"] = "testkey"
+    yield
+    if prev is None:
+        del os.environ["API_KEY"]
+    else:
+        os.environ["API_KEY"] = prev
+
+
+def test_auth_required():
+    client = TestClient(app)
+    resp = client.post("/diversify", json={"candidates": []})
+    assert resp.status_code == 401
+
+
+def test_empty_input_returns_200():
+    client = TestClient(app, headers=HEADERS)
+    resp = client.post("/diversify", json={"candidates": []})
+    assert resp.status_code == 200
+    assert resp.json()["candidates"] == []
+
+
+def test_all_candidates_preserved():
+    client = TestClient(app, headers=HEADERS)
+    candidates = [
+        {"at_uri": "at://a/1", "score": 0.9, "author_did": "did:plc:a"},
+        {"at_uri": "at://b/1", "score": 0.7, "author_did": "did:plc:b"},
+        {"at_uri": "at://c/1", "score": 0.5, "author_did": "did:plc:c"},
+    ]
+    resp = client.post("/diversify", json={"candidates": candidates})
+    assert resp.status_code == 200
+    uris = [c["at_uri"] for c in resp.json()["candidates"]]
+    assert set(uris) == {"at://a/1", "at://b/1", "at://c/1"}
+
+
+def test_same_author_spread():
+    client = TestClient(app, headers=HEADERS)
+    candidates = [
+        {"at_uri": "at://alice/1", "score": 1.0, "author_did": "did:plc:alice"},
+        {"at_uri": "at://alice/2", "score": 0.9, "author_did": "did:plc:alice"},
+        {"at_uri": "at://alice/3", "score": 0.8, "author_did": "did:plc:alice"},
+        {"at_uri": "at://bob/1", "score": 0.5, "author_did": "did:plc:bob"},
+    ]
+    resp = client.post("/diversify", json={"candidates": candidates})
+    assert resp.status_code == 200
+    uris = [c["at_uri"] for c in resp.json()["candidates"]]
+    assert uris[0] == "at://alice/1"
+    assert uris.index("at://bob/1") < uris.index("at://alice/2")

--- a/src/app/routers/skylight_test.py
+++ b/src/app/routers/skylight_test.py
@@ -79,6 +79,7 @@ def test_search_returns_embedding():
                 "minilm_l12_embedding": expected,
                 "score": 1.5,
                 "generator_name": None,
+                "author_did": None,
             }
         ]
     }
@@ -98,6 +99,7 @@ def test_similar_with_at_uris():
                 "minilm_l12_embedding": expected,
                 "score": 1.5,
                 "generator_name": None,
+                "author_did": None,
             }
         ]
     }
@@ -117,6 +119,7 @@ def test_similar_with_embeddings():
                 "minilm_l12_embedding": expected,
                 "score": 1.5,
                 "generator_name": None,
+                "author_did": None,
             }
         ]
     }

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from ..lib.candidates import run_generate
+from ..lib.diversify import mmr_rerank
 from ..lib.feed_cache import FeedCache, FirestoreFeedCache, DEFAULT_TTL_SECONDS
 from ..models import CandidateGenerateRequest, FeedCursor, GeneratorSpec
 from ..lib.atproto_auth import verify_auth_header
@@ -294,7 +295,9 @@ async def get_feed_skeleton(
                 gen_request, request.app.state.es, swallow_errors=True
             )
 
-            new_uris = [c.at_uri for c in result.candidates if c.at_uri]
+            candidates = sorted(result.candidates, key=lambda c: c.score or 0.0, reverse=True)
+            candidates = mmr_rerank(candidates)
+            new_uris = [c.at_uri for c in candidates if c.at_uri]
             if new_uris:
                 updated = await feed_cache.append(parsed.id, new_uris)
                 if updated is not None:
@@ -325,7 +328,9 @@ async def get_feed_skeleton(
         gen_request, request.app.state.es, swallow_errors=True
     )
 
-    all_uris = [c.at_uri for c in result.candidates if c.at_uri]
+    candidates = sorted(result.candidates, key=lambda c: c.score or 0.0, reverse=True)
+    candidates = mmr_rerank(candidates)
+    all_uris = [c.at_uri for c in candidates if c.at_uri]
 
     # First page to return immediately.
     page = all_uris[:limit]

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -360,6 +360,22 @@ class TestGetFeedSkeleton:
             data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
         assert data["feed"] == []
 
+    # --- MMR diversification ---
+
+    def test_same_author_candidates_are_spread_in_feed(self):
+        """MMR should interleave candidates from the same author with others."""
+        candidates = [
+            CandidatePost(at_uri="at://alice/1", score=1.0, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://alice/2", score=0.9, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://alice/3", score=0.8, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://bob/1", score=0.5, author_did="did:plc:bob", content=None, minilm_l12_embedding=None, generator_name="g"),
+        ]
+        with self._patch_generators(candidates):
+            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+        uris = [item["post"] for item in data["feed"]]
+        assert uris[0] == "at://alice/1"
+        assert uris.index("at://bob/1") < uris.index("at://alice/2")
+
     # --- posts with no at_uri are skipped ---
 
     def test_posts_without_at_uri_are_skipped(self):


### PR DESCRIPTION
Closes #80

This PR implements a Maximal Marginal Relevance (MMR) diversification pass on the feed pipeline to reduce same-author and topic-similar clustering. The pass runs after candidate generation and score-based sorting, as the final step before results are returned.

# This PR

- Adds `author_did: str | None` field to `CandidatePost` and populates it from Elasticsearch `_source.author_did` in all three candidate generators (`post_similarity`, `popularity`, `random_posts`)
- Implements greedy MMR in `src/app/lib/diversify.py`: selects candidates maximizing `(1 - BETA) * relevance - BETA * max_similarity_to_selected`, where similarity combines author identity and (when `AUTHOR_WEIGHT < 1.0`) embedding cosine distance. 
  - Sets AUTHOR_WEIGHT to 0.75 so same author posts are likely removed unless their content is maximally different. we might want to play with this though, because sometimes you want multiple related posts from an author in feed like when someone is doing a tweet chain on a topic and circumventing the max character limit.
  - Also, note: @davidfreifeld : I used "the maximum similarity between an item and any item from the set" from your comment, but we might consider coming back and using the smoothing option as you described, since will achieve max diversity which may not be optimal.
- Wires `mmr_rerank` into both the fresh-generation and pagination-regeneration branches of `getFeedSkeleton` in `xrpc.py`
- Exposes a standalone `POST /diversify` endpoint for external use

# Testing

- `pipenv run pytest` — 231 tests pass
- `src/app/lib/diversify_test.py`: empty input, single candidate, same-author spread (bob precedes alice/2), all-different-author relevance order
- `src/app/routers/diversify_test.py`: auth required, empty 200, all candidates preserved, same-author spread via HTTP
- `src/app/routers/xrpc_test.py`: added `test_same_author_candidates_are_spread_in_feed` verifying feed output interleaves same-author posts