### PR TITLE
Two tower feed

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -32,6 +32,7 @@ FEEDS: dict[str, FeedConfig] = {
     "random": FeedConfig(
         display_name="Random",
         description="Development feed — random posts.",
+        diversify=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -1,10 +1,10 @@
 """Feed catalog — the canonical registry of all published feeds.
 
 Each entry maps a short feed name (the AT Protocol rkey) to a ``FeedConfig``
-that holds display metadata **and** the generator pipeline template.  The
-template is a ``CandidateGenerateRequest`` with placeholder values for
-session-specific fields (``user_did``, ``num_candidates``), which are filled
-in at request time by the XRPC router.
+that holds display metadata **and** the generator/ranker pipeline templates.
+Templates are built with ``model_construct`` so that session-specific required
+fields (``user_did``, ``candidates``) can be omitted; the XRPC router fills
+them in at request time via ``model_copy``.
 
 This module is intentionally separate from the router so that other parts of
 the codebase (e.g.  the ``publish_feed.py`` script) can import it without
@@ -18,42 +18,40 @@ FEEDS: dict[str, FeedConfig] = {
     "basic-similarity": FeedConfig(
         display_name="Similarity",
         description="Development feed — post-similarity candidates with popularity infill.",
-        gen_request_template=CandidateGenerateRequest(
+        gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=0.6),
                 GeneratorSpec(name="followed_users", weight=0.4),
             ],
             infill="popularity",
-            user_did="",
             num_candidates=30,
             video_only=False,
+            exclude_uris=[],
         ),
     ),
     "random": FeedConfig(
         display_name="Random",
         description="Development feed — random posts.",
-        gen_request_template=CandidateGenerateRequest(
+        gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
-            user_did="",
             num_candidates=30,
             video_only=False,
+            exclude_uris=[],
         ),
     ),
     "ranked-similarity": FeedConfig(
         display_name="Ranked",
         description="Post-similarity candidates ranked by the two-tower model.",
-        gen_request_template=CandidateGenerateRequest(
+        gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
             infill="popularity",
-            user_did="",
             num_candidates=30,
             video_only=False,
+            exclude_uris=[],
         ),
-        rank_request_template=RankPredictRequest(
+        rank_request_template=RankPredictRequest.model_construct(
             model="two_tower",
-            user_did="",
-            candidates=[],
         ),
     ),
 }

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -11,7 +11,7 @@ the codebase (e.g.  the ``publish_feed.py`` script) can import it without
 pulling in FastAPI.
 """
 
-from .models import CandidateGenerateRequest, FeedConfig, GeneratorSpec
+from .models import CandidateGenerateRequest, FeedConfig, GeneratorSpec, RankPredictRequest
 
 # NOTE: display_name is limited to 24 chars, including the prefix ("GreenEarth, GE Dev, or GE Stg")
 FEEDS: dict[str, FeedConfig] = {
@@ -35,6 +35,22 @@ FEEDS: dict[str, FeedConfig] = {
             user_did="",
             num_candidates=30,
             video_only=False,
+        ),
+    ),
+    "ranked-similarity": FeedConfig(
+        display_name="Ranked",
+        description="Post-similarity candidates ranked by the two-tower model.",
+        gen_request_template=CandidateGenerateRequest(
+            generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
+            infill="popularity",
+            user_did="",
+            num_candidates=30,
+            video_only=False,
+        ),
+        rank_request_template=RankPredictRequest(
+            model="two_tower",
+            user_did="",
+            candidates=[],
         ),
     ),
 }

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -41,9 +41,9 @@ FEEDS: dict[str, FeedConfig] = {
             exclude_uris=[],
         ),
     ),
-    "ranked-similarity": FeedConfig(
+    "ranked": FeedConfig(
         display_name="Ranked",
-        description="Post-similarity candidates ranked by the two-tower model.",
+        description="Current-best ranked feed.",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
             infill="popularity",
@@ -56,3 +56,4 @@ FEEDS: dict[str, FeedConfig] = {
         ),
     ),
 }
+

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -32,6 +32,9 @@ async def run_predict(
     if ranker is None:
         raise RankModelNotFoundError(model_name)
 
+    if not request.candidates:
+        raise RankerError("candidates list must not be empty")
+
     if any(candidate.at_uri is None for candidate in request.candidates):
         raise RankerError("All candidates must include at_uri")
 

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -13,6 +13,7 @@ import httpx
 from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerExecutionError, RankerResult
 from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
+from ..embeddings import decode_float32_b64
 
 
 logger = logging.getLogger(__name__)
@@ -138,9 +139,24 @@ class TwoTowerRanker(Ranker):
         ####### CANDIATE POSTS #######
         valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
         candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
-        
-        # Get the embeddings for all the posts
-        candidate_embedding_pairs = await fetch_post_embeddings(es, list(candidates_by_uri))
+
+        # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+        candidate_embedding_pairs: list[tuple[str, list[float]]] = []
+        missing_uris: list[str] = []
+        for uri, candidate in candidates_by_uri.items():
+            if candidate.minilm_l12_embedding:
+                try:
+                    vec = decode_float32_b64(candidate.minilm_l12_embedding)
+                    candidate_embedding_pairs.append((uri, vec))
+                    continue
+                except Exception:
+                    pass
+            missing_uris.append(uri)
+
+        if missing_uris:
+            fetched = await fetch_post_embeddings(es, missing_uris)
+            candidate_embedding_pairs.extend(fetched)
+
         if not candidate_embedding_pairs:
             logger.info(
                 "No embeddings found for %d candidate posts of user %s",

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -37,6 +37,9 @@ def get_inference_settings() -> tuple[str, str]:
     return base_url, api_key
 
 
+POST_TOWER_BATCH_SIZE = 32
+
+
 async def predict_post_tower_batch(
     post_embeddings: list[list[float]],
     *,
@@ -45,13 +48,23 @@ async def predict_post_tower_batch(
 ) -> list[list[float]]:
     url = f"{base_url}/models/post-tower/predict"
     headers = {"X-API-Key": api_key}
-    payload = {"post_embeddings": post_embeddings}
 
+    results: list[list[float]] = []
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(url, json=payload, headers=headers) # type: ignore
-        resp.raise_for_status()
-        data = resp.json()
-        return data["outputs"]
+        for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE):
+            chunk = post_embeddings[i : i + POST_TOWER_BATCH_SIZE]
+            payload = {"post_embeddings": chunk}
+            resp = await client.post(url, json=payload, headers=headers) # type: ignore
+            if resp.is_error:
+                logger.error(
+                    "post-tower predict failed status=%s body=%s",
+                    resp.status_code,
+                    resp.text,
+                )
+                resp.raise_for_status()
+            data = resp.json()
+            results.extend(data["outputs"])
+    return results
 
 
 async def predict_user_tower_single(

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -104,7 +104,6 @@ class RankPredictRequest(BaseModel):
 
     candidates: list[CandidatePost] = Field(
         ...,
-        min_length=1,
         description="Candidates to rank in the same shape returned by /candidates/generate",
     )
     model: str | None = Field(
@@ -140,8 +139,16 @@ class FeedConfig(BaseModel):
     ``gen_request_template`` holds the generator pipeline spec using the same
     shape as ``CandidateGenerateRequest``.  Session-specific fields
     (``user_did``, ``num_candidates``) are filled in at request time.
+
+    ``rank_request_template`` optionally holds a ranking spec.  When set,
+    candidates are ranked by the named model before URIs are returned.
+    Runtime fields (``candidates``, ``user_did``) are filled via ``model_copy``.
     """
 
     display_name: str = Field(..., max_length=12)
     description: str = ""
     gen_request_template: CandidateGenerateRequest
+    rank_request_template: RankPredictRequest | None = Field(
+        None,
+        description="When set, candidates are ranked by this model before being returned.",
+    )

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -146,6 +146,9 @@ class FeedConfig(BaseModel):
     ``rank_request_template`` optionally holds a ranking spec.  When set,
     candidates are ranked by the named model before URIs are returned.
     Runtime fields (``candidates``, ``user_did``) are filled via ``model_copy``.
+
+    ``diversify`` controls whether MMR reranking is applied after candidate
+    generation and optional model ranking.  Defaults to ``True``.
     """
 
     display_name: str = Field(..., max_length=12)
@@ -155,3 +158,4 @@ class FeedConfig(BaseModel):
         None,
         description="When set, candidates are ranked by this model before being returned.",
     )
+    diversify: bool = Field(True, description="When False, MMR reranking is skipped.")

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -21,7 +21,8 @@ from pydantic import BaseModel, Field
 
 from ..lib.candidates import run_generate
 from ..lib.feed_cache import FeedCache, FirestoreFeedCache, DEFAULT_TTL_SECONDS
-from ..models import CandidateGenerateRequest, FeedCursor, GeneratorSpec
+from ..lib.rankers import run_predict
+from ..models import CandidateGenerateRequest, FeedConfig, FeedCursor, GeneratorSpec, RankPredictRequest
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.firestore import upsert_feed_activity, upsert_user
 from ..feeds import FEEDS
@@ -110,6 +111,30 @@ class FeedSkeletonResponse(BaseModel):
 
     feed: list[SkeletonItem] = Field(default_factory=list)
     cursor: str | None = Field(default=None, description="Pagination cursor")
+
+
+# ---------------------------------------------------------------------------
+# Feed pipeline
+# ---------------------------------------------------------------------------
+
+
+async def _run_ranking_pipeline(
+    feed_cfg: FeedConfig,
+    gen_request: CandidateGenerateRequest,
+    es,
+) -> list[str]:
+    """Generate candidates and optionally rank them, returning AT URIs in order."""
+    result = await run_generate(gen_request, es, swallow_errors=True)
+    candidates = result.candidates
+
+    if feed_cfg.rank_request_template is None or not candidates:
+        return [c.at_uri for c in candidates if c.at_uri]
+
+    rank_req = feed_cfg.rank_request_template.model_copy(
+        update={"candidates": candidates, "user_did": gen_request.user_did}
+    )
+    rank_result = await run_predict(rank_req, es)
+    return [r.at_uri for r in rank_result.rankings]
 
 
 # ---------------------------------------------------------------------------
@@ -290,11 +315,7 @@ async def get_feed_skeleton(
                 }
             )
 
-            result = await run_generate(
-                gen_request, request.app.state.es, swallow_errors=True
-            )
-
-            new_uris = [c.at_uri for c in result.candidates if c.at_uri]
+            new_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
             if new_uris:
                 updated = await feed_cache.append(parsed.id, new_uris)
                 if updated is not None:
@@ -321,11 +342,7 @@ async def get_feed_skeleton(
         update={"user_did": user_did, "num_candidates": batch}
     )
 
-    result = await run_generate(
-        gen_request, request.app.state.es, swallow_errors=True
-    )
-
-    all_uris = [c.at_uri for c in result.candidates if c.at_uri]
+    all_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
 
     # First page to return immediately.
     page = all_uris[:limit]

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -143,7 +143,8 @@ async def _run_ranking_pipeline(
     else:
         ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
 
-    return [c.at_uri for c in mmr_rerank(ordered) if c.at_uri]
+    final = mmr_rerank(ordered) if feed_cfg.diversify else ordered
+    return [c.at_uri for c in final if c.at_uri]
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from ..main import app
-from ..models import CandidatePost, FeedCursor
+from ..models import CandidatePost, FeedCursor, RankedCandidate, RankPredictResult
 from ..lib.candidates.base import CandidateResult
 from ..lib.feed_cache import FeedCache
 
@@ -22,6 +22,8 @@ FEED_RKEY = "basic-similarity"
 FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
+RANKED_FEED_RKEY = "ranked-similarity"
+RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
 # The AppView sends the publisher DID in the feed URI, not the service DID.
 FEED_URI_FROM_APPVIEW = f"at://{PUBLISHER_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 TEST_USERNAME = "testuser.bsky.app"
@@ -156,9 +158,14 @@ class TestDescribeFeedGenerator:
         uris = [f["uri"] for f in data["feeds"]]
         assert RANDOM_FEED_URI in uris
 
+    def test_feeds_list_contains_ranked_similarity(self):
+        data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
+        uris = [f["uri"] for f in data["feeds"]]
+        assert RANKED_FEED_URI in uris
+
     def test_feeds_list_length(self):
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
-        assert len(data["feeds"]) == 2
+        assert len(data["feeds"]) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -975,3 +982,70 @@ class TestConfigHelpers:
         from ..routers.xrpc import _get_hostname
         monkeypatch.setenv("GE_FEED_GENERATOR_DID", "did:plc:abc123")
         assert _get_hostname() == "localhost"
+
+
+# ---------------------------------------------------------------------------
+# Ranked feed
+# ---------------------------------------------------------------------------
+
+class TestRankedFeed:
+    """Tests for feeds with a rank_request_template wired in."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_authenticated_user(self):
+        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_firestore_upsert(self):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+            yield
+
+    def _patch_generators(self, candidates):
+        primary_gen = AsyncMock()
+        primary_gen.generate.return_value = CandidateResult(
+            generator_name="post_similarity", candidates=candidates
+        )
+        infill_gen = AsyncMock()
+        infill_gen.generate.return_value = CandidateResult(
+            generator_name="popularity", candidates=[]
+        )
+
+        def fake_get(name):
+            return {"post_similarity": primary_gen, "popularity": infill_gen}.get(name)
+
+        return patch("app.lib.candidates.generate.get_generator", side_effect=fake_get)
+
+    def test_ranking_applied_to_candidates(self):
+        """When ranking succeeds, posts are returned in ranked order."""
+        candidates = _make_candidates("p", 3)
+        # Ranker reverses the order: p/2, p/1, p/0
+        reversed_rankings = [
+            RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=float(3 - r))
+            for r, i in enumerate([2, 1, 0])
+        ]
+        rank_result = RankPredictResult(rankings=reversed_rankings)
+
+        with self._patch_generators(candidates), \
+             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            ).json()
+
+        posts = [item["post"] for item in data["feed"]]
+        assert posts == ["at://p/2", "at://p/1", "at://p/0"]
+
+    def test_ranking_failure_returns_500(self):
+        """When ranking raises, the feed fails with a 500."""
+        candidates = _make_candidates("p", 3)
+
+        with self._patch_generators(candidates), \
+             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
+            resp = TestClient(app, raise_server_exceptions=False).get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            )
+
+        assert resp.status_code == 500

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -22,7 +22,7 @@ FEED_RKEY = "basic-similarity"
 FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
-RANKED_FEED_RKEY = "ranked-similarity"
+RANKED_FEED_RKEY = "ranked"
 RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
 # The AppView sends the publisher DID in the feed URI, not the service DID.
 FEED_URI_FROM_APPVIEW = f"at://{PUBLISHER_DID}/app.bsky.feed.generator/{FEED_RKEY}"


### PR DESCRIPTION
## Two-tower ranked feed

Wires the two-tower inference model into a new `ranked` feed that uses `post_similarity` for candidate generation and the two-tower model for ranking.

### What changed

**New `ranked` feed** — `post_similarity` candidates (with `popularity` infill) are scored by the two-tower model before MMR diversification. The ranking pipeline is extracted into `_run_ranking_pipeline`, which handles the generate → rank → diversify sequence and is used for both fresh generation and cache-miss paths.

**`FeedConfig` extended** with `rank_request_template` (optional) and `diversify` (default `True`). When `rank_request_template` is set, candidates are passed through the named model before being returned. When `diversify=False`, MMR is skipped (used by the `random` feed).

**Batch splitting for post-tower calls** — the inference service has `GE_INFERENCE_MAX_BATCH=32` but the ranker was sending all candidates in a single request, causing 422s. Candidate embeddings are now sent in chunks of 32. Error responses now log the response body to make future inference errors easier to diagnose.

**Avoid redundant ES fetch for candidate embeddings** — candidate posts already carry `minilm_l12_embedding` from the generator step (both KNN hits and popularity results include it). The ranker now decodes it in memory rather than re-querying ES, falling back to a fetch only for any candidates missing it.

**`model_construct` for feed templates** — feed configs no longer need
placeholder values for session-specific fields (`user_did`, `candidates`).
