### PR TITLE
Return ranker results for users with empty like histories

### DIFF
--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -91,24 +91,23 @@ class TwoTowerRanker(Ranker):
         
         ####### USER #######
         # 1. Get recently liked post URIs
+        user_history_vectors = []
         user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
         if not user_history_liked_uris:
             logger.info("No likes found for user %s", user_did)
-            return RankerResult(model=self.name, result=RankPredictResult(rankings=[]))
+        else:
+            # 2. Fetch embeddings for those posts
+            user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(es, user_history_liked_uris)
 
-        # 2. Fetch embeddings for those posts
-        user_history_embedding_pairs = await fetch_post_embeddings(es, user_history_liked_uris)
-
-        if not user_history_embedding_pairs:
-            logger.info(
-                "No embeddings found for %d liked posts of user %s",
-                len(user_history_liked_uris),
-                user_did,
-            )
-            return RankerResult(model=self.name, result=RankPredictResult(rankings=[]))
-
-        user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
+            if not user_history_embedding_pairs:
+                logger.info(
+                    "No embeddings found for %d liked posts of user %s",
+                    len(user_history_liked_uris),
+                    user_did,
+                )
+            else:
+                user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
         
         # Call the inference API for the user tower
         output_user_embedding_list = await predict_user_tower_single(

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -5,8 +5,8 @@ import asyncio
 import pytest
 
 from ...models import CandidatePost
-from .base import RankerExecutionError
 from . import two_tower as two_tower_module
+from .base import RankerExecutionError
 from .two_tower import TwoTowerRanker
 
 
@@ -32,11 +32,15 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
         "get_inference_settings",
         lambda: ("https://example.com", "secret"),
     )
-    
+
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return ["at://liked/1"]
 
-    monkeypatch.setattr(two_tower_module, "fetch_recent_liked_post_uris", fake_fetch_recent_liked_post_uris)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_recent_liked_post_uris",
+        fake_fetch_recent_liked_post_uris,
+    )
 
     async def fake_fetch_post_embeddings(es, at_uris):
         if at_uris == ["at://liked/1"]:
@@ -55,7 +59,11 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
         assert post_embeddings == [[0.0, 1.0], [1.0, 0.0]]
         return post_embeddings
 
-    monkeypatch.setattr(two_tower_module, "predict_user_tower_single", fake_predict_user_tower_single)
+    monkeypatch.setattr(
+        two_tower_module,
+        "predict_user_tower_single",
+        fake_predict_user_tower_single,
+    )
     monkeypatch.setattr(two_tower_module, "predict_post_tower_batch", fake_predict_post_tower_batch)
 
     result = asyncio.run(
@@ -73,6 +81,111 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
     assert [ranking.model_dump() for ranking in result.result.rankings] == [
         {"at_uri": "at://post/a", "rank": 1, "rank_score": 1.0},
         {"at_uri": "at://post/b", "rank": 2, "rank_score": 0.0},
+    ]
+
+
+def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monkeypatch):
+    monkeypatch.setattr(
+        two_tower_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    seen = {}
+
+    async def fake_fetch_recent_liked_post_uris(es, user_did):
+        return []
+
+    async def fake_fetch_post_embeddings(es, at_uris):
+        seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
+        return [("at://post/a", [2.0, 0.0])]
+
+    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+        seen["history_embeddings"] = history_embeddings
+        return [[1.0, 0.0]]
+
+    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+        return post_embeddings
+
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_recent_liked_post_uris",
+        fake_fetch_recent_liked_post_uris,
+    )
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(
+        two_tower_module,
+        "predict_user_tower_single",
+        fake_predict_user_tower_single,
+    )
+    monkeypatch.setattr(two_tower_module, "predict_post_tower_batch", fake_predict_post_tower_batch)
+
+    result = asyncio.run(
+        TwoTowerRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[CandidatePost(at_uri="at://post/a")],
+        )
+    )
+
+    assert seen["history_embeddings"] == []
+    assert seen["fetch_post_embeddings_calls"] == [["at://post/a"]]
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": 2.0},
+    ]
+
+
+def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddings(monkeypatch):
+    monkeypatch.setattr(
+        two_tower_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    seen = {}
+
+    async def fake_fetch_recent_liked_post_uris(es, user_did):
+        return ["at://liked/1"]
+
+    async def fake_fetch_post_embeddings(es, at_uris):
+        seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
+        if at_uris == ["at://liked/1"]:
+            return []
+        return [("at://post/a", [2.0, 0.0])]
+
+    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+        seen["history_embeddings"] = history_embeddings
+        return [[1.0, 0.0]]
+
+    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+        return post_embeddings
+
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_recent_liked_post_uris",
+        fake_fetch_recent_liked_post_uris,
+    )
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(
+        two_tower_module,
+        "predict_user_tower_single",
+        fake_predict_user_tower_single,
+    )
+    monkeypatch.setattr(two_tower_module, "predict_post_tower_batch", fake_predict_post_tower_batch)
+
+    result = asyncio.run(
+        TwoTowerRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[CandidatePost(at_uri="at://post/a")],
+        )
+    )
+
+    assert seen["history_embeddings"] == []
+    assert seen["fetch_post_embeddings_calls"] == [
+        ["at://liked/1"],
+        ["at://post/a"],
+    ]
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": 2.0},
     ]
 
 
@@ -94,9 +207,17 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
     async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
         return []
 
-    monkeypatch.setattr(two_tower_module, "fetch_recent_liked_post_uris", fake_fetch_recent_liked_post_uris)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_recent_liked_post_uris",
+        fake_fetch_recent_liked_post_uris,
+    )
     monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
-    monkeypatch.setattr(two_tower_module, "predict_user_tower_single", fake_predict_user_tower_single)
+    monkeypatch.setattr(
+        two_tower_module,
+        "predict_user_tower_single",
+        fake_predict_user_tower_single,
+    )
 
     with pytest.raises(
         RankerExecutionError,


### PR DESCRIPTION
Closes #85 

If a user has no like history, the ranker currently returns an empty set. So a user with no like history wouldn't get a feed at all. 

The model already specifically has handling and training for users with no like history. So we just need to pass in an empty like history to the inference service, instead of short-circuiting and returning no results. 

I verified this on stage with my DID where I have no likes, and got results. Also added regression tests.