### PR TITLE
Return results when candidates are missing their content embeddings

### DIFF
--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -123,6 +123,7 @@ class TwoTowerRanker(Ranker):
         output_user_embedding = output_user_embedding_list[0]
 
         ####### CANDIATE POSTS #######
+        valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
         candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
         
         # Get the embeddings for all the posts
@@ -133,7 +134,16 @@ class TwoTowerRanker(Ranker):
                 len(candidates_by_uri),
                 user_did,
             )
-            return RankerResult(model=self.name, result=RankPredictResult(rankings=[]))
+            rankings = [
+                RankedCandidate(
+                    at_uri=candidate.at_uri,
+                    rank=rank_idx,
+                    rank_score=None,
+                )
+                for rank_idx, candidate in enumerate(valid_candidates, start=1)
+                if candidate.at_uri is not None
+            ]
+            return RankerResult(model=self.name, result=RankPredictResult(rankings=rankings))
 
         ranked_candidates_input = [
             candidates_by_uri[at_uri]
@@ -185,6 +195,18 @@ class TwoTowerRanker(Ranker):
                     at_uri=candidate.at_uri,
                     rank=rank_idx,
                     rank_score=score,
+                )
+            )
+
+        ranked_uris = {ranking.at_uri for ranking in rankings}
+        for candidate in valid_candidates:
+            if candidate.at_uri is None or candidate.at_uri in ranked_uris:
+                continue
+            rankings.append(
+                RankedCandidate(
+                    at_uri=candidate.at_uri,
+                    rank=len(rankings) + 1,
+                    rank_score=None,
                 )
             )
 

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -81,6 +81,7 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
     assert [ranking.model_dump() for ranking in result.result.rankings] == [
         {"at_uri": "at://post/a", "rank": 1, "rank_score": 1.0},
         {"at_uri": "at://post/b", "rank": 2, "rank_score": 0.0},
+        {"at_uri": "at://post/missing", "rank": 3, "rank_score": None},
     ]
 
 
@@ -186,6 +187,55 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
     ]
     assert [ranking.model_dump() for ranking in result.result.rankings] == [
         {"at_uri": "at://post/a", "rank": 1, "rank_score": 2.0},
+    ]
+
+
+def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missing(monkeypatch):
+    monkeypatch.setattr(
+        two_tower_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+
+    async def fake_fetch_recent_liked_post_uris(es, user_did):
+        return []
+
+    async def fake_fetch_post_embeddings(es, at_uris):
+        return []
+
+    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+        return [[1.0, 0.0]]
+
+    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+        raise AssertionError("post tower should not be called without candidate embeddings")
+
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_recent_liked_post_uris",
+        fake_fetch_recent_liked_post_uris,
+    )
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(
+        two_tower_module,
+        "predict_user_tower_single",
+        fake_predict_user_tower_single,
+    )
+    monkeypatch.setattr(two_tower_module, "predict_post_tower_batch", fake_predict_post_tower_batch)
+
+    result = asyncio.run(
+        TwoTowerRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(at_uri="at://post/a"),
+                CandidatePost(at_uri="at://post/b"),
+            ],
+        )
+    )
+
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": None},
+        {"at_uri": "at://post/b", "rank": 2, "rank_score": None},
     ]
 
 


### PR DESCRIPTION
Closes #87 

If candidates are missing content embeddings in elasticsearch, still return them, but with rank_score=None. Instead of dropping them silently.