### PR TITLE
Add followed users to ranked feed, fix wrong score bug

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -20,8 +20,8 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — post-similarity candidates with popularity infill.",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="post_similarity", weight=0.6),
-                GeneratorSpec(name="followed_users", weight=0.4),
+                GeneratorSpec(name="post_similarity", weight=0.5),
+                GeneratorSpec(name="followed_users", weight=0.5),
             ],
             infill="popularity",
             num_candidates=30,
@@ -34,7 +34,10 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — random posts.",
         diversify=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[GeneratorSpec(name="random_posts", weight=1.0)],
+            generators=[
+                GeneratorSpec(name="post_similarity", weight=0.5),
+                GeneratorSpec(name="followed_users", weight=0.5),
+            ],
             infill=None,
             num_candidates=30,
             video_only=False,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -34,10 +34,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — random posts.",
         diversify=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[
-                GeneratorSpec(name="post_similarity", weight=0.5),
-                GeneratorSpec(name="followed_users", weight=0.5),
-            ],
+            generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
             num_candidates=30,
             video_only=False,
@@ -48,7 +45,10 @@ FEEDS: dict[str, FeedConfig] = {
         display_name="Ranked",
         description="Current-best ranked feed.",
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
+            generators=[
+                GeneratorSpec(name="post_similarity", weight=0.5),
+                GeneratorSpec(name="followed_users", weight=0.5),
+            ],
             infill="popularity",
             num_candidates=30,
             video_only=False,

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -136,10 +136,14 @@ async def _run_ranking_pipeline(
             update={"candidates": candidates, "user_did": gen_request.user_did}
         )
         rank_result = await run_predict(rank_req, es)
-        # Reorder CandidatePosts by model rank so MMR diversifies starting
-        # from the highest-ranked items.
+        # Reorder CandidatePosts by model rank and stamp rank_score onto each
+        # so MMR uses the model's relevance scores, not the generator scores.
         by_uri = {c.at_uri: c for c in candidates if c.at_uri}
-        ordered = [by_uri[r.at_uri] for r in rank_result.rankings if r.at_uri in by_uri]
+        ordered = [
+            by_uri[r.at_uri].model_copy(update={"score": r.rank_score})
+            for r in rank_result.rankings
+            if r.at_uri in by_uri
+        ]
     else:
         ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
 

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1089,6 +1089,37 @@ class TestRankedFeed:
         posts = [item["post"] for item in data["feed"]]
         assert posts == ["at://p/2", "at://p/1", "at://p/0"]
 
+    def test_mmr_uses_rank_score_not_generator_score(self):
+        """MMR should weight by the model's rank_score, not the generator's ES score.
+
+        Candidates are given generator scores that disagree with the ranker's
+        ordering.  With no embeddings, MMR picks purely by relevance score, so
+        the output order reveals which score is used.
+        """
+        # Generator scores: p/0 highest, p/1 middle, p/2 lowest.
+        candidates = [
+            CandidatePost(at_uri="at://p/0", score=3.0, content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://p/1", score=2.0, content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://p/2", score=1.0, content=None, minilm_l12_embedding=None, generator_name="g"),
+        ]
+        # Ranker reverses the order: p/2 best, p/1 middle, p/0 worst.
+        rank_result = RankPredictResult(rankings=[
+            RankedCandidate(at_uri="at://p/2", rank=1, rank_score=3.0),
+            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=2.0),
+            RankedCandidate(at_uri="at://p/0", rank=3, rank_score=1.0),
+        ])
+
+        with self._patch_generators(candidates), \
+             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            ).json()
+
+        posts = [item["post"] for item in data["feed"]]
+        # Should follow rank_score order (p/2 first), not generator score (p/0 first).
+        assert posts == ["at://p/2", "at://p/1", "at://p/0"]
+
     def test_ranking_failure_returns_500(self):
         """When ranking raises, the feed fails with a 500."""
         candidates = _make_candidates("p", 3)

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1059,13 +1059,21 @@ class TestRankedFeed:
         primary_gen.generate.return_value = CandidateResult(
             generator_name="post_similarity", candidates=candidates
         )
+        followed_gen = AsyncMock()
+        followed_gen.generate.return_value = CandidateResult(
+            generator_name="followed_users", candidates=[]
+        )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[]
         )
 
         def fake_get(name):
-            return {"post_similarity": primary_gen, "popularity": infill_gen}.get(name)
+            return {
+                "post_similarity": primary_gen,
+                "followed_users": followed_gen,
+                "popularity": infill_gen,
+            }.get(name)
 
         return patch("app.lib.candidates.generate.get_generator", side_effect=fake_get)
 


### PR DESCRIPTION
### Bug fix

`_run_ranking_pipeline` was passing candidates to MMR with their original generator scores (ES/KNN relevance) still attached. MMR's relevance term drove off those scores rather than the model's `rank_score`, so the diversity reranking could partially undo the two-tower ordering. Fixed by stamping `rank_score` onto each `CandidatePost` before handing off to MMR. Test added that would have caught this: candidates with generator scores in the opposite order to rank scores, verifying that the final output follows rank scores.

### Feed weight changes

- `basic-similarity`: rebalanced `post_similarity`/`followed_users` from 60/40 to 50/50.
- `ranked`: switched generators to `post_similarity`/`followed_users` (50/50).

Closes #92 
