### PR TITLE
Improve public Swagger documentation for external AT Protocol developers

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -54,10 +54,103 @@ async def lifespan(app: FastAPI):
             pass
 
 
+_DESCRIPTION = """\
+The Green Earth API powers Bluesky content recommendation for the
+[Green Earth](https://greenearth.social) feed generator.  External
+Atmosphere Protocol developers can use it as a building block for their
+own content-discovery pipelines.
+
+## Pipeline overview
+
+The core recommendation pipeline has three stages that can be used
+independently or chained together:
+
+1. **Candidates** – retrieve posts from one or more named generators
+   (popularity, similarity, followed users, random …).
+2. **Rank** – score the candidate list with a trained engagement-prediction
+   model and return posts in descending score order.
+3. **Diversify** – rerank the ordered list with Maximal Marginal Relevance
+   (MMR) to reduce topical redundancy while preserving relevance.
+
+A typical integration calls `/candidates/generate`, pipes the result into
+`/rank/predict`, then optionally calls `/diversify` before presenting posts
+to a user.
+
+## Content search
+
+The **Skylight** endpoints (`/skylight/search` and `/skylight/similar`)
+provide standalone full-text and vector-similarity search over the post
+index.  They are independent of the candidate/rank/diversify pipeline and
+can be used on their own.
+
+## Authentication
+
+Most endpoints require an `X-API-Key` header.  Use the **Authorize**
+button above to set your key.
+
+The AT Protocol XRPC endpoints (`/xrpc/…`) use JWT authentication issued
+by the Bluesky AppView and do not require an API key.
+"""
+
+_TAGS = [
+    {
+        "name": "candidates",
+        "description": (
+            "Retrieve candidate posts from registered generators. "
+            "Each generator targets a different content source (popularity, "
+            "post similarity, followed users, random …). Multiple generators "
+            "can be combined with relative weights in a single request."
+        ),
+    },
+    {
+        "name": "rank",
+        "description": (
+            "Score and order candidate posts using trained engagement-prediction "
+            "models. Pass the output of `/candidates/generate` directly as the "
+            "request body and receive candidates back in descending score order."
+        ),
+    },
+    {
+        "name": "diversify",
+        "description": (
+            "Rerank an ordered candidate list using Maximal Marginal Relevance "
+            "(MMR) to reduce topical redundancy while preserving relevance. "
+            "Typically called as the final step after ranking."
+        ),
+    },
+    {
+        "name": "skylight",
+        "description": (
+            "Standalone full-text and vector-similarity search over the post "
+            "index. These endpoints are independent of the candidate/rank/"
+            "diversify pipeline and can be used on their own by applications "
+            "that need direct content search (e.g. the Skylight app)."
+        ),
+    },
+    {
+        "name": "health",
+        "description": "Service liveness check.",
+    },
+    {
+        "name": "xrpc",
+        "description": (
+            "AT Protocol XRPC endpoints that implement the Bluesky feed "
+            "generator specification (`app.bsky.feed.describeFeedGenerator` "
+            "and `app.bsky.feed.getFeedSkeleton`). These endpoints are public "
+            "and use AT Protocol JWT authentication rather than an API key."
+        ),
+    },
+]
+
 app = FastAPI(
     title="Green Earth API",
-    description="An API server for handling bluesky content recommendation requests",
+    description=_DESCRIPTION,
     version="0.1.0",
+    contact={
+        "name": "Green Earth community",
+        "url": "https://discord.com/invite/8bWEyrkrJC",
+    },
+    openapi_tags=_TAGS,
     lifespan=lifespan,
 )
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -99,7 +99,10 @@ class CandidateGenerateRequest(BaseModel):
 class CandidateGenerateResult(BaseModel):
     """The output of a generation pipeline run."""
 
-    candidates: list[CandidatePost]
+    candidates: list[CandidatePost] = Field(
+        default_factory=list,
+        description="De-duplicated candidate posts in interleaved generator order.",
+    )
 
 
 class RankPredictRequest(BaseModel):

--- a/src/app/routers/candidates.py
+++ b/src/app/routers/candidates.py
@@ -10,7 +10,7 @@ POST /candidates/generate
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..models import CandidateGenerateRequest, CandidateGenerateResult
 from ..lib.candidates import (
@@ -33,7 +33,10 @@ logger = logging.getLogger(__name__)
 class GeneratorListResponse(BaseModel):
     """Lists available generator names."""
 
-    generators: list[str]
+    generators: list[str] = Field(
+        default_factory=list,
+        description="Names of all registered candidate generators (use in `GeneratorSpec.name`).",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +49,14 @@ async def candidates_list_generators() -> GeneratorListResponse:
     return GeneratorListResponse(generators=list_generators())
 
 
-@router.post("/candidates/generate", response_model=CandidateGenerateResult)
+@router.post(
+    "/candidates/generate",
+    response_model=CandidateGenerateResult,
+    responses={
+        404: {"description": "A named generator was not found"},
+        502: {"description": "Upstream generator service failed"},
+    },
+)
 async def candidates_generate(
     request: Request,
     payload: CandidateGenerateRequest,
@@ -56,6 +66,12 @@ async def candidates_generate(
     When multiple generators are specified, candidates from each are
     interleaved according to their proportional weights and then
     de-duplicated (first occurrence wins).
+
+    Set `video_only: true` to restrict results to posts that contain video.
+    Use `infill` to name a fallback generator that fills remaining slots when
+    primary generators return fewer candidates than `num_candidates`.
+    Pass previously shown AT URIs in `exclude_uris` to avoid repeating posts
+    across pagination pages.
     """
     try:
         result = await run_generate(payload, request.app.state.es)

--- a/src/app/routers/diversify.py
+++ b/src/app/routers/diversify.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..lib.diversify import mmr_rerank
 from ..models import CandidatePost
@@ -9,13 +9,39 @@ router = APIRouter(tags=["diversify"], dependencies=[Depends(verify_api_key)])
 
 
 class DiversifyRequest(BaseModel):
-    candidates: list[CandidatePost]
+    """Ordered list of candidates to rerank for diversity."""
+
+    candidates: list[CandidatePost] = Field(
+        ...,
+        description=(
+            "Candidate posts to rerank, in their current order (e.g. as "
+            "returned by /rank/predict). MiniLM L12 embeddings must be "
+            "present on each post for MMR to compute similarity."
+        ),
+    )
 
 
 class DiversifyResponse(BaseModel):
-    candidates: list[CandidatePost]
+    """Reranked candidate list with improved topical variety."""
+
+    candidates: list[CandidatePost] = Field(
+        ...,
+        description="Candidates reordered by MMR to reduce topical redundancy.",
+    )
 
 
 @router.post("/diversify", response_model=DiversifyResponse)
 async def diversify(payload: DiversifyRequest) -> DiversifyResponse:
+    """Rerank candidates using Maximal Marginal Relevance (MMR).
+
+    MMR balances relevance against redundancy: each successive post is chosen
+    to be as relevant as possible while being as dissimilar as possible from
+    the posts already selected. This reduces topical clustering in the final
+    feed without sacrificing overall quality.
+
+    Call this endpoint as the final step after `/rank/predict` (or directly
+    after `/candidates/generate` if skipping ranking).  Posts must carry
+    `minilm_l12_embedding` values for similarity to be computed; posts
+    without embeddings are appended to the end of the reranked list.
+    """
     return DiversifyResponse(candidates=mmr_rerank(payload.candidates))

--- a/src/app/routers/health.py
+++ b/src/app/routers/health.py
@@ -1,13 +1,14 @@
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 router = APIRouter(tags=["health"])
 
 
 class HealthResponse(BaseModel):
-    status: str
+    status: str = Field(..., description="'ok' when the service is healthy")
 
 
 @router.get("/health", response_model=HealthResponse, status_code=200)
-async def healthcheck():
-    return {"status": "ok"}
+async def healthcheck() -> HealthResponse:
+    """Returns 200 when the service is running."""
+    return HealthResponse(status="ok")

--- a/src/app/routers/rank.py
+++ b/src/app/routers/rank.py
@@ -47,12 +47,26 @@ async def rank_list_models() -> RankModelListResponse:
     return RankModelListResponse(rankers=list_rankers())
 
 
-@router.post("/rank/predict", response_model=RankPredictResult)
+@router.post(
+    "/rank/predict",
+    response_model=RankPredictResult,
+    responses={
+        400: {"description": "Invalid request (e.g. unsupported model configuration)"},
+        404: {"description": "Requested ranking model not found"},
+        502: {"description": "Upstream ranker service failed"},
+    },
+)
 async def rank_predict(
     request: Request,
     payload: RankPredictRequest,
 ) -> RankPredictResult:
-    """Rank the supplied candidate posts."""
+    """Score and order candidate posts using an engagement-prediction model.
+
+    Each candidate is scored by the named model (or the service default when
+    `model` is omitted).  The response lists candidates in descending score
+    order with 1-based `rank` positions.  Pass the output of
+    `/candidates/generate` directly as the request body.
+    """
     try:
         result = await run_predict(payload, request.app.state.es)
     except RankModelNotFoundError as exc:

--- a/src/app/routers/skylight.py
+++ b/src/app/routers/skylight.py
@@ -5,7 +5,7 @@ import logging
 # client errors as general exceptions here to avoid import-time issues.
 from fastapi import APIRouter, HTTPException, Query, Request, Depends
 from ..security import verify_api_key
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from ..models import CandidatePost
 
 from ..lib.embeddings import (
@@ -24,13 +24,32 @@ logger = logging.getLogger(__name__)
 
 class SkylightSearchResponse(BaseModel):
     """Search response returning a list of post results."""
-    results: list[CandidatePost]
+
+    results: list[CandidatePost] = Field(
+        default_factory=list,
+        description="Matching posts in relevance order.",
+    )
 
 
 class SkylightSimilarRequest(BaseModel):
-    at_uris: list[str] | None = None
-    embeddings: list[str] | None = None
-    size: int = 10
+    """Seeds for a nearest-neighbor similarity search."""
+
+    at_uris: list[str] | None = Field(
+        None,
+        description=(
+            "AT URIs of seed posts. The service fetches their stored MiniLM "
+            "L12 embeddings from the index and averages them into a query vector."
+        ),
+    )
+    embeddings: list[str] | None = Field(
+        None,
+        description=(
+            "Base64-encoded float32 MiniLM L12 embeddings (384-d) to use as "
+            "similarity seeds. Averaged with any embeddings looked up via "
+            "`at_uris`. At least one of `at_uris` or `embeddings` is required."
+        ),
+    )
+    size: int = Field(10, ge=1, le=100, description="Number of nearest-neighbor results to return.")
 
 
 def posts_response_to_results(resp) -> list[CandidatePost]:
@@ -73,15 +92,21 @@ def posts_response_to_results(resp) -> list[CandidatePost]:
     return results
 
 
-@router.get("/skylight/search", response_model=SkylightSearchResponse)
+@router.get(
+    "/skylight/search",
+    response_model=SkylightSearchResponse,
+    responses={502: {"description": "Upstream Elasticsearch request failed"}},
+)
 async def skylight_search(
     request: Request,
-    q: str = Query(..., description="Elasticsearch query string"),
-    size: int = Query(10, ge=1, le=100),
+    q: str = Query(..., description="Elasticsearch query string syntax — supports field qualifiers, wildcards, and boolean operators"),
+    size: int = Query(10, ge=1, le=100, description="Maximum number of results to return (1–100)"),
 ) -> SkylightSearchResponse:
     """Search the `posts` index `content` field and return matching posts.
 
-    Returns stored MiniLM vectors when present.
+    Results are currently scoped to posts that contain video.
+    Stored MiniLM L12 vectors are returned on each result when present,
+    which can be passed directly to `/skylight/similar` as `embeddings`.
     """
     # Only return posts that contain video. Use a boolean query with a
     # `must` for the original query_string and a `filter` for the
@@ -121,13 +146,27 @@ async def skylight_search(
 
 
 
-@router.post("/skylight/similar", response_model=SkylightSearchResponse)
+@router.post(
+    "/skylight/similar",
+    response_model=SkylightSearchResponse,
+    responses={
+        400: {"description": "No embeddings supplied, invalid base64, or dimension mismatch"},
+        404: {"description": "None of the supplied `at_uris` had stored embeddings"},
+        502: {"description": "Upstream Elasticsearch request failed"},
+    },
+)
 async def skylight_similar(request: Request, payload: SkylightSimilarRequest):
-    """Return posts most similar to the average MiniLM L12 embedding for
-    the supplied `at_uris` and/or base64-encoded `embeddings`.
+    """Return posts most similar to the average MiniLM L12 embedding of the seeds.
 
-    If `at_uris` are provided but none of them are found with embeddings,
-    return 404.
+    The service averages the embeddings from `at_uris` (fetched from the index)
+    and/or directly supplied `embeddings` into a single query vector, then runs
+    a k-nearest-neighbor search against the post index.
+
+    Results are currently scoped to posts that contain video.
+
+    At least one of `at_uris` or `embeddings` must be provided.  If `at_uris`
+    are given but none are found in the index with stored embeddings, the
+    endpoint returns 404.
     """
     vectors: list[list[float]] = []
 


### PR DESCRIPTION
Closes #97

This PR improves the OpenAPI/Swagger documentation exposed at `/docs` to make the API more accessible to external Atmosphere Protocol developers. The changes are documentation-only — no functional logic was modified.

# This PR

- Add rich markdown app description to `/docs` covering the Candidates → Rank → Diversify pipeline overview, Skylight as a standalone search service, and authentication model (X-API-Key vs. AT Protocol JWT)
- Add per-tag descriptions in the Swagger sidebar for all six tag groups (`candidates`, `rank`, `diversify`, `skylight`, `health`, `xrpc`)
- Add contact block pointing to the Green Earth Discord
- Add endpoint docstrings to `GET /health` and `POST /diversify` (previously undocumented)
- Add class docstrings and `Field` descriptions to `DiversifyRequest`, `DiversifyResponse`, `SkylightSimilarRequest`, and `SkylightSearchResponse`
- Expand `POST /candidates/generate` docstring to surface `video_only`, `infill`, and `exclude_uris` behavior
- Expand `POST /rank/predict` docstring to explain descending score order and 1-based rank positions
- Note video-only filter scope in both Skylight endpoint docstrings
- Add `responses=` error documentation (400/404/502) to `candidates/generate`, `rank/predict`, `skylight/search`, and `skylight/similar`
- Add field descriptions to `GeneratorListResponse.generators` and `CandidateGenerateResult.candidates`

# Testing

- CI tests