### PR TITLE
Feed generation optimization, first pass

### DIFF
--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -5,6 +5,8 @@ import logging
 
 import httpx
 
+from .http_client import get_http_client
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -49,7 +51,7 @@ async def _get_follows_page(
 ) -> dict:
     for attempt in range(FOLLOWS_MAX_RETRIES + 1):
         try:
-            resp = await client.get(base_url, params=params)
+            resp = await client.get(base_url, params=params, timeout=FOLLOWS_HTTP_TIMEOUT)
             resp.raise_for_status()
             return resp.json()
         except httpx.HTTPError as exc:
@@ -71,53 +73,54 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
     if limit <= 0:
         return followed_dids
 
+    client = get_http_client()
+
     try:
-        async with httpx.AsyncClient(timeout=FOLLOWS_HTTP_TIMEOUT) as client:
-            async with asyncio.timeout(FOLLOWS_LOOKUP_TIMEOUT_SECONDS):
-                while len(followed_dids) < limit:
-                    page_limit = min(FOLLOWS_PAGE_LIMIT, limit - len(followed_dids))
-                    params = {"actor": user_did, "limit": page_limit}
-                    if cursor:
-                        params["cursor"] = cursor
+        async with asyncio.timeout(FOLLOWS_LOOKUP_TIMEOUT_SECONDS):
+            while len(followed_dids) < limit:
+                page_limit = min(FOLLOWS_PAGE_LIMIT, limit - len(followed_dids))
+                params = {"actor": user_did, "limit": page_limit}
+                if cursor:
+                    params["cursor"] = cursor
 
-                    try:
-                        data = await _get_follows_page(client, base_url, params)
-                        if not isinstance(data, dict):
-                            raise FollowedUsersLookupError(
-                                f"Unexpected follows response for {user_did}"
-                            )
+                try:
+                    data = await _get_follows_page(client, base_url, params)
+                    if not isinstance(data, dict):
+                        raise FollowedUsersLookupError(
+                            f"Unexpected follows response for {user_did}"
+                        )
 
-                        follows = data.get("follows", [])
-                        if not isinstance(follows, list):
-                            raise FollowedUsersLookupError(
-                                f"Unexpected follows response for {user_did}"
-                            )
-                    except (
-                        httpx.HTTPError,
-                        ValueError,
-                        FollowedUsersLookupError,
-                    ) as exc:
-                        if followed_dids:
-                            logger.warning(
-                                "Returning %s partial followed users for %s after "
-                                "follow lookup page failed: %s",
-                                len(followed_dids),
-                                user_did,
-                                exc,
-                            )
-                            return followed_dids[:limit]
-                        raise
+                    follows = data.get("follows", [])
+                    if not isinstance(follows, list):
+                        raise FollowedUsersLookupError(
+                            f"Unexpected follows response for {user_did}"
+                        )
+                except (
+                    httpx.HTTPError,
+                    ValueError,
+                    FollowedUsersLookupError,
+                ) as exc:
+                    if followed_dids:
+                        logger.warning(
+                            "Returning %s partial followed users for %s after "
+                            "follow lookup page failed: %s",
+                            len(followed_dids),
+                            user_did,
+                            exc,
+                        )
+                        return followed_dids[:limit]
+                    raise
 
-                    followed_dids.extend(
-                        follow["did"]
-                        for follow in follows
-                        if isinstance(follow, dict)
-                        and isinstance(follow.get("did"), str)
-                    )
+                followed_dids.extend(
+                    follow["did"]
+                    for follow in follows
+                    if isinstance(follow, dict)
+                    and isinstance(follow.get("did"), str)
+                )
 
-                    cursor = data.get("cursor")
-                    if not isinstance(cursor, str) or not cursor:
-                        break
+                cursor = data.get("cursor")
+                if not isinstance(cursor, str) or not cursor:
+                    break
     except TimeoutError as exc:
         if followed_dids:
             logger.warning(

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -24,40 +24,26 @@ class FakeResponse:
 
 
 class FakeAsyncClient:
-    instances: list["FakeAsyncClient"] = []
-    response = FakeResponse({"follows": []})
-    responses: list[FakeResponse | Exception] = []
-
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
+    def __init__(self):
         self.get_calls: list[dict] = []
-        self.closed = False
-        FakeAsyncClient.instances.append(self)
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        self.closed = True
+        self.response: FakeResponse = FakeResponse({"follows": []})
+        self.responses: list[FakeResponse | Exception] = []
 
     async def get(self, url, *, params=None, **kwargs):
         self.get_calls.append({"url": url, "params": params, "kwargs": kwargs})
-        if FakeAsyncClient.responses:
-            response = FakeAsyncClient.responses.pop(0)
+        if self.responses:
+            response = self.responses.pop(0)
             if isinstance(response, Exception):
                 raise response
             return response
-        return FakeAsyncClient.response
+        return self.response
 
 
 @pytest.fixture
 def fake_http_client(monkeypatch):
-    FakeAsyncClient.instances = []
-    FakeAsyncClient.response = FakeResponse({"follows": []})
-    FakeAsyncClient.responses = []
-    monkeypatch.setattr(bsky_module.httpx, "AsyncClient", FakeAsyncClient)
-    return FakeAsyncClient
+    client = FakeAsyncClient()
+    monkeypatch.setattr(bsky_module, "get_http_client", lambda: client)
+    return client
 
 
 class TestGetFollowedUserDids:
@@ -73,13 +59,10 @@ class TestGetFollowedUserDids:
         dids = await get_followed_user_dids("did:plc:user1", limit=50)
 
         assert dids == ["did:plc:follow1", "did:plc:follow2"]
-        client = fake_http_client.instances[0]
-        assert client.kwargs == {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT}
-        assert client.closed is True
-        assert client.get_calls == [{
+        assert fake_http_client.get_calls == [{
             "url": "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows",
             "params": {"actor": "did:plc:user1", "limit": 50},
-            "kwargs": {},
+            "kwargs": {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT},
         }]
 
     @pytest.mark.asyncio
@@ -98,12 +81,11 @@ class TestGetFollowedUserDids:
         dids = await get_followed_user_dids("did:plc:user1", limit=103)
 
         assert dids == [f"did:plc:follow{i}" for i in range(103)]
-        client = fake_http_client.instances[0]
-        assert client.get_calls == [
+        assert fake_http_client.get_calls == [
             {
                 "url": "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows",
                 "params": {"actor": "did:plc:user1", "limit": 100},
-                "kwargs": {},
+                "kwargs": {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT},
             },
             {
                 "url": "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows",
@@ -112,7 +94,7 @@ class TestGetFollowedUserDids:
                     "limit": 3,
                     "cursor": "next-page",
                 },
-                "kwargs": {},
+                "kwargs": {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT},
             },
         ]
 
@@ -131,15 +113,14 @@ class TestGetFollowedUserDids:
         dids = await get_followed_user_dids("did:plc:user1", limit=1)
 
         assert dids == ["did:plc:follow1"]
-        client = fake_http_client.instances[0]
-        assert client.get_calls[0]["params"] == {"actor": "did:plc:user1", "limit": 1}
+        assert fake_http_client.get_calls[0]["params"] == {"actor": "did:plc:user1", "limit": 1}
 
     @pytest.mark.asyncio
     async def test_non_positive_limit_skips_http_request(self, fake_http_client):
         dids = await get_followed_user_dids("did:plc:user1", limit=0)
 
         assert dids == []
-        assert fake_http_client.instances == []
+        assert fake_http_client.get_calls == []
 
     @pytest.mark.asyncio
     async def test_skips_malformed_follow_entries(self, fake_http_client):
@@ -181,8 +162,7 @@ class TestGetFollowedUserDids:
         with pytest.raises(FollowedUsersLookupError, match="Failed to fetch"):
             await get_followed_user_dids("did:plc:user1", limit=100)
 
-        client = fake_http_client.instances[0]
-        assert len(client.get_calls) == 2
+        assert len(fake_http_client.get_calls) == 2
 
     @pytest.mark.asyncio
     async def test_retries_transient_http_error_once(
@@ -213,8 +193,7 @@ class TestGetFollowedUserDids:
 
         assert dids == ["did:plc:follow1"]
         assert sleeps == [bsky_module.FOLLOWS_RETRY_BACKOFF_SECONDS]
-        client = fake_http_client.instances[0]
-        assert len(client.get_calls) == 2
+        assert len(fake_http_client.get_calls) == 2
 
     @pytest.mark.asyncio
     async def test_returns_partial_dids_when_later_page_fails(
@@ -247,8 +226,7 @@ class TestGetFollowedUserDids:
 
         assert dids == [f"did:plc:follow{i}" for i in range(100)]
         assert "partial followed users" in caplog.text
-        client = fake_http_client.instances[0]
-        assert len(client.get_calls) == 3
+        assert len(fake_http_client.get_calls) == 3
 
     @pytest.mark.asyncio
     async def test_returns_partial_dids_when_total_lookup_budget_expires(

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -6,6 +6,7 @@ a fallback generator.  This module is used by both the ``/candidates``
 REST API and the XRPC feed-skeleton endpoint.
 """
 
+import asyncio
 import logging
 import math
 
@@ -15,7 +16,7 @@ from ...models import (
     CandidatePost,
     GeneratorSpec,
 )
-from .base import CandidateResult, get_generator
+from .base import CandidateGenerator, CandidateResult, get_generator
 
 logger = logging.getLogger(__name__)
 
@@ -104,18 +105,22 @@ async def run_generate(
     """
     counts = allocate_counts(request.generators, request.num_candidates)
 
-    all_candidates: list[CandidatePost] = []
-
+    # Resolve generators up front so missing-name errors raise deterministically
+    # before any network work begins.
+    active: list[tuple[GeneratorSpec, int, CandidateGenerator]] = []
     for spec, count in zip(request.generators, counts):
         if count <= 0:
             continue
-
         gen = get_generator(spec.name)
         if gen is None:
             raise GeneratorNotFoundError(spec.name)
+        active.append((spec, count, gen))
 
+    async def _run_one(
+        spec: GeneratorSpec, count: int, gen: CandidateGenerator
+    ) -> CandidateResult | None:
         try:
-            result = await gen.generate(
+            return await gen.generate(
                 es=es,
                 user_did=request.user_did,
                 num_candidates=count,
@@ -125,9 +130,17 @@ async def run_generate(
         except Exception as exc:
             logger.exception("Candidate generator '%s' failed", spec.name)
             if swallow_errors:
-                continue
+                return None
             raise GeneratorError(spec.name, exc) from exc
 
+    results = await asyncio.gather(
+        *(_run_one(spec, count, gen) for spec, count, gen in active)
+    )
+
+    all_candidates: list[CandidatePost] = []
+    for result in results:
+        if result is None:
+            continue
         all_candidates.extend(result.candidates)
 
     deduped = dedup_candidates(all_candidates)

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -10,6 +10,7 @@ from elastic_transport import ObjectApiResponse
 from fastapi import HTTPException
 
 from .embeddings import MINILM_L12_EMBEDDING_FIELD, MINILM_L12_EMBEDDING_KEY
+from .request_cache import get_request_cache
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,10 @@ async def fetch_recent_liked_post_uris(
     Queries the ``likes`` index for documents where ``author_did`` matches
     *user_did*, sorted by ``created_at`` descending, and extracts the
     ``subject_uri`` field from each hit.
+
+    When a request cache is active the result is memoized so repeat
+    calls within the same request (e.g. post_similarity and the two-tower
+    ranker) share a single ES round-trip.
     """
     if isinstance(user_dids, str):
         user_dids = [user_dids]
@@ -51,27 +56,34 @@ async def fetch_recent_liked_post_uris(
     if not user_dids:
         return []
 
-    query = {
-        "bool": {
-            "filter": [{"terms": {"author_did": user_dids}}],
+    async def _fetch() -> list[str]:
+        query = {
+            "bool": {
+                "filter": [{"terms": {"author_did": user_dids}}],
+            }
         }
-    }
 
-    resp = await es.search(
-        index="likes",
-        query=query,
-        size=limit,
-        sort=[{"created_at": "desc"}],
-        _source=["subject_uri"],
-    )
+        resp = await es.search(
+            index="likes",
+            query=query,
+            size=limit,
+            sort=[{"created_at": "desc"}],
+            _source=["subject_uri"],
+        )
 
-    data = unwrap_es_response(resp)
-    uris: list[str] = []
-    for hit in data.get("hits", {}).get("hits", []):
-        uri = (hit.get("_source") or {}).get("subject_uri")
-        if uri:
-            uris.append(uri)
-    return uris
+        data = unwrap_es_response(resp)
+        uris: list[str] = []
+        for hit in data.get("hits", {}).get("hits", []):
+            uri = (hit.get("_source") or {}).get("subject_uri")
+            if uri:
+                uris.append(uri)
+        return uris
+
+    cache = get_request_cache()
+    if cache is None:
+        return await _fetch()
+    key = ("fetch_recent_liked_post_uris", tuple(sorted(user_dids)), limit)
+    return await cache.get_or_compute(key, _fetch)
 
 
 async def fetch_post_embeddings(
@@ -82,35 +94,45 @@ async def fetch_post_embeddings(
 
     Returns ``(at_uri, embedding)`` pairs in the same order as ``at_uris``.
     Posts without embeddings are silently skipped.
+
+    When a request cache is active the result is memoized so repeat
+    calls within the same request share a single ES round-trip.
     """
     if not at_uris:
         return []
 
-    query = {"terms": {"at_uri": at_uris}}
+    async def _fetch() -> list[tuple[str, list[float]]]:
+        query = {"terms": {"at_uri": at_uris}}
 
-    resp = await es.search(
-        index="posts",
-        query=query,
-        size=len(at_uris),
-        _source=["at_uri", MINILM_L12_EMBEDDING_FIELD],
-    )
+        resp = await es.search(
+            index="posts",
+            query=query,
+            size=len(at_uris),
+            _source=["at_uri", MINILM_L12_EMBEDDING_FIELD],
+        )
 
-    data = unwrap_es_response(resp)
-    embeddings_by_uri: dict[str, list[float]] = {}
-    for hit in data.get("hits", {}).get("hits", []):
-        src = hit.get("_source") or {}
-        at_uri = src.get("at_uri")
-        if not at_uri:
-            continue
-        emb = src.get("embeddings")
-        if isinstance(emb, dict):
-            vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+        data = unwrap_es_response(resp)
+        embeddings_by_uri: dict[str, list[float]] = {}
+        for hit in data.get("hits", {}).get("hits", []):
+            src = hit.get("_source") or {}
+            at_uri = src.get("at_uri")
+            if not at_uri:
+                continue
+            emb = src.get("embeddings")
+            if isinstance(emb, dict):
+                vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+                if vec:
+                    embeddings_by_uri[at_uri] = vec
+
+        ordered_embeddings: list[tuple[str, list[float]]] = []
+        for at_uri in at_uris:
+            vec = embeddings_by_uri.get(at_uri)
             if vec:
-                embeddings_by_uri[at_uri] = vec
+                ordered_embeddings.append((at_uri, vec))
+        return ordered_embeddings
 
-    ordered_embeddings: list[tuple[str, list[float]]] = []
-    for at_uri in at_uris:
-        vec = embeddings_by_uri.get(at_uri)
-        if vec:
-            ordered_embeddings.append((at_uri, vec))
-    return ordered_embeddings
+    cache = get_request_cache()
+    if cache is None:
+        return await _fetch()
+    key = ("fetch_post_embeddings", tuple(at_uris))
+    return await cache.get_or_compute(key, _fetch)

--- a/src/app/lib/http_client.py
+++ b/src/app/lib/http_client.py
@@ -1,0 +1,41 @@
+"""Process-wide shared ``httpx.AsyncClient``.
+
+Inference and Bluesky calls previously constructed a fresh
+``httpx.AsyncClient`` per invocation, paying a TLS handshake every
+time. This module hoists one client to app scope so its connection
+pools live across requests.
+
+The lifespan handler calls :func:`init_http_client` at startup and
+:func:`close_http_client` at shutdown. Other callers obtain the
+client via :func:`get_http_client`; outside of app lifetime (e.g.
+tests that bypass lifespan) it lazily creates a client so callers
+never get ``None``.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+_client: httpx.AsyncClient | None = None
+
+
+def init_http_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=30.0)
+    return _client
+
+
+async def close_http_client() -> None:
+    global _client
+    if _client is not None:
+        try:
+            await _client.aclose()
+        finally:
+            _client = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    if _client is None:
+        return init_http_client()
+    return _client

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -9,12 +9,11 @@ import asyncio
 import logging
 import os
 
-import httpx
-
 from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerExecutionError, RankerResult
 from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
 from ..embeddings import decode_float32_b64
+from ..http_client import get_http_client
 
 
 logger = logging.getLogger(__name__)
@@ -56,22 +55,22 @@ async def predict_post_tower_batch(
         for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE)
     ]
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        async def _call_chunk(chunk: list[list[float]]) -> list[list[float]]:
-            resp = await client.post(  # type: ignore
-                url, json={"post_embeddings": chunk}, headers=headers
+    client = get_http_client()
+
+    async def _call_chunk(chunk: list[list[float]]) -> list[list[float]]:
+        resp = await client.post(
+            url, json={"post_embeddings": chunk}, headers=headers
+        )
+        if resp.is_error:
+            logger.error(
+                "post-tower predict failed status=%s body=%s",
+                resp.status_code,
+                resp.text,
             )
-            if resp.is_error:
-                logger.error(
-                    "post-tower predict failed status=%s body=%s",
-                    resp.status_code,
-                    resp.text,
-                )
-                resp.raise_for_status()
-            return resp.json()["outputs"]
+            resp.raise_for_status()
+        return resp.json()["outputs"]
 
-        chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
-
+    chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
     return [item for chunk_out in chunk_outputs for item in chunk_out]
 
 
@@ -85,11 +84,10 @@ async def predict_user_tower_single(
     headers = {"X-API-Key": api_key}
     payload = {"history_embeddings": history_embeddings}
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(url, json=payload, headers=headers) # type: ignore
-        resp.raise_for_status()
-        data = resp.json()
-        return data["outputs"]
+    client = get_http_client()
+    resp = await client.post(url, json=payload, headers=headers)
+    resp.raise_for_status()
+    return resp.json()["outputs"]
 
 
 class TwoTowerRanker(Ranker):

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -5,6 +5,7 @@ Also calls inference on a post tower for each post to get final post embeddings.
 Performs vector-matrix multiplication to get scores for each post, and returns the posts in order.
 """
 
+import asyncio
 import logging
 import os
 
@@ -50,12 +51,16 @@ async def predict_post_tower_batch(
     url = f"{base_url}/models/post-tower/predict"
     headers = {"X-API-Key": api_key}
 
-    results: list[list[float]] = []
+    chunks = [
+        post_embeddings[i : i + POST_TOWER_BATCH_SIZE]
+        for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE)
+    ]
+
     async with httpx.AsyncClient(timeout=30.0) as client:
-        for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE):
-            chunk = post_embeddings[i : i + POST_TOWER_BATCH_SIZE]
-            payload = {"post_embeddings": chunk}
-            resp = await client.post(url, json=payload, headers=headers) # type: ignore
+        async def _call_chunk(chunk: list[list[float]]) -> list[list[float]]:
+            resp = await client.post(  # type: ignore
+                url, json={"post_embeddings": chunk}, headers=headers
+            )
             if resp.is_error:
                 logger.error(
                     "post-tower predict failed status=%s body=%s",
@@ -63,9 +68,11 @@ async def predict_post_tower_batch(
                     resp.text,
                 )
                 resp.raise_for_status()
-            data = resp.json()
-            results.extend(data["outputs"])
-    return results
+            return resp.json()["outputs"]
+
+        chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
+
+    return [item for chunk_out in chunk_outputs for item in chunk_out]
 
 
 async def predict_user_tower_single(
@@ -94,7 +101,7 @@ class TwoTowerRanker(Ranker):
 
 
     async def predict(
-        self, 
+        self,
         es,
         user_did: str,
         candidates: list[CandidatePost]
@@ -102,62 +109,91 @@ class TwoTowerRanker(Ranker):
         inference_base_url, inference_api_key = (
             get_inference_settings()
         )
-        
-        ####### USER #######
-        # 1. Get recently liked post URIs
-        user_history_vectors = []
-        user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
-        if not user_history_liked_uris:
-            logger.info("No likes found for user %s", user_did)
-        else:
-            # 2. Fetch embeddings for those posts
-            user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(es, user_history_liked_uris)
-
-            if not user_history_embedding_pairs:
-                logger.info(
-                    "No embeddings found for %d liked posts of user %s",
-                    len(user_history_liked_uris),
-                    user_did,
-                )
-            else:
-                user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
-        
-        # Call the inference API for the user tower
-        output_user_embedding_list = await predict_user_tower_single(
-            user_history_vectors,
-            base_url=inference_base_url,
-            api_key=inference_api_key,
-        )
-        if len(output_user_embedding_list) != 1:
-            raise RankerExecutionError(
-                self.name,
-                f"user inference returned {len(output_user_embedding_list)} embeddings; expected 1",
-            )
-        output_user_embedding = output_user_embedding_list[0]
-
-        ####### CANDIATE POSTS #######
         valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
         candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
 
-        # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
-        candidate_embedding_pairs: list[tuple[str, list[float]]] = []
-        missing_uris: list[str] = []
-        for uri, candidate in candidates_by_uri.items():
-            if candidate.minilm_l12_embedding:
-                try:
-                    vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                    candidate_embedding_pairs.append((uri, vec))
-                    continue
-                except Exception:
-                    pass
-            missing_uris.append(uri)
+        async def _compute_user_embedding() -> list[float]:
+            user_history_vectors: list[list[float]] = []
+            user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
-        if missing_uris:
-            fetched = await fetch_post_embeddings(es, missing_uris)
-            candidate_embedding_pairs.extend(fetched)
+            if not user_history_liked_uris:
+                logger.info("No likes found for user %s", user_did)
+            else:
+                user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(
+                    es, user_history_liked_uris
+                )
+                if not user_history_embedding_pairs:
+                    logger.info(
+                        "No embeddings found for %d liked posts of user %s",
+                        len(user_history_liked_uris),
+                        user_did,
+                    )
+                else:
+                    user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
 
-        if not candidate_embedding_pairs:
+            output_user_embedding_list = await predict_user_tower_single(
+                user_history_vectors,
+                base_url=inference_base_url,
+                api_key=inference_api_key,
+            )
+            if len(output_user_embedding_list) != 1:
+                raise RankerExecutionError(
+                    self.name,
+                    f"user inference returned {len(output_user_embedding_list)} embeddings; expected 1",
+                )
+            return output_user_embedding_list[0]
+
+        async def _compute_candidate_post_embeddings() -> (
+            tuple[list[CandidatePost], list[list[float]]] | None
+        ):
+            # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+            candidate_embedding_pairs: list[tuple[str, list[float]]] = []
+            missing_uris: list[str] = []
+            for uri, candidate in candidates_by_uri.items():
+                if candidate.minilm_l12_embedding:
+                    try:
+                        vec = decode_float32_b64(candidate.minilm_l12_embedding)
+                        candidate_embedding_pairs.append((uri, vec))
+                        continue
+                    except Exception:
+                        pass
+                missing_uris.append(uri)
+
+            if missing_uris:
+                fetched = await fetch_post_embeddings(es, missing_uris)
+                candidate_embedding_pairs.extend(fetched)
+
+            if not candidate_embedding_pairs:
+                return None
+
+            ranked_candidates_input = [
+                candidates_by_uri[at_uri]
+                for at_uri, _ in candidate_embedding_pairs
+                if at_uri in candidates_by_uri
+            ]
+            input_post_embeddings = [
+                embedding for _, embedding in candidate_embedding_pairs
+            ]
+
+            output_post_embeddings = await predict_post_tower_batch(
+                input_post_embeddings,
+                base_url=inference_base_url,
+                api_key=inference_api_key,
+            )
+            if len(output_post_embeddings) != len(ranked_candidates_input):
+                raise RankerExecutionError(
+                    self.name,
+                    "post inference returned a different number of embeddings than requested",
+                )
+            return ranked_candidates_input, output_post_embeddings
+
+        output_user_embedding, candidate_result = await asyncio.gather(
+            _compute_user_embedding(),
+            _compute_candidate_post_embeddings(),
+        )
+
+        if candidate_result is None:
             logger.info(
                 "No embeddings found for %d candidate posts of user %s",
                 len(candidates_by_uri),
@@ -174,26 +210,7 @@ class TwoTowerRanker(Ranker):
             ]
             return RankerResult(model=self.name, result=RankPredictResult(rankings=rankings))
 
-        ranked_candidates_input = [
-            candidates_by_uri[at_uri]
-            for at_uri, _ in candidate_embedding_pairs
-            if at_uri in candidates_by_uri
-        ]
-        input_post_embeddings = [
-            embedding for _, embedding in candidate_embedding_pairs
-        ]
-
-        # Call the post tower for the whole batch
-        output_post_embeddings = await predict_post_tower_batch(
-            input_post_embeddings,
-            base_url=inference_base_url,
-            api_key=inference_api_key,
-        )
-        if len(output_post_embeddings) != len(ranked_candidates_input):
-            raise RankerExecutionError(
-                self.name,
-                "post inference returned a different number of embeddings than requested",
-            )
+        ranked_candidates_input, output_post_embeddings = candidate_result
 
         # For each candidate post, take the dot product of its output embedding with the user output embedding
         final_scores = []

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -257,6 +257,9 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
     async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
         return []
 
+    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+        return post_embeddings
+
     monkeypatch.setattr(
         two_tower_module,
         "fetch_recent_liked_post_uris",
@@ -268,6 +271,7 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
         "predict_user_tower_single",
         fake_predict_user_tower_single,
     )
+    monkeypatch.setattr(two_tower_module, "predict_post_tower_batch", fake_predict_post_tower_batch)
 
     with pytest.raises(
         RankerExecutionError,

--- a/src/app/lib/request_cache.py
+++ b/src/app/lib/request_cache.py
@@ -1,0 +1,64 @@
+"""Per-request cache for expensive lookups.
+
+A ``ContextVar`` holds the current request's cache so helper functions
+(e.g. the Elasticsearch query wrappers in ``lib/elasticsearch.py``) can
+consult it transparently without callers passing a cache parameter
+through every layer.
+
+The router enters ``request_cache_scope()`` at the top of each request;
+the scope is per-task, so concurrent requests get independent caches
+and child tasks spawned via ``asyncio.gather`` inherit the parent's
+cache automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from contextvars import ContextVar
+from typing import Any, Awaitable, Callable
+
+_current_cache: ContextVar["RequestCache | None"] = ContextVar(
+    "ge_request_cache", default=None
+)
+
+
+class RequestCache:
+    """Async-safe single-flight cache keyed by any hashable value.
+
+    Two concurrent calls with the same key share one underlying
+    computation, so duplicate ES queries within a request collapse
+    into a single round-trip.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[Any, Any] = {}
+        self._locks: dict[Any, asyncio.Lock] = {}
+
+    async def get_or_compute(
+        self, key: Any, factory: Callable[[], Awaitable[Any]]
+    ) -> Any:
+        if key in self._store:
+            return self._store[key]
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            if key in self._store:
+                return self._store[key]
+            value = await factory()
+            self._store[key] = value
+            return value
+
+
+def get_request_cache() -> RequestCache | None:
+    return _current_cache.get()
+
+
+@contextlib.asynccontextmanager
+async def request_cache_scope():
+    """Install a fresh ``RequestCache`` for the duration of the block."""
+    cache = RequestCache()
+    token = _current_cache.set(cache)
+    try:
+        yield cache
+    finally:
+        _current_cache.reset(token)

--- a/src/app/lib/request_cache_test.py
+++ b/src/app/lib/request_cache_test.py
@@ -1,0 +1,82 @@
+"""Tests for the per-request cache."""
+
+import asyncio
+
+import pytest
+
+from .request_cache import (
+    RequestCache,
+    get_request_cache,
+    request_cache_scope,
+)
+
+
+def test_get_request_cache_returns_none_outside_scope():
+    assert get_request_cache() is None
+
+
+def test_request_cache_scope_installs_and_clears():
+    async def run():
+        async with request_cache_scope() as cache:
+            assert get_request_cache() is cache
+        assert get_request_cache() is None
+
+    asyncio.run(run())
+
+
+def test_request_cache_memoizes_within_scope():
+    calls = 0
+
+    async def factory():
+        nonlocal calls
+        calls += 1
+        return calls
+
+    async def run():
+        cache = RequestCache()
+        v1 = await cache.get_or_compute("k", factory)
+        v2 = await cache.get_or_compute("k", factory)
+        assert v1 == 1 and v2 == 1
+        return calls
+
+    assert asyncio.run(run()) == 1
+
+
+def test_request_cache_collapses_concurrent_calls():
+    """Two concurrent calls with the same key share one underlying computation."""
+    started = 0
+
+    async def factory():
+        nonlocal started
+        started += 1
+        await asyncio.sleep(0)  # yield so a racing caller would see no value yet
+        return "result"
+
+    async def run():
+        cache = RequestCache()
+        results = await asyncio.gather(
+            cache.get_or_compute("k", factory),
+            cache.get_or_compute("k", factory),
+        )
+        return started, results
+
+    started_count, results = asyncio.run(run())
+    assert results == ["result", "result"]
+    assert started_count == 1
+
+
+def test_request_cache_distinguishes_keys():
+    async def run():
+        cache = RequestCache()
+        a = await cache.get_or_compute("a", _async_value(1))
+        b = await cache.get_or_compute("b", _async_value(2))
+        return a, b
+
+    assert asyncio.run(run()) == (1, 2)
+
+
+def _async_value(v):
+    async def factory():
+        return v
+
+    return factory

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -8,6 +8,7 @@ from .security import RequireApiKey
 from .lib.atproto_auth import init_id_resolver
 from .lib.feed_cache import FirestoreFeedCache
 from .lib.firestore import init_firestore_client
+from .lib.http_client import close_http_client, init_http_client
 
 from elasticsearch import AsyncElasticsearch
 
@@ -41,6 +42,7 @@ async def lifespan(app: FastAPI):
     app.state.id_resolver = init_id_resolver()
     app.state.firestore = init_firestore_client()
     app.state.feed_cache = FirestoreFeedCache(app.state.firestore)
+    init_http_client()
     try:
         yield
     finally:
@@ -50,6 +52,10 @@ async def lifespan(app: FastAPI):
             pass
         try:
             app.state.firestore.close()
+        except Exception:
+            pass
+        try:
+            await close_http_client()
         except Exception:
             pass
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -26,6 +26,7 @@ from ..lib.rankers import run_predict
 from ..models import CandidateGenerateRequest, FeedConfig, FeedCursor, GeneratorSpec, RankPredictRequest
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.firestore import upsert_feed_activity, upsert_user
+from ..lib.request_cache import request_cache_scope
 from ..feeds import FEEDS
 
 logger = logging.getLogger(__name__)
@@ -124,31 +125,38 @@ async def _run_ranking_pipeline(
     gen_request: CandidateGenerateRequest,
     es,
 ) -> list[str]:
-    """Generate candidates, optionally rank them, then diversify with MMR."""
-    result = await run_generate(gen_request, es, swallow_errors=True)
-    candidates = result.candidates
+    """Generate candidates, optionally rank them, then diversify with MMR.
 
-    if not candidates:
-        return []
+    Runs inside a per-request cache scope so that identical ES queries
+    issued by different stages (e.g. ``fetch_recent_liked_post_uris`` in
+    both ``post_similarity`` and the two-tower ranker) collapse to a
+    single round-trip.
+    """
+    async with request_cache_scope():
+        result = await run_generate(gen_request, es, swallow_errors=True)
+        candidates = result.candidates
 
-    if feed_cfg.rank_request_template is not None:
-        rank_req = feed_cfg.rank_request_template.model_copy(
-            update={"candidates": candidates, "user_did": gen_request.user_did}
-        )
-        rank_result = await run_predict(rank_req, es)
-        # Reorder CandidatePosts by model rank and stamp rank_score onto each
-        # so MMR uses the model's relevance scores, not the generator scores.
-        by_uri = {c.at_uri: c for c in candidates if c.at_uri}
-        ordered = [
-            by_uri[r.at_uri].model_copy(update={"score": r.rank_score})
-            for r in rank_result.rankings
-            if r.at_uri in by_uri
-        ]
-    else:
-        ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
+        if not candidates:
+            return []
 
-    final = mmr_rerank(ordered) if feed_cfg.diversify else ordered
-    return [c.at_uri for c in final if c.at_uri]
+        if feed_cfg.rank_request_template is not None:
+            rank_req = feed_cfg.rank_request_template.model_copy(
+                update={"candidates": candidates, "user_did": gen_request.user_did}
+            )
+            rank_result = await run_predict(rank_req, es)
+            # Reorder CandidatePosts by model rank and stamp rank_score onto each
+            # so MMR uses the model's relevance scores, not the generator scores.
+            by_uri = {c.at_uri: c for c in candidates if c.at_uri}
+            ordered = [
+                by_uri[r.at_uri].model_copy(update={"score": r.rank_score})
+                for r in rank_result.rankings
+                if r.at_uri in by_uri
+            ]
+        else:
+            ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
+
+        final = mmr_rerank(ordered) if feed_cfg.diversify else ordered
+        return [c.at_uri for c in final if c.at_uri]
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -11,6 +11,7 @@ Implements the two endpoints required by the AT Protocol Feed Generator spec:
 See: https://docs.bsky.app/docs/starter-templates/custom-feeds
 """
 
+import asyncio
 import logging
 import os
 import uuid
@@ -181,6 +182,46 @@ def _get_feed_cache(request: Request) -> FeedCache:
     return cache
 
 
+# Fire-and-forget background tasks (Firestore session writes, …). Keeping a
+# strong reference here prevents the event loop from garbage-collecting them
+# mid-flight; the done callback removes them once they complete.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_background(coro) -> asyncio.Task:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+async def _record_session(request: Request, user_did: str, feed_name: str, db) -> None:
+    """Resolve the caller's handle and upsert user + feed-activity docs.
+
+    Runs as a background task so the user-facing latency of getFeedSkeleton
+    isn't paying for a DID document fetch plus two Firestore round-trips.
+    Failures are logged but do not surface to the caller — these writes are
+    analytics, not request-critical.
+    """
+    try:
+        username = await _resolve_username(request, user_did)
+    except Exception:
+        logger.exception("Failed to resolve username for %s in background", user_did)
+        return
+
+    try:
+        await upsert_user(db, user_did, username)
+    except Exception:
+        logger.exception("Failed to upsert user '%s' in Firestore", user_did)
+
+    try:
+        await upsert_feed_activity(db, user_did, feed_name)
+    except Exception:
+        logger.exception(
+            "Failed to record feed activity for user '%s', feed '%s'", user_did, feed_name
+        )
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -277,26 +318,17 @@ async def get_feed_skeleton(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    username = await _resolve_username(request, user_did)
-
-    # Record authenticated users in Firestore for backend analytics/state.
-    # Firestore persistence is required and failures are treated as fatal.
+    # Record authenticated users in Firestore for backend analytics. The
+    # username resolve and the two upserts are observational only — kick
+    # them off as a background task so they overlap with the pipeline
+    # instead of gating the response on a DID document fetch and two
+    # Firestore round-trips.
     db = getattr(request.app.state, "firestore", None)
     if db is None:
         logger.error("Firestore client not initialized")
         raise HTTPException(status_code=500, detail="Firestore unavailable")
 
-    try:
-        await upsert_user(db, user_did, username)
-    except Exception:
-        logger.exception("Failed to upsert user '%s' in Firestore", user_did)
-        raise HTTPException(status_code=500, detail="Firestore write failed")
-
-    try:
-        await upsert_feed_activity(db, user_did, feed_name)
-    except Exception:
-        logger.exception("Failed to record feed activity for user '%s', feed '%s'", user_did, feed_name)
-        raise HTTPException(status_code=500, detail="Firestore write failed")
+    _spawn_background(_record_session(request, user_did, feed_name, db))
 
     feed_cache = _get_feed_cache(request)
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -199,9 +199,8 @@ async def _record_session(request: Request, user_did: str, feed_name: str, db) -
     """Resolve the caller's handle and upsert user + feed-activity docs.
 
     Runs as a background task so the user-facing latency of getFeedSkeleton
-    isn't paying for a DID document fetch plus two Firestore round-trips.
-    Failures are logged but do not surface to the caller — these writes are
-    analytics, not request-critical.
+    isn't paying for firebase roundtrips.
+    Failures are logged but do not surface to the caller.
     """
     try:
         username = await _resolve_username(request, user_did)
@@ -318,11 +317,8 @@ async def get_feed_skeleton(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Record authenticated users in Firestore for backend analytics. The
-    # username resolve and the two upserts are observational only — kick
-    # them off as a background task so they overlap with the pipeline
-    # instead of gating the response on a DID document fetch and two
-    # Firestore round-trips.
+    # Record authenticated users in Firestore for backend analytics. Runs in
+    # the background since this isn't essential for serving.
     db = getattr(request.app.state, "firestore", None)
     if db is None:
         logger.error("Firestore client not initialized")

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -875,8 +875,9 @@ class TestGetFeedSkeletonAuth:
             TEST_USERNAME,
         )
 
-    def test_username_resolution_failure_is_fatal(self):
-        """Username resolution failures should fail the request."""
+    def test_username_resolution_failure_is_logged_but_non_fatal(self, caplog):
+        """Username resolution runs in a background task; failures are logged
+        but don't block the response."""
         from unittest.mock import MagicMock
 
         mock_payload = MagicMock()
@@ -897,11 +898,12 @@ class TestGetFeedSkeletonAuth:
                 headers={"Authorization": "Bearer valid.jwt.token"},
             )
 
-        assert resp.status_code == 500
-        assert resp.json()["detail"] == "Username resolution failed"
+        assert resp.status_code == 200
+        assert "Failed to resolve username" in caplog.text
 
-    def test_firestore_upsert_failure_is_fatal(self):
-        """Firestore write errors should fail the request."""
+    def test_firestore_upsert_failure_is_logged_but_non_fatal(self, caplog):
+        """Firestore user upserts run in a background task; failures are
+        logged but don't block the response."""
         from unittest.mock import MagicMock
 
         mock_payload = MagicMock()
@@ -926,8 +928,8 @@ class TestGetFeedSkeletonAuth:
                 headers={"Authorization": "Bearer valid.jwt.token"},
             )
 
-        assert resp.status_code == 500
-        assert resp.json()["detail"] == "Firestore write failed"
+        assert resp.status_code == 200
+        assert "Failed to upsert user" in caplog.text
 
     def test_missing_firestore_client_is_fatal(self):
         """Missing Firestore client should fail the request."""
@@ -991,8 +993,9 @@ class TestGetFeedSkeletonAuth:
         assert resp.status_code == 200
         mock_activity.assert_awaited_once_with(app.state.firestore, "did:plc:autheduser", FEED_RKEY)
 
-    def test_feed_activity_failure_is_fatal(self):
-        """Feed activity write errors should fail the request."""
+    def test_feed_activity_failure_is_logged_but_non_fatal(self, caplog):
+        """Feed-activity upserts run in a background task; failures are
+        logged but don't block the response."""
         mock_payload = MagicMock()
         mock_payload.iss = "did:plc:autheduser"
 
@@ -1015,8 +1018,8 @@ class TestGetFeedSkeletonAuth:
                 headers={"Authorization": "Bearer valid.jwt.token"},
             )
 
-        assert resp.status_code == 500
-        assert resp.json()["detail"] == "Firestore write failed"
+        assert resp.status_code == 200
+        assert "Failed to record feed activity" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The `ranked` feed's `getFeedSkeleton` is taking up to ~30s per request. A read of the call path surfaced several places where the handler was paying the sum of independent latencies (instead of the max), re-fetching data it already had, opening a fresh TLS connection per inference call, and gating the response on analytics writes. None of these are individually a 30s-class problem — but collectively they account for several seconds of wall clock on every request.

This PR is four self-contained commits, each addressing one of those.

## Commits

**`run independent candidate generators and inference calls concurrently`**
- `run_generate` now dispatches all generators via `asyncio.gather` so e.g. `post_similarity` and `followed_users` (which makes an outbound call to `public.api.bsky.app`) overlap instead of running back-to-back.
- `TwoTowerRanker.predict` runs the user-side fetch + user-tower inference concurrently with the candidate-side fetch + post-tower inference.
- `predict_post_tower_batch` fires its 32-embedding chunks in parallel on the shared client instead of sequentially.

**`add per-request cache for ES query results`**
- New `ContextVar`-backed `RequestCache`. `_run_ranking_pipeline` enters a `request_cache_scope()`, and the existing ES helpers (`fetch_recent_liked_post_uris`, `fetch_post_embeddings`) consult it transparently — no signature changes anywhere else.
- This removes the duplicate ES round-trips where `post_similarity` and the two-tower ranker were both fetching the user's recent likes and their embeddings. The cache is single-flight (per-key `asyncio.Lock`) so concurrent identical lookups collapse into one query.
- Future components that query the same data automatically benefit; no plumbing required.

**`share a single httpx.AsyncClient across requests`**
- Previously the two-tower ranker and the Bluesky follows lookup each constructed a fresh `httpx.AsyncClient` per invocation, paying a TLS handshake every time. A single ranked-feed request opened 3+ TLS connections (2 to inference, 1 to `public.api.bsky.app`).
- Hoist a process-wide `AsyncClient` managed by the lifespan handler. The bsky path now passes its tight per-request timeout via the per-call kwarg.

**`move session-recording Firestore writes off the request path`**
- The handler was awaiting, in series before the pipeline started: a DID document fetch (for username) + a Firestore read+write to upsert the user + a Firestore read+write to upsert feed activity. Pure analytics overhead gating every response.
- Spawn the resolve + upserts as a background task that overlaps with the pipeline.

## Behavior change (intentional)

Firestore session-write failures used to return `500 "Firestore write failed"`. They now log an error and return the normal `200` response, since these are analytics writes and aren't needed to compute the feed. The three tests that asserted the old contract were updated to assert the new logged-but-non-fatal contract. If you'd rather keep the fatal behavior, the simplest fix is to await the background task at the end of the handler.
