### PR TITLE
Fix Feed name char limits; hide non-public feeds

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -308,29 +308,38 @@ resolve_generator_did() {
     echo "did:web:$service_host"
 }
 
-sync_feeds() {
-    log_info "Syncing feed generator records for $ENVIRONMENT..."
+_sync_feeds_to_account() {
+    local account_label="$1"
+    local bsky_handle="$2"
+    local bsky_secret="$3"
+    local generator_did="$4"
+    local visibility_flag="$5"   # "--public-only", "--internal-only", or ""
 
-    # Determine Bluesky handle and secret name for this environment
-    local bsky_handle
-    local bsky_secret
-    if [ "$ENVIRONMENT" = "prod" ]; then
-        bsky_handle="greenearth-social.bsky.social"
-        bsky_secret="bsky-app-password-prod"
-    else
-        bsky_handle="ge-stage.bsky.social"
-        bsky_secret="bsky-app-password"
-    fi
-
-    # Fetch app password from Secret Manager
     local bsky_password
     bsky_password=$(gcloud secrets versions access latest --secret="$bsky_secret" --project="$PROJECT_ID" 2>/dev/null)
     if [ -z "$bsky_password" ]; then
-        log_warn "Could not fetch Bluesky app password from secret '$bsky_secret'"
-        log_warn "Skipping feed sync. Store the password with:"
+        log_warn "Could not fetch $account_label app password from secret '$bsky_secret'"
+        log_warn "Skipping $account_label feed sync. Store the password with:"
         log_warn "  echo -n '<password>' | gcloud secrets create $bsky_secret --data-file=- --project=$PROJECT_ID"
         return 0
     fi
+
+    log_info "Syncing feeds → $account_label ($bsky_handle)..."
+
+    # shellcheck disable=SC2086
+    pipenv run python scripts/publish_feed.py \
+        --handle "$bsky_handle" \
+        --app-password "$bsky_password" \
+        --generator-did "$generator_did" \
+        --environment "$ENVIRONMENT" \
+        --sync \
+        $visibility_flag \
+    && log_info "$account_label feed sync complete" \
+    || log_warn "$account_label feed sync failed — feeds may be out of date"
+}
+
+sync_feeds() {
+    log_info "Syncing feed generator records for $ENVIRONMENT..."
 
     local generator_did
     if ! generator_did=$(resolve_generator_did); then
@@ -338,20 +347,33 @@ sync_feeds() {
         return 0
     fi
 
-    log_info "Handle:        $bsky_handle"
     log_info "Generator DID: $generator_did"
 
-    pipenv run python scripts/publish_feed.py \
-        --handle "$bsky_handle" \
-        --app-password "$bsky_password" \
-        --generator-did "$generator_did" \
-        --environment "$ENVIRONMENT" \
-        --sync
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        # Prod: two-pass sync
+        #   Pass 1 — public feeds → GreenEarth account (original names, "| GreenEarth" descriptions)
+        #   Pass 2 — internal feeds → Caterpie account (obfuscated names, "Built by Caterpie")
+        _sync_feeds_to_account \
+            "GreenEarth" \
+            "greenearth-social.bsky.social" \
+            "bsky-app-password-prod" \
+            "$generator_did" \
+            "--public-only"
 
-    if [ $? -eq 0 ]; then
-        log_info "Feed records synced successfully"
+        _sync_feeds_to_account \
+            "Caterpie" \
+            "caterpie-internal.bsky.social" \
+            "bsky-app-password-caterpie-prod" \
+            "$generator_did" \
+            "--internal-only"
     else
-        log_warn "Feed sync failed — feeds may be out of date"
+        # Stage/dev: all feeds go to Caterpie (display names get "GE " prefix)
+        _sync_feeds_to_account \
+            "Caterpie" \
+            "caterpie-internal.bsky.social" \
+            "bsky-app-password-caterpie" \
+            "$generator_did" \
+            ""
     fi
 }
 

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -434,7 +434,14 @@ def sync_feeds(
             _put_record(client, pds, access_jwt, repo_did, published_rkey, record)
             print(f"  Published: {rkey} ({display_name})")
 
-        stale = existing_rkeys - desired_rkeys
+        if visibility is None:
+            stale = existing_rkeys - desired_rkeys
+        else:
+            # When syncing a visibility subset, restrict cleanup to rkeys owned
+            # by feeds in this class. Without this, an --internal-only prod pass
+            # would delete public feeds' Caterpie records left by a stage deploy.
+            class_rkeys = {cfg.internal_rkey for _, cfg in feed_items} | {rkey for rkey, _ in feed_items}
+            stale = (existing_rkeys & class_rkeys) - desired_rkeys
         for rkey in sorted(stale):
             _delete_record(client, pds, access_jwt, repo_did, rkey)
             print(f"  Deleted stale: {rkey}")

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -45,8 +45,10 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import hashlib
 import os
 import sys
+from typing import Literal
 
 import httpx
 from dotenv import load_dotenv
@@ -71,6 +73,22 @@ ENV_ALIASES: dict[str, str] = {
     "prod": "prod",
     "production": "prod",
 }
+
+
+def _acronym(display_name: str) -> str:
+    return "".join(word[0].upper() for word in display_name.split())
+
+
+def _stable_hash(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()[:2]
+
+
+def _caterpie_display_name(display_name: str) -> str:
+    return f"{_stable_hash(display_name)} {_acronym(display_name)}"
+
+
+def _caterpie_rkey(display_name: str) -> str:
+    return f"{_stable_hash(display_name)}-{_acronym(display_name).lower()}"
 
 
 def _normalize_environment(environment: str | None) -> str | None:
@@ -361,51 +379,78 @@ def list_feeds(
             print()
 
 
+def _resolve_feed_publish_params(
+    rkey: str,
+    feed_cfg,
+    normalized_env: str | None,
+) -> tuple[str, str, str]:
+    """Return (published_rkey, display_name, description) for a feed based on routing rules."""
+    is_greenearth = normalized_env == "prod" and feed_cfg.public
+    if is_greenearth:
+        return rkey, feed_cfg.display_name, f"{feed_cfg.description} | GreenEarth"
+    caterpie_name = _caterpie_display_name(feed_cfg.display_name)
+    published_rkey = _caterpie_rkey(feed_cfg.display_name)
+    if normalized_env in ("dev", "stage"):
+        published_display_name = f"GE {caterpie_name}"
+    else:
+        published_display_name = caterpie_name
+    return published_rkey, published_display_name, "Built by Caterpie"
+
+
 def sync_feeds(
     *,
     handle: str,
     password: str,
     generator_did: str,
     environment: str | None = None,
+    visibility: Literal["public", "internal"] | None = None,
     pds: str = DEFAULT_PDS,
 ) -> None:
     """Sync published feed records with the FEEDS config.
 
-    Creates or updates a record for every feed in ``FEEDS`` and deletes any
-    existing records whose rkey is *not* present in ``FEEDS``.  Because
-    ``putRecord`` is an upsert, feeds that already exist are updated in place
-    without a visible gap.
+    Creates or updates a record for every feed in ``FEEDS`` (filtered by
+    *visibility* when set) and deletes any existing records whose rkey is
+    *not* in the desired set.  Because ``putRecord`` is an upsert, feeds that
+    already exist are updated in place without a visible gap.
     """
-    if not FEEDS:
+    feed_items = list(FEEDS.items())
+    if visibility == "public":
+        feed_items = [(k, v) for k, v in feed_items if v.public]
+    elif visibility == "internal":
+        feed_items = [(k, v) for k, v in feed_items if not v.public]
+
+    if not feed_items:
         print("No feeds configured in FEEDS.", file=sys.stderr)
         sys.exit(1)
+
+    normalized_env = _normalize_environment(environment)
 
     with httpx.Client(timeout=30) as client:
         session = _create_session(client, pds, handle, password)
         access_jwt = session["accessJwt"]
         repo_did = session["did"]
 
-        # Discover existing records
         existing_records = _list_records(client, pds, access_jwt, repo_did)
         existing_rkeys = {r["uri"].split("/")[-1] for r in existing_records}
-        desired_rkeys = set(FEEDS.keys())
 
         from datetime import datetime, timezone
 
-        # Publish / update every feed in FEEDS
-        for rkey, feed_cfg in FEEDS.items():
-            display_name = _prefixed_display_name(feed_cfg.display_name, environment)
+        desired_rkeys: set[str] = set()
+        for rkey, feed_cfg in feed_items:
+            published_rkey, display_name, description = _resolve_feed_publish_params(
+                rkey, feed_cfg, normalized_env
+            )
+            desired_rkeys.add(published_rkey)
             record: dict = {
                 "$type": "app.bsky.feed.generator",
                 "did": generator_did,
                 "displayName": display_name,
-                "description": feed_cfg.description,
+                "description": description,
                 "createdAt": datetime.now(timezone.utc).isoformat(),
             }
-            _put_record(client, pds, access_jwt, repo_did, rkey, record)
+            _put_record(client, pds, access_jwt, repo_did, published_rkey, record)
             print(f"  Published: {rkey} ({display_name})")
 
-        # Remove stale records not in FEEDS
         stale = existing_rkeys - desired_rkeys
         for rkey in sorted(stale):
             _delete_record(client, pds, access_jwt, repo_did, rkey)
@@ -454,6 +499,18 @@ def main() -> None:
             "Sync mode: publish/update all feeds from FEEDS config and delete "
             "any stale records not present in FEEDS. Avoids delete-recreate."
         ),
+    )
+    parser.add_argument(
+        "--public-only",
+        action="store_true",
+        dest="public_only",
+        help="Sync only public feeds (requires --sync).",
+    )
+    parser.add_argument(
+        "--internal-only",
+        action="store_true",
+        dest="internal_only",
+        help="Sync only internal (non-public) feeds (requires --sync).",
     )
     parser.add_argument(
         "--list",
@@ -515,6 +572,11 @@ def main() -> None:
     if mode_flags > 1:
         parser.error("Only one of --all, --delete, --delete-all, --list, or --sync can be used at a time.")
 
+    if args.public_only and args.internal_only:
+        parser.error("--public-only and --internal-only are mutually exclusive.")
+    if (args.public_only or args.internal_only) and not args.sync:
+        parser.error("--public-only and --internal-only require --sync.")
+
     # Handle list mode
     if args.list:
         list_feeds(
@@ -533,11 +595,15 @@ def main() -> None:
             parser.error(
                 "--generator-did is required for --sync (or set GE_FEED_GENERATOR_DID)"
             )
+        visibility: Literal["public", "internal"] | None = (
+            "public" if args.public_only else ("internal" if args.internal_only else None)
+        )
         sync_feeds(
             handle=args.handle,
             password=password,
             generator_did=generator_did,
             environment=resolved_environment,
+            visibility=visibility,
             pds=args.pds,
         )
         return

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -387,7 +387,7 @@ def _resolve_feed_publish_params(
     """Return (published_rkey, display_name, description) for a feed based on routing rules."""
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
-        return rkey, feed_cfg.display_name, f"{feed_cfg.description} | GreenEarth"
+        return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
     caterpie_name = _caterpie_display_name(feed_cfg.display_name)
     published_rkey = _caterpie_rkey(feed_cfg.display_name)
     if normalized_env in ("dev", "stage"):

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -371,8 +371,8 @@ def _resolve_feed_publish_params(
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
         return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
-    published_rkey = feed_cfg.internal_rkey or rkey
-    base_display_name = feed_cfg.internal_display_name or feed_cfg.display_name
+    published_rkey = feed_cfg.internal_rkey
+    base_display_name = feed_cfg.internal_display_name
     if normalized_env in ("dev", "stage"):
         published_display_name = f"GE {base_display_name}"
     else:

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import argparse
 import getpass
-import hashlib
 import os
 import sys
 from typing import Literal
@@ -73,22 +72,6 @@ ENV_ALIASES: dict[str, str] = {
     "prod": "prod",
     "production": "prod",
 }
-
-
-def _acronym(display_name: str) -> str:
-    return "".join(word[0].upper() for word in display_name.split())
-
-
-def _stable_hash(s: str) -> str:
-    return hashlib.sha256(s.encode()).hexdigest()[:2]
-
-
-def _caterpie_display_name(display_name: str) -> str:
-    return f"{_stable_hash(display_name)} {_acronym(display_name)}"
-
-
-def _caterpie_rkey(display_name: str) -> str:
-    return f"{_stable_hash(display_name)}-{_acronym(display_name).lower()}"
 
 
 def _normalize_environment(environment: str | None) -> str | None:
@@ -388,12 +371,12 @@ def _resolve_feed_publish_params(
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
         return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
-    caterpie_name = _caterpie_display_name(feed_cfg.display_name)
-    published_rkey = _caterpie_rkey(feed_cfg.display_name)
+    published_rkey = feed_cfg.internal_rkey or rkey
+    base_display_name = feed_cfg.internal_display_name or feed_cfg.display_name
     if normalized_env in ("dev", "stage"):
-        published_display_name = f"GE {caterpie_name}"
+        published_display_name = f"GE {base_display_name}"
     else:
-        published_display_name = caterpie_name
+        published_display_name = base_display_name
     return published_rkey, published_display_name, "Built by Caterpie"
 
 

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -10,6 +10,9 @@ import pytest
 from publish_feed import (
     ENV_DISPLAY_PREFIX,
     FEEDS,
+    _acronym,
+    _caterpie_display_name,
+    _caterpie_rkey,
     _create_session,
     _delete_record,
     _list_records,
@@ -17,6 +20,8 @@ from publish_feed import (
     _prefixed_display_name,
     _put_record,
     _resolve_environment,
+    _resolve_feed_publish_params,
+    _stable_hash,
     delete_all_feeds,
     delete_feed,
     list_feeds,
@@ -625,27 +630,23 @@ class TestSyncFeeds:
         captured = capsys.readouterr()
         assert "Published: basic-similarity" in captured.out
         assert "Published: random" in captured.out
-        assert "GreenEarth Similarity" in captured.out
+        assert "Best of Friends" in captured.out
         assert "Deleted stale: old-feed" in captured.out
         assert "Sync complete:" in captured.out
 
     @patch("publish_feed.httpx.Client")
     def test_no_stale_records(self, MockClient, capsys):
-        """sync_feeds with no stale records deletes nothing."""
+        """sync_feeds with no existing records deletes nothing."""
         client = MagicMock()
         MockClient.return_value.__enter__ = MagicMock(return_value=client)
         MockClient.return_value.__exit__ = MagicMock(return_value=False)
 
-        existing_record = {
-            "uri": f"at://{REPO_DID}/app.bsky.feed.generator/basic-similarity",
-            "value": {},
-        }
         feed_count = len(FEEDS)
         client.post.side_effect = [
             _mock_response(200, SESSION_RESPONSE),  # createSession
             *[_mock_response(200, {"cid": "bafyabc"}) for _ in range(feed_count)],
         ]
-        client.get.return_value = _mock_response(200, {"records": [existing_record]})
+        client.get.return_value = _mock_response(200, {"records": []})
 
         sync_feeds(
             handle=HANDLE,
@@ -657,3 +658,228 @@ class TestSyncFeeds:
         captured = capsys.readouterr()
         assert "Deleted stale" not in captured.out
         assert f"{feed_count} published, 0 deleted" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Caterpie helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAcronym:
+    def test_best_of_friends(self):
+        assert _acronym("Best of Friends") == "BOF"
+
+    def test_your_feed(self):
+        assert _acronym("Your Feed") == "YF"
+
+    def test_random(self):
+        assert _acronym("Random") == "R"
+
+    def test_similarity(self):
+        assert _acronym("Similarity") == "S"
+
+
+class TestStableHash:
+    def test_returns_two_hex_chars(self):
+        h = _stable_hash("Best of Friends")
+        assert len(h) == 2
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_is_deterministic(self):
+        assert _stable_hash("Best of Friends") == _stable_hash("Best of Friends")
+
+    def test_different_inputs_differ(self):
+        assert _stable_hash("Random") != _stable_hash("Similarity")
+
+
+class TestCaterpieHelpers:
+    def test_display_name_format(self):
+        name = _caterpie_display_name("Best of Friends")
+        h = _stable_hash("Best of Friends")
+        assert name == f"{h} BOF"
+
+    def test_rkey_format_lowercase(self):
+        rkey = _caterpie_rkey("Best of Friends")
+        h = _stable_hash("Best of Friends")
+        assert rkey == f"{h}-bof"
+
+    def test_rkey_valid_at_chars(self):
+        for display_name in [cfg.display_name for cfg in FEEDS.values()]:
+            rkey = _caterpie_rkey(display_name)
+            assert all(c.isalnum() or c == "-" for c in rkey)
+
+
+class TestCaterpieRkeyUniqueness:
+    def test_all_feeds_produce_unique_caterpie_rkeys(self):
+        rkeys = [_caterpie_rkey(cfg.display_name) for cfg in FEEDS.values()]
+        assert len(rkeys) == len(set(rkeys)), f"Caterpie rkey collision: {rkeys}"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_feed_publish_params
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFeedPublishParams:
+    def _public_feed(self):
+        return FEEDS["best-of-friends"]
+
+    def _internal_feed(self):
+        return FEEDS["basic-similarity"]
+
+    def test_prod_public_uses_greenearth_path(self):
+        feed = self._public_feed()
+        rkey, name, desc = _resolve_feed_publish_params("best-of-friends", feed, "prod")
+        assert rkey == "best-of-friends"
+        assert name == feed.display_name
+        assert "GreenEarth" in desc
+
+    def test_prod_internal_uses_caterpie_path(self):
+        feed = self._internal_feed()
+        rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "prod")
+        assert rkey == _caterpie_rkey(feed.display_name)
+        assert name == _caterpie_display_name(feed.display_name)
+        assert desc == "Built by Caterpie"
+
+    def test_dev_any_uses_caterpie_with_ge_prefix(self):
+        feed = self._public_feed()
+        rkey, name, desc = _resolve_feed_publish_params("best-of-friends", feed, "dev")
+        assert rkey == _caterpie_rkey(feed.display_name)
+        assert name.startswith("GE ")
+        assert desc == "Built by Caterpie"
+
+    def test_stage_any_uses_caterpie_with_ge_prefix(self):
+        feed = self._internal_feed()
+        rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "stage")
+        assert rkey == _caterpie_rkey(feed.display_name)
+        assert name.startswith("GE ")
+        assert desc == "Built by Caterpie"
+
+
+# ---------------------------------------------------------------------------
+# Searchability
+# ---------------------------------------------------------------------------
+
+
+class TestSearchability:
+    def test_prod_public_display_name_is_original(self):
+        feed = FEEDS["best-of-friends"]
+        _, name, desc = _resolve_feed_publish_params("best-of-friends", feed, "prod")
+        assert name == feed.display_name
+        assert "greenearth" in desc.lower()
+
+    def test_caterpie_display_name_excludes_original(self):
+        feed = FEEDS["basic-similarity"]
+        _, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "prod")
+        assert feed.display_name not in name
+        assert desc == "Built by Caterpie"
+
+    def test_dev_caterpie_display_name_excludes_original(self):
+        feed = FEEDS["random"]
+        _, name, desc = _resolve_feed_publish_params("random", feed, "dev")
+        assert feed.display_name not in name
+        assert desc == "Built by Caterpie"
+
+
+# ---------------------------------------------------------------------------
+# Display name length guard
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayNameLength:
+    @pytest.mark.parametrize("rkey,feed_cfg", list(FEEDS.items()))
+    @pytest.mark.parametrize("env", ["prod", "stage", "dev"])
+    def test_display_name_within_24_chars(self, rkey, feed_cfg, env):
+        _, name, _ = _resolve_feed_publish_params(rkey, feed_cfg, env)
+        assert len(name) <= 24, f"{rkey} @ {env}: '{name}' is {len(name)} chars"
+
+
+# ---------------------------------------------------------------------------
+# CLI: --public-only / --internal-only
+# ---------------------------------------------------------------------------
+
+
+class TestPublicInternalOnlyCLI:
+    def test_mutually_exclusive(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with pytest.raises(SystemExit):
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE, "--sync",
+                     "--environment", "prod", "--public-only", "--internal-only"],
+                ):
+                    from publish_feed import main
+                    main()
+
+    def test_public_only_requires_sync(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with pytest.raises(SystemExit):
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE,
+                     "--all", "--environment", "prod", "--public-only"],
+                ):
+                    from publish_feed import main
+                    main()
+
+    def test_internal_only_requires_sync(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with pytest.raises(SystemExit):
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE,
+                     "--list", "--internal-only"],
+                ):
+                    from publish_feed import main
+                    main()
+
+    def test_public_only_passes_visibility_public(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with patch("publish_feed.sync_feeds") as mock_sync:
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE, "--sync",
+                     "--environment", "prod", "--public-only"],
+                ):
+                    from publish_feed import main
+                    main()
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args.kwargs["visibility"] == "public"
+
+    def test_internal_only_passes_visibility_internal(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with patch("publish_feed.sync_feeds") as mock_sync:
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE, "--sync",
+                     "--environment", "prod", "--internal-only"],
+                ):
+                    from publish_feed import main
+                    main()
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args.kwargs["visibility"] == "internal"
+
+    def test_no_flag_passes_visibility_none(self, monkeypatch):
+        monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
+        monkeypatch.setenv("GE_FEED_GENERATOR_DID", GENERATOR_DID)
+        with patch("publish_feed.load_dotenv"):
+            with patch("publish_feed.sync_feeds") as mock_sync:
+                with patch(
+                    "sys.argv",
+                    ["publish_feed.py", "--handle", HANDLE, "--sync",
+                     "--environment", "prod"],
+                ):
+                    from publish_feed import main
+                    main()
+        mock_sync.assert_called_once()
+        assert mock_sync.call_args.kwargs["visibility"] is None

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -655,6 +655,45 @@ class TestSyncFeeds:
         assert "Deleted stale" not in captured.out
         assert f"{feed_count} published, 0 deleted" in captured.out
 
+    @patch("publish_feed.httpx.Client")
+    def test_internal_only_does_not_delete_public_feed_caterpie_records(self, MockClient, capsys):
+        """A prod --internal-only sync must not delete public feeds' Caterpie
+        records that were published by an earlier stage (unfiltered) deployment."""
+        client = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=client)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Simulate stage having already published all four feeds to Caterpie.
+        public_feed_rkeys = [
+            cfg.internal_rkey for cfg in FEEDS.values() if cfg.public
+        ]
+        internal_feed_rkeys = [
+            cfg.internal_rkey for cfg in FEEDS.values() if not cfg.public
+        ]
+        stage_records = [
+            {"uri": f"at://{REPO_DID}/app.bsky.feed.generator/{rkey}", "value": {}}
+            for rkey in public_feed_rkeys + internal_feed_rkeys
+        ]
+        client.post.side_effect = [
+            _mock_response(200, SESSION_RESPONSE),  # createSession
+            *[_mock_response(200, {"cid": "bafyabc"}) for _ in internal_feed_rkeys],
+        ]
+        client.get.return_value = _mock_response(200, {"records": stage_records})
+
+        sync_feeds(
+            handle=HANDLE,
+            password=PASSWORD,
+            generator_did=GENERATOR_DID,
+            environment="prod",
+            visibility="internal",
+            pds=PDS,
+        )
+
+        captured = capsys.readouterr()
+        assert "Deleted stale" not in captured.out
+        for rkey in public_feed_rkeys:
+            assert rkey not in captured.out or f"Deleted stale: {rkey}" not in captured.out
+
 
 # ---------------------------------------------------------------------------
 # _resolve_feed_publish_params

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -10,9 +10,6 @@ import pytest
 from publish_feed import (
     ENV_DISPLAY_PREFIX,
     FEEDS,
-    _acronym,
-    _caterpie_display_name,
-    _caterpie_rkey,
     _create_session,
     _delete_record,
     _list_records,
@@ -21,7 +18,6 @@ from publish_feed import (
     _put_record,
     _resolve_environment,
     _resolve_feed_publish_params,
-    _stable_hash,
     delete_all_feeds,
     delete_feed,
     list_feeds,
@@ -661,61 +657,6 @@ class TestSyncFeeds:
 
 
 # ---------------------------------------------------------------------------
-# Caterpie helpers
-# ---------------------------------------------------------------------------
-
-
-class TestAcronym:
-    def test_best_of_friends(self):
-        assert _acronym("Best of Friends") == "BOF"
-
-    def test_your_feed(self):
-        assert _acronym("Your Feed") == "YF"
-
-    def test_random(self):
-        assert _acronym("Random") == "R"
-
-    def test_similarity(self):
-        assert _acronym("Similarity") == "S"
-
-
-class TestStableHash:
-    def test_returns_two_hex_chars(self):
-        h = _stable_hash("Best of Friends")
-        assert len(h) == 2
-        assert all(c in "0123456789abcdef" for c in h)
-
-    def test_is_deterministic(self):
-        assert _stable_hash("Best of Friends") == _stable_hash("Best of Friends")
-
-    def test_different_inputs_differ(self):
-        assert _stable_hash("Random") != _stable_hash("Similarity")
-
-
-class TestCaterpieHelpers:
-    def test_display_name_format(self):
-        name = _caterpie_display_name("Best of Friends")
-        h = _stable_hash("Best of Friends")
-        assert name == f"{h} BOF"
-
-    def test_rkey_format_lowercase(self):
-        rkey = _caterpie_rkey("Best of Friends")
-        h = _stable_hash("Best of Friends")
-        assert rkey == f"{h}-bof"
-
-    def test_rkey_valid_at_chars(self):
-        for display_name in [cfg.display_name for cfg in FEEDS.values()]:
-            rkey = _caterpie_rkey(display_name)
-            assert all(c.isalnum() or c == "-" for c in rkey)
-
-
-class TestCaterpieRkeyUniqueness:
-    def test_all_feeds_produce_unique_caterpie_rkeys(self):
-        rkeys = [_caterpie_rkey(cfg.display_name) for cfg in FEEDS.values()]
-        assert len(rkeys) == len(set(rkeys)), f"Caterpie rkey collision: {rkeys}"
-
-
-# ---------------------------------------------------------------------------
 # _resolve_feed_publish_params
 # ---------------------------------------------------------------------------
 
@@ -737,21 +678,21 @@ class TestResolveFeedPublishParams:
     def test_prod_internal_uses_caterpie_path(self):
         feed = self._internal_feed()
         rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "prod")
-        assert rkey == _caterpie_rkey(feed.display_name)
-        assert name == _caterpie_display_name(feed.display_name)
+        assert rkey == feed.internal_rkey
+        assert name == feed.internal_display_name
         assert desc == "Built by Caterpie"
 
     def test_dev_any_uses_caterpie_with_ge_prefix(self):
         feed = self._public_feed()
         rkey, name, desc = _resolve_feed_publish_params("best-of-friends", feed, "dev")
-        assert rkey == _caterpie_rkey(feed.display_name)
+        assert rkey == feed.internal_rkey
         assert name.startswith("GE ")
         assert desc == "Built by Caterpie"
 
     def test_stage_any_uses_caterpie_with_ge_prefix(self):
         feed = self._internal_feed()
         rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "stage")
-        assert rkey == _caterpie_rkey(feed.display_name)
+        assert rkey == feed.internal_rkey
         assert name.startswith("GE ")
         assert desc == "Built by Caterpie"
 

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -32,7 +32,8 @@ FEEDS: dict[str, FeedConfig] = {
     ),
     "random": FeedConfig(
         display_name="Random",
-        description="Development feed — random posts.",
+        description="A random selection of recent posts from the community.",
+        public=True,
         diversify=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
@@ -42,9 +43,10 @@ FEEDS: dict[str, FeedConfig] = {
             exclude_uris=[],
         ),
     ),
-    "ranked": FeedConfig(
-        display_name="Ranked",
-        description="Current-best ranked feed.",
+    "your-feed": FeedConfig(
+        display_name="Your Feed",
+        description="Posts ranked and personalized just for you.",
+        public=True,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=0.5),
@@ -62,6 +64,7 @@ FEEDS: dict[str, FeedConfig] = {
     "best-of-friends": FeedConfig(
         display_name="Best of Friends",
         description="The best posts from people you follow, curated just for you.",
+        public=True,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],
             infill=None,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -19,6 +19,8 @@ FEEDS: dict[str, FeedConfig] = {
     "basic-similarity": FeedConfig(
         display_name="Similarity",
         description="Development feed — post-similarity candidates with popularity infill.",
+        internal_rkey="e2-s",
+        internal_display_name="e2 S",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=0.5),
@@ -34,6 +36,8 @@ FEEDS: dict[str, FeedConfig] = {
         display_name="Random",
         description="A random selection of recent posts from the community.",
         public=True,
+        internal_rkey="67-r",
+        internal_display_name="67 R",
         diversify=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
@@ -47,6 +51,8 @@ FEEDS: dict[str, FeedConfig] = {
         display_name="Your Feed",
         description="Posts ranked and personalized just for you.",
         public=True,
+        internal_rkey="a0-yf",
+        internal_display_name="a0 YF",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=0.5),
@@ -65,6 +71,8 @@ FEEDS: dict[str, FeedConfig] = {
         display_name="Best of Friends",
         description="The best posts from people you follow, curated just for you.",
         public=True,
+        internal_rkey="fd-bof",
+        internal_display_name="fd BOF",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],
             infill=None,

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -2,11 +2,6 @@ from app.feeds import FEEDS
 
 
 class TestFeedsRegistry:
-    def test_all_feeds_have_internal_rkey_and_internal_display_name(self):
-        for rkey, cfg in FEEDS.items():
-            assert cfg.internal_rkey is not None, f"{rkey} missing internal_rkey"
-            assert cfg.internal_display_name is not None, f"{rkey} missing internal_display_name"
-
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
         primary_rkeys = set(FEEDS.keys())
         internal_rkeys = {

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -1,0 +1,13 @@
+from app.feeds import FEEDS
+
+
+class TestFeedsRegistry:
+    def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
+        primary_rkeys = set(FEEDS.keys())
+        internal_rkeys = {
+            cfg.internal_rkey
+            for cfg in FEEDS.values()
+            if cfg.internal_rkey is not None
+        }
+        overlap = primary_rkeys & internal_rkeys
+        assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -2,6 +2,11 @@ from app.feeds import FEEDS
 
 
 class TestFeedsRegistry:
+    def test_all_feeds_have_internal_rkey_and_internal_display_name(self):
+        for rkey, cfg in FEEDS.items():
+            assert cfg.internal_rkey is not None, f"{rkey} missing internal_rkey"
+            assert cfg.internal_display_name is not None, f"{rkey} missing internal_display_name"
+
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
         primary_rkeys = set(FEEDS.keys())
         internal_rkeys = {

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -157,8 +157,8 @@ class FeedConfig(BaseModel):
     display_name: str = Field(..., max_length=19)
     description: str = ""
     public: bool = Field(False)
-    internal_rkey: str | None = Field(None)
-    internal_display_name: str | None = Field(None)
+    internal_rkey: str
+    internal_display_name: str
     gen_request_template: CandidateGenerateRequest
     rank_request_template: RankPredictRequest | None = Field(
         None,

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -154,8 +154,9 @@ class FeedConfig(BaseModel):
     generation and optional model ranking.  Defaults to ``True``.
     """
 
-    display_name: str = Field(..., max_length=15)
+    display_name: str = Field(..., max_length=19)
     description: str = ""
+    public: bool = Field(False)
     gen_request_template: CandidateGenerateRequest
     rank_request_template: RankPredictRequest | None = Field(
         None,

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -157,6 +157,8 @@ class FeedConfig(BaseModel):
     display_name: str = Field(..., max_length=19)
     description: str = ""
     public: bool = Field(False)
+    internal_rkey: str | None = Field(None)
+    internal_display_name: str | None = Field(None)
     gen_request_template: CandidateGenerateRequest
     rank_request_template: RankPredictRequest | None = Field(
         None,

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -14,35 +14,39 @@ def _minimal_gen_request() -> CandidateGenerateRequest:
     )
 
 
+def _minimal_feed_cfg(**kwargs) -> FeedConfig:
+    defaults = dict(
+        display_name="Test",
+        internal_rkey="ab-t",
+        internal_display_name="ab T",
+        gen_request_template=_minimal_gen_request(),
+    )
+    return FeedConfig(**{**defaults, **kwargs})
+
+
 class TestFeedConfig:
     def test_public_defaults_to_false(self):
-        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
-        assert cfg.public is False
+        assert _minimal_feed_cfg().public is False
 
     def test_public_can_be_set_true(self):
-        cfg = FeedConfig(display_name="Test", public=True, gen_request_template=_minimal_gen_request())
-        assert cfg.public is True
+        assert _minimal_feed_cfg(public=True).public is True
 
     def test_rejects_display_name_over_19_chars(self):
         with pytest.raises(ValidationError):
-            FeedConfig(display_name="A" * 20, gen_request_template=_minimal_gen_request())
+            _minimal_feed_cfg(display_name="A" * 20)
 
     def test_accepts_display_name_of_exactly_19_chars(self):
-        cfg = FeedConfig(display_name="A" * 19, gen_request_template=_minimal_gen_request())
-        assert len(cfg.display_name) == 19
+        assert len(_minimal_feed_cfg(display_name="A" * 19).display_name) == 19
 
-    def test_internal_rkey_defaults_to_none(self):
-        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
-        assert cfg.internal_rkey is None
+    def test_internal_rkey_is_required(self):
+        with pytest.raises(ValidationError):
+            _minimal_feed_cfg(internal_rkey=None)
 
-    def test_internal_display_name_defaults_to_none(self):
-        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
-        assert cfg.internal_display_name is None
+    def test_internal_display_name_is_required(self):
+        with pytest.raises(ValidationError):
+            _minimal_feed_cfg(internal_display_name=None)
 
-    def test_internal_rkey_can_be_set(self):
-        cfg = FeedConfig(display_name="Test", internal_rkey="e2-s", gen_request_template=_minimal_gen_request())
+    def test_internal_fields_can_be_set(self):
+        cfg = _minimal_feed_cfg(internal_rkey="e2-s", internal_display_name="e2 S")
         assert cfg.internal_rkey == "e2-s"
-
-    def test_internal_display_name_can_be_set(self):
-        cfg = FeedConfig(display_name="Test", internal_display_name="e2 S", gen_request_template=_minimal_gen_request())
         assert cfg.internal_display_name == "e2 S"

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import ValidationError
+
+from app.models import CandidateGenerateRequest, FeedConfig, GeneratorSpec
+
+
+def _minimal_gen_request() -> CandidateGenerateRequest:
+    return CandidateGenerateRequest.model_construct(
+        generators=[GeneratorSpec(name="test", weight=1.0)],
+        num_candidates=30,
+        video_only=False,
+        exclude_uris=[],
+        infill=None,
+    )
+
+
+class TestFeedConfig:
+    def test_public_defaults_to_false(self):
+        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
+        assert cfg.public is False
+
+    def test_public_can_be_set_true(self):
+        cfg = FeedConfig(display_name="Test", public=True, gen_request_template=_minimal_gen_request())
+        assert cfg.public is True
+
+    def test_rejects_display_name_over_19_chars(self):
+        with pytest.raises(ValidationError):
+            FeedConfig(display_name="A" * 20, gen_request_template=_minimal_gen_request())
+
+    def test_accepts_display_name_of_exactly_19_chars(self):
+        cfg = FeedConfig(display_name="A" * 19, gen_request_template=_minimal_gen_request())
+        assert len(cfg.display_name) == 19

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -30,3 +30,19 @@ class TestFeedConfig:
     def test_accepts_display_name_of_exactly_19_chars(self):
         cfg = FeedConfig(display_name="A" * 19, gen_request_template=_minimal_gen_request())
         assert len(cfg.display_name) == 19
+
+    def test_internal_rkey_defaults_to_none(self):
+        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
+        assert cfg.internal_rkey is None
+
+    def test_internal_display_name_defaults_to_none(self):
+        cfg = FeedConfig(display_name="Test", gen_request_template=_minimal_gen_request())
+        assert cfg.internal_display_name is None
+
+    def test_internal_rkey_can_be_set(self):
+        cfg = FeedConfig(display_name="Test", internal_rkey="e2-s", gen_request_template=_minimal_gen_request())
+        assert cfg.internal_rkey == "e2-s"
+
+    def test_internal_display_name_can_be_set(self):
+        cfg = FeedConfig(display_name="Test", internal_display_name="e2 S", gen_request_template=_minimal_gen_request())
+        assert cfg.internal_display_name == "e2 S"

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -291,8 +291,14 @@ async def get_feed_skeleton(
         rkey = ""
         collection = ""
 
-    if collection == "app.bsky.feed.generator" and rkey in FEEDS:
-        feed_name = rkey
+    if collection == "app.bsky.feed.generator":
+        if rkey in FEEDS:
+            feed_name = rkey
+        else:
+            for key, cfg in FEEDS.items():
+                if cfg.internal_rkey == rkey:
+                    feed_name = key
+                    break
 
     if feed_name is None:
         raise HTTPException(

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -22,7 +22,7 @@ FEED_RKEY = "basic-similarity"
 FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
-RANKED_FEED_RKEY = "ranked"
+RANKED_FEED_RKEY = "your-feed"
 RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
 BEST_OF_FRIENDS_FEED_RKEY = "best-of-friends"
 BEST_OF_FRIENDS_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{BEST_OF_FRIENDS_FEED_RKEY}"
@@ -204,7 +204,7 @@ class TestDescribeFeedGenerator:
         uris = [f["uri"] for f in data["feeds"]]
         assert RANDOM_FEED_URI in uris
 
-    def test_feeds_list_contains_ranked_similarity(self):
+    def test_feeds_list_contains_your_feed(self):
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
         uris = [f["uri"] for f in data["feeds"]]
         assert RANKED_FEED_URI in uris

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -275,6 +275,18 @@ class TestGetFeedSkeleton:
         assert resp.status_code == 200
         assert len(resp.json()["feed"]) == 2
 
+    def test_matches_feed_by_internal_rkey(self):
+        """Feeds published under their Caterpie internal_rkey are still served."""
+        feed_cfg = FEEDS["basic-similarity"]
+        internal_uri = f"at://{SERVICE_DID}/app.bsky.feed.generator/{feed_cfg.internal_rkey}"
+        with self._patch_generators(_make_candidates("p", 2)):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": internal_uri},
+            )
+        assert resp.status_code == 200
+        assert len(resp.json()["feed"]) == 2
+
     # --- unknown feed ---
 
     def test_unknown_feed_returns_400(self):


### PR DESCRIPTION
Closes #99

Deploying to prod failed because feed display names exceeded Bluesky's 24-grapheme limit. Additionally, internal/development feeds needed to be hidden from end-user discovery. This PR adds a `public` flag to feeds and a routing system that sends prod+public feeds to the GreenEarth account under their original names, and everything else to a Caterpie account under hardcoded obfuscated names.

See the full routing rules table in #99.

# This PR

- Add `public: bool`, `internal_rkey: str`, and `internal_display_name: str` to `FeedConfig`; bump `display_name` max_length from 15 → 19
- Rename `"ranked"` → `"your-feed"` with `display_name="Your Feed"`; set `public=True` on `best-of-friends`, `random`, and `your-feed`; update descriptions to remove "Development feed" phrasing; hardcode `internal_rkey`/`internal_display_name` on all feeds
- Add `_resolve_feed_publish_params()` routing function: prod+public → GreenEarth (original name/rkey, `"…\nBuilt by GreenEarth (https://www.greenearth.social)."` description); all others → Caterpie (hardcoded `internal_rkey`/`internal_display_name`, `"Built by Caterpie"` description); dev/stage Caterpie names get a `"GE "` prefix
- Rewrite `sync_feeds()` to use `_resolve_feed_publish_params` and accept `visibility: Literal["public", "internal"] | None`
- Add `--public-only` / `--internal-only` CLI flags (mutually exclusive, require `--sync`)
- Update `deploy.sh`: prod runs two sync passes (GreenEarth for public feeds, Caterpie for internal); stage runs a single Caterpie pass
- Update XRPC router to fall back to an `internal_rkey` reverse-lookup so feeds published under their Caterpie rkey are served correctly

# Testing

- `pipenv run pytest` — 337 tests pass
- `TestDisplayNameLength` parametrizes all FEEDS × all envs and asserts `len(name) <= 24`
- `TestSearchability` verifies prod+public feeds use original names and Caterpie feeds omit original names
- `TestPublicInternalOnlyCLI` covers mutual-exclusion, requires-sync, and visibility pass-through
- `test_matches_feed_by_internal_rkey` confirms the XRPC router serves feeds requested by their Caterpie rkey
- `feeds_test.py` guards against `internal_rkey` colliding with any primary FEEDS key

Deployed to stage:
https://bsky.app/profile/caterpie-internal.bsky.social/feed/a0-yf
https://bsky.app/profile/caterpie-internal.bsky.social/feed/67-r
https://bsky.app/profile/caterpie-internal.bsky.social/feed/fd-bof
https://bsky.app/profile/caterpie-internal.bsky.social/feed/e2-s