### PR TITLE
Request profiling for bsky feed serving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,12 @@ export GE_INFERENCE_BASE_URL=""
 export GE_INFERENCE_DOMAIN="inference-stage.greenearth.social"
 export GE_ENABLE_INFERENCE_DOMAIN_MAPPING=true
 export GE_INFERENCE_API_KEY="inference-service-api-key-here"
+
+########## Debugging Variables ##########
+
+# Set GE_TIMING_LOGS to "1" to enable logging of timing data for various operations in the API.
+export GE_TIMING_LOGS=""
+
+# Set GE_PROFILE to "1" to enable profiling of the API. Results will be stored in the
+# "profiles" directory.
+export GE_PROFILE=""

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ firebase-debug.log
 
 # pyinstrument flame charts written when GE_PROFILE=1
 profiles/
+
+# macOS metadata files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ requirements.txt
 firestore-debug.log
 firebase-debug.log
 .firebase/
+
+# pyinstrument flame charts written when GE_PROFILE=1
+profiles/

--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ pytest = "*"
 pytest-asyncio = "*"
 httpx = "*"
 ruff = "*"
+pyinstrument = "*"
 
 [requires]
 python_version = "3.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d16b47f1e60a7f6e8979b6cc60d3e388551db5d10397a647c3051bd2e21cfddc"
+            "sha256": "2466f697e68a8f61f34ad32bd06f38d900e28c272e9dec6392461fd5135acfc6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1983,11 +1983,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
-                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
+                "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+                "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.2.25"
+            "version": "==2026.4.22"
         },
         "h11": {
             "hashes": [
@@ -2015,11 +2015,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
-                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.11"
+            "version": "==3.15"
         },
         "iniconfig": {
             "hashes": [
@@ -2052,6 +2052,78 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.20.0"
+        },
+        "pyinstrument": {
+            "hashes": [
+                "sha256:059442106b8b5de29ae5ac1bdc20d044fed4da534b8caba434b6ffb119037bf5",
+                "sha256:0baed297beee2bb9897e737bbd89e3b9d45a2fbbea9f1ad4e809007d780a9b1e",
+                "sha256:0c45c14974ff04b1bfdc6c2a448627c6da7409c7800d0eb7bd03fb435dcb41d7",
+                "sha256:1249d2799cdd57151b4444167e5c7736e2c9b5e79bd781b0779d631338509553",
+                "sha256:12af1e83795b6c640d657d339014dd1ff718b182dec736d7d1f1d8a97534eb53",
+                "sha256:13dcc138a61298ef4994b7aebff509d2c06db89dfd6e2021f0b9cd96aaa44ec3",
+                "sha256:22b9c04b3982c41c04b1c5ed05d1bc3a2ba26533450084058119f6dc160e70a3",
+                "sha256:2519865d4bf58936f2506c1c46a82d29a20f3239aa50c941df1ca9618c7da5f0",
+                "sha256:2565513658e742c5eb691a779cb29d19d01bc9ee951d0eb76482e9f343c38c2e",
+                "sha256:2588bc34c25d50f29d3a117c7dfac06513ee59c507b65081e66ca9569bcf45e0",
+                "sha256:2bacb980c95d4c9ea6a253e5ccf3e99993082de29ff7e7fc397e9484355577b1",
+                "sha256:2d653206f50260f20bc78339c3d7aa0f19f8cf9c9f71939fbf02e2ea30353487",
+                "sha256:2f456cabdb95fd343c798a7f2a56688b028f981522e283c5f59bd59195b66df5",
+                "sha256:3739a05583ea6312c385eb59fe985cd20d9048e95f9eeeb6a2f6c35202e2d36e",
+                "sha256:38a2180a7801c51610b50e5d423674b21872efd019ccf05a11b7f9016cb1dcfc",
+                "sha256:3b68aa9f0d5217c67370762c99a80750ce56f66e5e9281c31b5baa3e4b88894d",
+                "sha256:3d21221a29718d5dcdc1453dbbbdd100734525672ef1e34ff03d49bc5d688ca4",
+                "sha256:3fb839429671a42bf349335af4c1ce5cf83386ac11f04df0bc40720d4cb7d77d",
+                "sha256:47f14f248108f1202d48f34903bddc053a47c62ce46908aee848c1f667a1925b",
+                "sha256:4e9c4dcc1f2c4a0cd6b576e3604abc37496a7868243c9a1443ad3b9db69d590f",
+                "sha256:50299bddfc1fe0039898f895b10ef12f9db08acffb4d85326fad589cda24d2ee",
+                "sha256:5381cc6583d26e04d9298acded4242f4fe71986f1472c8aee6992c6816f0cac5",
+                "sha256:554077b031b278593cb2301f0057be771ea62a729878c69aaf29fcdfb7b71281",
+                "sha256:55a905384ba43efc924b8863aa6cfd276f029e4aa70c4a0e3b7389e27b191e45",
+                "sha256:5957a94f84564b374a7f856d1b322345d600964280b0d687b8ddcc483f21e576",
+                "sha256:5afd0ba788a1d112da49fb77966918e01df1f9e7d62e72894d82f7acb0996c2d",
+                "sha256:5c4995ee0774801790c138f0dfec17d4e7a7ef09a6d56d53cbcbf0578a711021",
+                "sha256:64246d2bd475870b62ed5df4808bfb33328135e8dfbdff823f9cb7d1358eb40b",
+                "sha256:660d7fc486a839814db0b2f716bc13d8b99b9c780aaeb47f74a70a34adc02a7b",
+                "sha256:755702f01800934c3bec3c0d30483f97b6ff1fc1d2afcf6d816584703c9f1235",
+                "sha256:75a7e17377d4405666bbaf126b1fd7bbb7e206d7246e6db3d62864d3d4790ae3",
+                "sha256:7a49a55ca5b75218767e29cacbe515d0b66fc18cb48a937bca0f77b8dafc7202",
+                "sha256:7afb24d11d24fb1762059240ed97a1a4607779d5f221f91d62b67ae089bd506d",
+                "sha256:7b8bab2334bf1d4c9e92d61db574300b914b594588a6b6dd67c45450152dfc29",
+                "sha256:7c9ee05dc75ac5fb18498c311e624f77f7f321f7ff325b251aa09e52e46f1d6a",
+                "sha256:7df09fc0d5b72daf48b73cdf07738761bff7f656c81aff686b3ccdd7d2abe236",
+                "sha256:9ba0e6b17a7e86c3dc02d208e4c25506e8f914d9964ae89449f1f37f0b70abc0",
+                "sha256:9c7f0167903ecff8b1d744f7e37b2bd4918e05a69cca724cb112f5ed59d1e41b",
+                "sha256:9d671168508129b472be570bc9aee361190ba917b997c703bd134bb4de445ce7",
+                "sha256:a193ff08825ece115ececa136832acb14c491c77ab1e6b6a361905df8753d5c6",
+                "sha256:acf93b128328c6d80fdb85431068ac17508f0f7845e89505b0ea6130dead5ca6",
+                "sha256:af09af38ee8407ca273407e24a8e6470d2444561d01005ee6a8db5f2fd908c08",
+                "sha256:af149d672da9493fa37334a1cc68f7b80c3e6cb9fd99b9e426c447db5c650bf0",
+                "sha256:af8651b239049accbeecd389d35823233f649446f76f47fd005316b05d08cef2",
+                "sha256:b007327e0d6a6a01d5064883dd27c19996f044ce7488d507826fee7884e6a32e",
+                "sha256:b6a71f5e7f53c86c9b476b30cf19509463a63581ef17ddbd8680fee37ae509db",
+                "sha256:bad403c157f9c6dba7f731a6fca5bfcd8ca2701a39bcc717dcc6e0b10055ffc4",
+                "sha256:bea0687665c181c6e62677fb560739a473c4286816582a43f8eb0aa6094ed529",
+                "sha256:c031eb066ddc16425e1e2f56aad5c1ce1e27b2432a70329e5385b85e812decee",
+                "sha256:c6082f1c3e43e1d22834e91ba8975f0080186df4018a04b4dd29f9623c59df1d",
+                "sha256:c8abd4a7ffa2e7f9e00039a5e549e8eebc80d7ca8d43f0fb51a50ff2b117ce4a",
+                "sha256:cc3f2688981af764fa2c5f5a00d7040c0c12771ca5a026730f2d826f7a28d277",
+                "sha256:cd51f2d54fc39a4cfd73ba6be27cd0187123132ce3f445b639bff5e1b23d7e26",
+                "sha256:ce3f6b1f9a2b5d74819ecc07d631eadececf915f551474a75ad65ac580ec5a0e",
+                "sha256:d0b0c6e289725f14d0ff73f8190c953bdcb98f21c5c29c3eafb0dca8025583cb",
+                "sha256:db8243e602aca43dc7ce8e40ed7d0ca4820d024c3c03824870c5a9e98f84e953",
+                "sha256:de887ba19e1057bd2d86e6584f17788516a890ae6fe1b7eed9927873f416b4d8",
+                "sha256:eb3a05108edebc30f31e2c69c904576042f1158b2513ab80adc08f7848a7a8f0",
+                "sha256:ebb910a32a45bde6c3fc30c578efc28a54517990e11e94b5e48a0d5479728568",
+                "sha256:ec08a530bef8d3492d31d8b0b12d0cfde09539f2a1c4b9678662ebc3c843e478",
+                "sha256:f224fe80ba288a00980af298d3808219f9d246fd95b4f91729c9c33a0dc54fe6",
+                "sha256:f447ec391cad30667ba412dce41607aaa20d4a2496a7ab867e0c199f0fe3ae3d",
+                "sha256:f70d588b53f3f35829d1d1ddfa05e07fcebf1434b3b1509d542ca317d8e9a2a5",
+                "sha256:fe449e4a8ee60a2a27cf509350a584670f4c3704649601be7937598f09dbe7ca",
+                "sha256:ff6fd3c7907e57f082cdd405bec1b34768c1810a165538299d259ee1bff5d7b6"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==5.1.2"
         },
         "pytest": {
             "hashes": [

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -8,6 +8,7 @@ from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from .utils import candidate_posts_from_es_response
 from ..bsky import get_followed_user_dids, FollowedUsersLookupError
+from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +44,11 @@ async def followed_users_search(
         must_not.append({"terms": {"at_uri": exclude_uris}})
 
     try:
-        followed_dids: list[str] = await get_followed_user_dids(
-            user_did,
-            limit=MAX_FOLLOWED_USERS,
-        )
+        async with timed(logger, "bsky_get_follows", user_did=user_did):
+            followed_dids: list[str] = await get_followed_user_dids(
+                user_did,
+                limit=MAX_FOLLOWED_USERS,
+            )
     except FollowedUsersLookupError as exc:
         logger.warning(
             "Skipping followed_users candidate generation for %s after follow "
@@ -69,12 +71,18 @@ async def followed_users_search(
         }
     }
 
-    resp = await es.search(
-        index="posts",
-        query=query,
-        size=num_candidates,
-        sort=[{"created_at": "desc"}],
-    )
+    async with timed(
+        logger,
+        "es_followed_users",
+        n_followed=len(followed_dids),
+        num_candidates=num_candidates,
+    ):
+        resp = await es.search(
+            index="posts",
+            query=query,
+            size=num_candidates,
+            sort=[{"created_at": "desc"}],
+        )
     return candidate_posts_from_es_response(resp, generator_name=generator_name)
 
 

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -17,6 +17,7 @@ from ...models import (
     GeneratorSpec,
 )
 from .base import CandidateGenerator, CandidateResult, get_generator
+from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -120,13 +121,14 @@ async def run_generate(
         spec: GeneratorSpec, count: int, gen: CandidateGenerator
     ) -> CandidateResult | None:
         try:
-            return await gen.generate(
-                es=es,
-                user_did=request.user_did,
-                num_candidates=count,
-                video_only=request.video_only,
-                exclude_uris=request.exclude_uris or None,
-            )
+            async with timed(logger, "generator", name=spec.name, count=count):
+                return await gen.generate(
+                    es=es,
+                    user_did=request.user_did,
+                    num_candidates=count,
+                    video_only=request.video_only,
+                    exclude_uris=request.exclude_uris or None,
+                )
         except Exception as exc:
             logger.exception("Candidate generator '%s' failed", spec.name)
             if swallow_errors:

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -21,6 +21,7 @@ import logging
 from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from .utils import candidate_posts_from_es_response
+from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,8 @@ async def popularity_search(
         }
     }
 
-    resp = await es.search(index="posts", query=query, size=num_candidates)
+    async with timed(logger, "es_popularity", num_candidates=num_candidates):
+        resp = await es.search(index="posts", query=query, size=num_candidates)
     return candidate_posts_from_es_response(resp, generator_name=generator_name)
 
 

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 
 from .embeddings import MINILM_L12_EMBEDDING_FIELD, MINILM_L12_EMBEDDING_KEY
 from .request_cache import get_request_cache
+from .telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -57,27 +58,30 @@ async def fetch_recent_liked_post_uris(
         return []
 
     async def _fetch() -> list[str]:
-        query = {
-            "bool": {
-                "filter": [{"terms": {"author_did": user_dids}}],
+        async with timed(
+            logger, "es_recent_likes", n_users=len(user_dids), limit=limit
+        ):
+            query = {
+                "bool": {
+                    "filter": [{"terms": {"author_did": user_dids}}],
+                }
             }
-        }
 
-        resp = await es.search(
-            index="likes",
-            query=query,
-            size=limit,
-            sort=[{"created_at": "desc"}],
-            _source=["subject_uri"],
-        )
+            resp = await es.search(
+                index="likes",
+                query=query,
+                size=limit,
+                sort=[{"created_at": "desc"}],
+                _source=["subject_uri"],
+            )
 
-        data = unwrap_es_response(resp)
-        uris: list[str] = []
-        for hit in data.get("hits", {}).get("hits", []):
-            uri = (hit.get("_source") or {}).get("subject_uri")
-            if uri:
-                uris.append(uri)
-        return uris
+            data = unwrap_es_response(resp)
+            uris: list[str] = []
+            for hit in data.get("hits", {}).get("hits", []):
+                uri = (hit.get("_source") or {}).get("subject_uri")
+                if uri:
+                    uris.append(uri)
+            return uris
 
     cache = get_request_cache()
     if cache is None:
@@ -102,34 +106,35 @@ async def fetch_post_embeddings(
         return []
 
     async def _fetch() -> list[tuple[str, list[float]]]:
-        query = {"terms": {"at_uri": at_uris}}
+        async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
+            query = {"terms": {"at_uri": at_uris}}
 
-        resp = await es.search(
-            index="posts",
-            query=query,
-            size=len(at_uris),
-            _source=["at_uri", MINILM_L12_EMBEDDING_FIELD],
-        )
+            resp = await es.search(
+                index="posts",
+                query=query,
+                size=len(at_uris),
+                _source=["at_uri", MINILM_L12_EMBEDDING_FIELD],
+            )
 
-        data = unwrap_es_response(resp)
-        embeddings_by_uri: dict[str, list[float]] = {}
-        for hit in data.get("hits", {}).get("hits", []):
-            src = hit.get("_source") or {}
-            at_uri = src.get("at_uri")
-            if not at_uri:
-                continue
-            emb = src.get("embeddings")
-            if isinstance(emb, dict):
-                vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+            data = unwrap_es_response(resp)
+            embeddings_by_uri: dict[str, list[float]] = {}
+            for hit in data.get("hits", {}).get("hits", []):
+                src = hit.get("_source") or {}
+                at_uri = src.get("at_uri")
+                if not at_uri:
+                    continue
+                emb = src.get("embeddings")
+                if isinstance(emb, dict):
+                    vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+                    if vec:
+                        embeddings_by_uri[at_uri] = vec
+
+            ordered_embeddings: list[tuple[str, list[float]]] = []
+            for at_uri in at_uris:
+                vec = embeddings_by_uri.get(at_uri)
                 if vec:
-                    embeddings_by_uri[at_uri] = vec
-
-        ordered_embeddings: list[tuple[str, list[float]]] = []
-        for at_uri in at_uris:
-            vec = embeddings_by_uri.get(at_uri)
-            if vec:
-                ordered_embeddings.append((at_uri, vec))
-        return ordered_embeddings
+                    ordered_embeddings.append((at_uri, vec))
+            return ordered_embeddings
 
     cache = get_request_cache()
     if cache is None:

--- a/src/app/lib/profiling.py
+++ b/src/app/lib/profiling.py
@@ -1,0 +1,71 @@
+"""Env-gated pyinstrument middleware.
+
+When ``GE_PROFILE=1`` is set, every HTTP request is sampled by
+pyinstrument at 1 ms intervals (``async_mode="enabled"`` so it
+follows ``await`` boundaries across ``asyncio.gather``). The flame
+chart is written to ``./profiles/`` as HTML, named with the current
+request ID so it can be cross-referenced with the corresponding
+``timed()`` log lines via ``grep``.
+
+The pyinstrument import is lazy so production deployments without
+the dev extras don't fail at startup.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+
+from .request_context import get_request_id
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROFILE_DIR = "profiles"
+
+
+def _path_slug(path: str) -> str:
+    """Filesystem-safe slug for the request path component of the filename."""
+    return re.sub(r"[^a-zA-Z0-9]+", "_", path).strip("_") or "root"
+
+
+def install_profiling(app: FastAPI) -> None:
+    """Install the per-request pyinstrument middleware if ``GE_PROFILE=1``.
+
+    No-op otherwise. Must be called after the request-ID middleware is
+    registered so the ID is set by the time we build the output filename.
+    """
+    if os.environ.get("GE_PROFILE") != "1":
+        return
+
+    # Lazy import so this is not a hard runtime dep when GE_PROFILE is unset.
+    from pyinstrument import Profiler
+
+    profile_dir = Path(os.environ.get("GE_PROFILE_DIR", DEFAULT_PROFILE_DIR))
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("pyinstrument profiling enabled; writing to %s", profile_dir)
+
+    @app.middleware("http")
+    async def profile_mw(request: Request, call_next):
+        profiler = Profiler(interval=0.001, async_mode="enabled")
+        profiler.start()
+        try:
+            response = await call_next(request)
+        finally:
+            profiler.stop()
+
+        rid = get_request_id() or "no-rid"
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        filename = f"{ts}-{rid}-{_path_slug(request.url.path)}.html"
+        output_path = profile_dir / filename
+        try:
+            output_path.write_text(profiler.output_html())
+            logger.info("profile_written rid=%s path=%s", rid, output_path)
+        except Exception:
+            logger.exception("Failed to write pyinstrument profile to %s", output_path)
+
+        return response

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -14,6 +14,7 @@ from .base import Ranker, RankerExecutionError, RankerResult
 from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
 from ..embeddings import decode_float32_b64
 from ..http_client import get_http_client
+from ..request_context import get_request_id
 
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,19 @@ def get_inference_settings() -> tuple[str, str]:
 POST_TOWER_BATCH_SIZE = 32
 
 
+def _build_inference_headers(api_key: str) -> dict[str, str]:
+    """Outbound headers for inference HTTP calls.
+
+    Includes the current request ID (when set) so the inference service
+    can log it alongside our own logs for cross-service correlation.
+    """
+    headers = {"X-API-Key": api_key}
+    rid = get_request_id()
+    if rid is not None:
+        headers["x-request-id"] = rid
+    return headers
+
+
 async def predict_post_tower_batch(
     post_embeddings: list[list[float]],
     *,
@@ -48,7 +62,7 @@ async def predict_post_tower_batch(
     api_key: str,
 ) -> list[list[float]]:
     url = f"{base_url}/models/post-tower/predict"
-    headers = {"X-API-Key": api_key}
+    headers = _build_inference_headers(api_key)
 
     chunks = [
         post_embeddings[i : i + POST_TOWER_BATCH_SIZE]
@@ -81,7 +95,7 @@ async def predict_user_tower_single(
     api_key: str,
 ) -> list[list[float]]:
     url = f"{base_url}/models/user-tower/predict"
-    headers = {"X-API-Key": api_key}
+    headers = _build_inference_headers(api_key)
     payload = {"history_embeddings": history_embeddings}
 
     client = get_http_client()

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -15,6 +15,7 @@ from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
 from ..embeddings import decode_float32_b64
 from ..http_client import get_http_client
 from ..request_context import get_request_id
+from ..telemetry import timed
 
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,10 @@ async def predict_post_tower_batch(
             resp.raise_for_status()
         return resp.json()["outputs"]
 
-    chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
+    async with timed(
+        logger, "post_tower_http", n_posts=len(post_embeddings), n_chunks=len(chunks)
+    ):
+        chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
     return [item for chunk_out in chunk_outputs for item in chunk_out]
 
 
@@ -99,7 +103,8 @@ async def predict_user_tower_single(
     payload = {"history_embeddings": history_embeddings}
 
     client = get_http_client()
-    resp = await client.post(url, json=payload, headers=headers)
+    async with timed(logger, "user_tower_http", n_history=len(history_embeddings)):
+        resp = await client.post(url, json=payload, headers=headers)
     resp.raise_for_status()
     return resp.json()["outputs"]
 
@@ -126,79 +131,83 @@ class TwoTowerRanker(Ranker):
         candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
 
         async def _compute_user_embedding() -> list[float]:
-            user_history_vectors: list[list[float]] = []
-            user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
+            async with timed(logger, "two_tower_user_side", user_did=user_did):
+                user_history_vectors: list[list[float]] = []
+                user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
-            if not user_history_liked_uris:
-                logger.info("No likes found for user %s", user_did)
-            else:
-                user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(
-                    es, user_history_liked_uris
-                )
-                if not user_history_embedding_pairs:
-                    logger.info(
-                        "No embeddings found for %d liked posts of user %s",
-                        len(user_history_liked_uris),
-                        user_did,
-                    )
+                if not user_history_liked_uris:
+                    logger.info("No likes found for user %s", user_did)
                 else:
-                    user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
+                    user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(
+                        es, user_history_liked_uris
+                    )
+                    if not user_history_embedding_pairs:
+                        logger.info(
+                            "No embeddings found for %d liked posts of user %s",
+                            len(user_history_liked_uris),
+                            user_did,
+                        )
+                    else:
+                        user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
 
-            output_user_embedding_list = await predict_user_tower_single(
-                user_history_vectors,
-                base_url=inference_base_url,
-                api_key=inference_api_key,
-            )
-            if len(output_user_embedding_list) != 1:
-                raise RankerExecutionError(
-                    self.name,
-                    f"user inference returned {len(output_user_embedding_list)} embeddings; expected 1",
+                output_user_embedding_list = await predict_user_tower_single(
+                    user_history_vectors,
+                    base_url=inference_base_url,
+                    api_key=inference_api_key,
                 )
-            return output_user_embedding_list[0]
+                if len(output_user_embedding_list) != 1:
+                    raise RankerExecutionError(
+                        self.name,
+                        f"user inference returned {len(output_user_embedding_list)} embeddings; expected 1",
+                    )
+                return output_user_embedding_list[0]
 
         async def _compute_candidate_post_embeddings() -> (
             tuple[list[CandidatePost], list[list[float]]] | None
         ):
-            # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
-            candidate_embedding_pairs: list[tuple[str, list[float]]] = []
-            missing_uris: list[str] = []
-            for uri, candidate in candidates_by_uri.items():
-                if candidate.minilm_l12_embedding:
-                    try:
-                        vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                        candidate_embedding_pairs.append((uri, vec))
-                        continue
-                    except Exception:
-                        pass
-                missing_uris.append(uri)
+            async with timed(
+                logger, "two_tower_post_side", n_candidates=len(candidates_by_uri)
+            ):
+                # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+                candidate_embedding_pairs: list[tuple[str, list[float]]] = []
+                missing_uris: list[str] = []
+                for uri, candidate in candidates_by_uri.items():
+                    if candidate.minilm_l12_embedding:
+                        try:
+                            vec = decode_float32_b64(candidate.minilm_l12_embedding)
+                            candidate_embedding_pairs.append((uri, vec))
+                            continue
+                        except Exception:
+                            pass
+                    missing_uris.append(uri)
 
-            if missing_uris:
-                fetched = await fetch_post_embeddings(es, missing_uris)
-                candidate_embedding_pairs.extend(fetched)
+                if missing_uris:
+                    fetched = await fetch_post_embeddings(es, missing_uris)
+                    candidate_embedding_pairs.extend(fetched)
 
-            if not candidate_embedding_pairs:
-                return None
+                if not candidate_embedding_pairs:
+                    return None
 
-            ranked_candidates_input = [
-                candidates_by_uri[at_uri]
-                for at_uri, _ in candidate_embedding_pairs
-                if at_uri in candidates_by_uri
-            ]
-            input_post_embeddings = [
-                embedding for _, embedding in candidate_embedding_pairs
-            ]
+                ranked_candidates_input = [
+                    candidates_by_uri[at_uri]
+                    for at_uri, _ in candidate_embedding_pairs
+                    if at_uri in candidates_by_uri
+                ]
+                input_post_embeddings = [
+                    embedding for _, embedding in candidate_embedding_pairs
+                ]
 
-            output_post_embeddings = await predict_post_tower_batch(
-                input_post_embeddings,
-                base_url=inference_base_url,
-                api_key=inference_api_key,
-            )
-            if len(output_post_embeddings) != len(ranked_candidates_input):
-                raise RankerExecutionError(
-                    self.name,
-                    "post inference returned a different number of embeddings than requested",
+                output_post_embeddings = await predict_post_tower_batch(
+                    input_post_embeddings,
+                    base_url=inference_base_url,
+                    api_key=inference_api_key,
                 )
-            return ranked_candidates_input, output_post_embeddings
+                if len(output_post_embeddings) != len(ranked_candidates_input):
+                    raise RankerExecutionError(
+                        self.name,
+                        "post inference returned a different number of embeddings than requested",
+                    )
+                return ranked_candidates_input, output_post_embeddings
 
         output_user_embedding, candidate_result = await asyncio.gather(
             _compute_user_embedding(),

--- a/src/app/lib/request_context.py
+++ b/src/app/lib/request_context.py
@@ -1,0 +1,34 @@
+"""Per-request ID propagated via a ContextVar.
+
+A short, server-generated UUID is stamped on each inbound HTTP request
+by the request-ID middleware in :mod:`app.main` and stored here so that
+log lines emitted anywhere on the request path can include it without
+the caller having to thread an ID parameter through every function.
+
+The ID is **always** server-generated; we deliberately do not honor an
+inbound ``x-request-id`` header. Trusting client-supplied IDs would let
+any caller inject arbitrary values into our logs.
+
+ContextVar propagation through ``asyncio.gather`` is identical to
+``request_cache_scope``: child tasks inherit the parent's context at
+spawn time, so concurrent generators and the two-tower side branches
+all see the same ``rid``.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+_request_id: ContextVar[str | None] = ContextVar("ge_request_id", default=None)
+
+
+def get_request_id() -> str | None:
+    return _request_id.get()
+
+
+def set_request_id(rid: str) -> Token:
+    return _request_id.set(rid)
+
+
+def reset_request_id(token: Token) -> None:
+    _request_id.reset(token)

--- a/src/app/lib/telemetry.py
+++ b/src/app/lib/telemetry.py
@@ -1,13 +1,23 @@
 """Telemetry helpers for timing API and Elasticsearch operations."""
 
 import logging
+import os
 import time
 from contextlib import asynccontextmanager
+
+from .request_context import get_request_id
 
 
 @asynccontextmanager
 async def timed(logger: logging.Logger, label: str, **extra: object):
     """Async context manager that logs elapsed time for a labelled operation.
+
+    The wrapped block always runs. The log line is only emitted when
+    ``GE_TIMING_LOGS=1`` is set in the environment, so production logs
+    stay quiet until someone is actively debugging performance. When a
+    request ID is set on the current ContextVar it is included as
+    ``rid=<id>`` so a single ``grep`` ties together all spans from one
+    request.
 
     Usage::
 
@@ -18,10 +28,21 @@ async def timed(logger: logging.Logger, label: str, **extra: object):
     try:
         yield
     finally:
-        elapsed_ms = (time.monotonic() - start) * 1000
-        logger.info(
-            "%s elapsed_ms=%.1f",
-            label,
-            elapsed_ms,
-            extra={"elapsed_ms": elapsed_ms, **extra},
-        )
+        if os.environ.get("GE_TIMING_LOGS") == "1":
+            elapsed_ms = (time.monotonic() - start) * 1000
+            rid = get_request_id()
+            if rid is not None:
+                logger.info(
+                    "%s rid=%s elapsed_ms=%.1f",
+                    label,
+                    rid,
+                    elapsed_ms,
+                    extra={"elapsed_ms": elapsed_ms, "rid": rid, **extra},
+                )
+            else:
+                logger.info(
+                    "%s elapsed_ms=%.1f",
+                    label,
+                    elapsed_ms,
+                    extra={"elapsed_ms": elapsed_ms, **extra},
+                )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,7 +1,8 @@
 import os
+import uuid
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from .routers import candidates, diversify, health, rank, skylight, xrpc
 from .security import RequireApiKey
@@ -9,6 +10,7 @@ from .lib.atproto_auth import init_id_resolver
 from .lib.feed_cache import FirestoreFeedCache
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
+from .lib.request_context import reset_request_id, set_request_id
 
 from elasticsearch import AsyncElasticsearch
 
@@ -159,6 +161,25 @@ app = FastAPI(
     openapi_tags=_TAGS,
     lifespan=lifespan,
 )
+
+
+@app.middleware("http")
+async def request_id_mw(request: Request, call_next):
+    """Stamp a server-generated request ID on every request.
+
+    The ID is set as a ContextVar so log lines emitted on the request
+    path (via ``timed()`` or otherwise) can include it. We deliberately
+    ignore any inbound ``x-request-id`` header to avoid log forging or
+    correlation poisoning from untrusted callers.
+    """
+    rid = uuid.uuid4().hex[:12]
+    token = set_request_id(rid)
+    try:
+        response = await call_next(request)
+    finally:
+        reset_request_id(token)
+    response.headers["x-request-id"] = rid
+    return response
 
 
 app.include_router(candidates.router)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,6 +10,7 @@ from .lib.atproto_auth import init_id_resolver
 from .lib.feed_cache import FirestoreFeedCache
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
+from .lib.profiling import install_profiling
 from .lib.request_context import reset_request_id, set_request_id
 
 from elasticsearch import AsyncElasticsearch
@@ -161,6 +162,13 @@ app = FastAPI(
     openapi_tags=_TAGS,
     lifespan=lifespan,
 )
+
+
+# Register profiling middleware first so that when both are stacked it ends up
+# *inside* request_id_mw. Starlette runs the last-registered middleware first
+# (outermost); we want request_id_mw outer so the rid is set before profile_mw
+# tries to read it for the output filename.
+install_profiling(app)
 
 
 @app.middleware("http")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,8 +1,19 @@
+import logging
 import os
 import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+
+# Configure the root logger so app modules' INFO+ messages reach stderr.
+# Uvicorn only configures handlers on its own loggers (uvicorn.error,
+# uvicorn.access) — without this, our `timed()` spans and `profile_written`
+# lines are silently dropped. Level is configurable via GE_LOG_LEVEL.
+logging.basicConfig(
+    level=os.environ.get("GE_LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    force=True,
+)
 
 from .routers import candidates, diversify, health, rank, skylight, xrpc
 from .security import RequireApiKey

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -28,6 +28,7 @@ from ..models import CandidateGenerateRequest, FeedConfig, FeedCursor, Generator
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.firestore import upsert_feed_activity, upsert_user
 from ..lib.request_cache import request_cache_scope
+from ..lib.telemetry import timed
 from ..feeds import FEEDS
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,13 @@ async def _run_ranking_pipeline(
     single round-trip.
     """
     async with request_cache_scope():
-        result = await run_generate(gen_request, es, swallow_errors=True)
+        async with timed(
+            logger,
+            "run_generate",
+            num_candidates=gen_request.num_candidates,
+            n_generators=len(gen_request.generators),
+        ):
+            result = await run_generate(gen_request, es, swallow_errors=True)
         candidates = result.candidates
 
         if not candidates:
@@ -144,7 +151,13 @@ async def _run_ranking_pipeline(
             rank_req = feed_cfg.rank_request_template.model_copy(
                 update={"candidates": candidates, "user_did": gen_request.user_did}
             )
-            rank_result = await run_predict(rank_req, es)
+            async with timed(
+                logger,
+                "run_predict",
+                n_candidates=len(candidates),
+                model=rank_req.model,
+            ):
+                rank_result = await run_predict(rank_req, es)
             # Reorder CandidatePosts by model rank and stamp rank_score onto each
             # so MMR uses the model's relevance scores, not the generator scores.
             by_uri = {c.at_uri: c for c in candidates if c.at_uri}
@@ -343,7 +356,8 @@ async def get_feed_skeleton(
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid cursor")
 
-        cached_uris = await feed_cache.retrieve(parsed.id)
+        async with timed(logger, "feedcache_retrieve", cache_id=parsed.id):
+            cached_uris = await feed_cache.retrieve(parsed.id)
         if cached_uris is not None:
             if parsed.offset < len(cached_uris):
                 # Serve from the existing cached batch.
@@ -373,7 +387,8 @@ async def get_feed_skeleton(
 
             new_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
             if new_uris:
-                updated = await feed_cache.append(parsed.id, new_uris)
+                async with timed(logger, "feedcache_append", cache_id=parsed.id):
+                    updated = await feed_cache.append(parsed.id, new_uris)
                 if updated is not None:
                     page = new_uris[:limit]
                     next_offset = parsed.offset + len(page)
@@ -407,7 +422,8 @@ async def get_feed_skeleton(
     next_cursor = None
     if len(all_uris) > limit:
         cache_key = uuid.uuid4().hex
-        await feed_cache.store(cache_key, all_uris)
+        async with timed(logger, "feedcache_store", cache_id=cache_key):
+            await feed_cache.store(cache_key, all_uris)
         next_cursor = FeedCursor(id=cache_key, offset=limit).encode()
 
     return FeedSkeletonResponse(


### PR DESCRIPTION
## Motivation

The earlier perf pass on `raindrift/quick-performance-fixes` removed obvious code-read inefficiencies but didn't shrink the ranked feed's `getFeedSkeleton` latency enough. To know what to fix next, we need to attribute time to specific stages — ideally on real Bluesky AppView traffic that hits a locally-tunneled dev server, since synthetic curl calls don't reproduce the full request mix.

This PR adds two complementary profiling layers, both off by default in prod:

- **Stage-level `timed()` log lines** — semantic breakdown ("`run_generate` 800 ms, `run_predict` 2.3 s, `bsky_get_follows` 1.1 s") in the uvicorn console, enabled via `GE_TIMING_LOGS=1`.
- **`pyinstrument` flame chart per request** — written as HTML to `api/profiles/` when `GE_PROFILE=1` is set, for drilling into library-internal time that stage labels can't anticipate.

Both layers correlate via a server-generated 12-hex request ID so a single `grep` ties a waterfall to its flame chart file.

## Commits

**`add server-generated request ID and gate timed() logs on env var`**
- A Starlette middleware mints a request ID into a ContextVar and echoes it back as `x-request-id`. Inbound `x-request-id` headers are deliberately ignored to avoid log forging / correlation poisoning from untrusted callers.
- `timed()` now reads the ContextVar and emits `rid=<id>` when set, and **only emits the log line at all when `GE_TIMING_LOGS=1`**. The wrapped block always runs; production stays quiet by default.
- The inference HTTP calls forward the rid via the existing outbound headers dict, so once the inference service starts logging it we get cross-service correlation. The Bluesky public-API call is intentionally not modified — we don't send internal IDs to third-party services.

**`add timed() spans across the ranked feed path`**
- Spans at `run_generate`, `run_predict`, per generator, both two-tower side coroutines, both inference HTTP calls, the cached ES helpers, `popularity` / `followed_users` / `bsky_get_follows` calls, and the three feed-cache operations.
- Pure-CPU work (MMR, dedup, dot products, base64 decode) is intentionally not timed — those have always been microseconds.
- The two existing `timed()` callers (kNN searches) inherit the rid + env-var gate for free.

**`add pyinstrument middleware gated on GE_PROFILE=1`**
- Per-request flame chart at `interval=0.001`, `async_mode="enabled"` so `await` boundaries inside `asyncio.gather` are followed correctly.
- HTML files named `{ts}-{rid}-{path-slug}.html` in `api/profiles/` (gitignored). The directory and the filename embed the rid so a `grep rid=<id>` finds both the stage log lines and the matching profile file.
- pyinstrument is added to `[dev-packages]` with a lazy import inside `install_profiling`, so prod containers without the dev extras still start.
- Registered *before* `request_id_mw` so that Starlette's last-registered-first dispatch leaves the profiler nested inside the request-ID setup. That way the profiler sees the rid still set when building the output filename.

**`configure root logger so app INFO logs reach the console`**
- Uvicorn only attaches handlers to its own loggers, so anything emitted via `logging.getLogger("app.xxx")` — including the existing kNN spans, the new `timed()` lines, and `profile_written` — was being silently dropped. A `logging.basicConfig(..., force=True)` at the top of `main.py` fixes it. Level is overridable via `GE_LOG_LEVEL`.

## Behavior

| `GE_TIMING_LOGS` | `GE_PROFILE` | What you see |
|---|---|---|
| unset | unset | App startup logs + uvicorn access lines. `x-request-id` echoed on response. |
| `1` | unset | + per-stage waterfall in console, all sharing one `rid` per request. |
| unset | `1` | + an HTML flame chart in `api/profiles/` per request, plus a `profile_written rid=… path=…` log line. |
| `1` | `1` | Both. |
