### PR TITLE
pass author dids to the two tower model call

### DIFF
--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -9,7 +9,8 @@ from ..candidates.post_similarity import (
     fetch_recent_liked_post_uris,
     knn_search_posts,
 )
-from ..embeddings import MINILM_L12_EMBEDDING_KEY
+from ..elasticsearch import fetch_post_embeddings_and_authors
+from ..embeddings import MINILM_L12_EMBEDDING_FIELD, MINILM_L12_EMBEDDING_KEY
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +154,86 @@ class TestFetchPostEmbeddings:
         })
         vecs = await fetch_post_embeddings(es, ["at://1", "at://2", "at://3"])
         assert vecs == [("at://1", [0.1, 0.2])]
+
+
+class TestFetchPostEmbeddingsAndAuthors:
+    @pytest.mark.asyncio
+    async def test_returns_embeddings_and_authors_in_requested_uri_order(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "at_uri": "at://2",
+                                "author_did": "did:plc:two",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                            }
+                        },
+                        {
+                            "_source": {
+                                "at_uri": "at://1",
+                                "author_did": "did:plc:one",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                    ]
+                }
+            }
+        })
+        vecs = await fetch_post_embeddings_and_authors(es, ["at://1", "at://2"])
+        assert vecs == [
+            ("at://1", [0.1, 0.2], "did:plc:one"),
+            ("at://2", [0.3, 0.4], "did:plc:two"),
+        ]
+        assert es.calls[0]["_source"] == [
+            "at_uri",
+            MINILM_L12_EMBEDDING_FIELD,
+            "author_did",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_keeps_posts_with_missing_author_dids(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "at_uri": "at://1",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                        {
+                            "_source": {
+                                "at_uri": "at://2",
+                                "author_did": 123,
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                            }
+                        },
+                        {
+                            "_source": {
+                                "at_uri": "at://3",
+                                "author_did": "did:plc:three",
+                                "embeddings": {},
+                            }
+                        },
+                    ]
+                }
+            }
+        })
+        vecs = await fetch_post_embeddings_and_authors(es, ["at://1", "at://2", "at://3"])
+        assert vecs == [
+            ("at://1", [0.1, 0.2], ""),
+            ("at://2", [0.3, 0.4], ""),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_input(self):
+        es = FakeEs()
+        vecs = await fetch_post_embeddings_and_authors(es, [])
+        assert vecs == []
+        assert len(es.calls) == 0
 
 
 class TestAverageVectors:

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -163,12 +163,11 @@ async def fetch_post_embeddings_and_authors(
         async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
             query = {"terms": {"at_uri": at_uris}}
 
-            source_fields = ["at_uri", MINILM_L12_EMBEDDING_FIELD, "author_did"]
             resp = await es.search(
                 index="posts",
                 query=query,
                 size=len(at_uris),
-                _source=source_fields,
+                _source=["at_uri", MINILM_L12_EMBEDDING_FIELD, "author_did"],
             )
 
             data = unwrap_es_response(resp)

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -147,7 +147,14 @@ async def fetch_post_embeddings_and_authors(
     es,
     at_uris: list[str],
 ) -> list[tuple[str, list[float], str]]:
-    """
+    """Fetch MiniLM L12 embeddings for a list of post AT URIs, as well as their author DIDs.
+
+    Returns ``(at_uri, embedding, author_did)`` triples in the same order as ``at_uris``.
+    Posts without embeddings are silently skipped.
+    Posts without author DIDs are kept, with an empty string ("") author_did.
+
+    When a request cache is active the result is memoized so repeat
+    calls within the same request share a single ES round-trip.
     """
     if not at_uris:
         return []
@@ -184,8 +191,8 @@ async def fetch_post_embeddings_and_authors(
             ordered_embeddings: list[tuple[str, list[float], str]] = []
             for at_uri in at_uris:
                 vec = embeddings_by_uri.get(at_uri)
-                author_did = author_dids_by_uri.get(at_uri)
-                if vec and author_did:
+                author_did = author_dids_by_uri.get(at_uri, "")
+                if vec:
                     ordered_embeddings.append((at_uri, vec, author_did))
             return ordered_embeddings
 

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -141,3 +141,56 @@ async def fetch_post_embeddings(
         return await _fetch()
     key = ("fetch_post_embeddings", tuple(at_uris))
     return await cache.get_or_compute(key, _fetch)
+
+
+async def fetch_post_embeddings_and_authors(
+    es,
+    at_uris: list[str],
+) -> list[tuple[str, list[float], str]]:
+    """
+    """
+    if not at_uris:
+        return []
+
+    async def _fetch() -> list[tuple[str, list[float], str]]:
+        async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
+            query = {"terms": {"at_uri": at_uris}}
+
+            source_fields = ["at_uri", MINILM_L12_EMBEDDING_FIELD, "author_did"]
+            resp = await es.search(
+                index="posts",
+                query=query,
+                size=len(at_uris),
+                _source=source_fields,
+            )
+
+            data = unwrap_es_response(resp)
+            embeddings_by_uri: dict[str, list[float]] = {}
+            author_dids_by_uri: dict[str, str] = {}
+            for hit in data.get("hits", {}).get("hits", []):
+                src = hit.get("_source") or {}
+                at_uri = src.get("at_uri")
+                if not at_uri:
+                    continue
+                emb = src.get("embeddings")
+                if isinstance(emb, dict):
+                    vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+                    if vec:
+                        embeddings_by_uri[at_uri] = vec
+                author_did = src.get("author_did")
+                if isinstance(author_did, str):
+                    author_dids_by_uri[at_uri] = author_did
+
+            ordered_embeddings: list[tuple[str, list[float], str]] = []
+            for at_uri in at_uris:
+                vec = embeddings_by_uri.get(at_uri)
+                author_did = author_dids_by_uri.get(at_uri)
+                if vec and author_did:
+                    ordered_embeddings.append((at_uri, vec, author_did))
+            return ordered_embeddings
+
+    cache = get_request_cache()
+    if cache is None:
+        return await _fetch()
+    key = ("fetch_post_embeddings_and_authors", tuple(at_uris))
+    return await cache.get_or_compute(key, _fetch)

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -11,7 +11,7 @@ import os
 
 from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerExecutionError, RankerResult
-from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
+from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings_and_authors
 from ..embeddings import decode_float32_b64
 from ..http_client import get_http_client
 from ..request_context import get_request_id
@@ -56,8 +56,19 @@ def _build_inference_headers(api_key: str) -> dict[str, str]:
     return headers
 
 
+def _raise_inference_response_error(model_type: str, status_code: int, body: str) -> None:
+    body = body.strip()
+    if len(body) > 2000:
+        body = f"{body[:2000]}..."
+    raise RankerExecutionError(
+        TWO_TOWER_MODEL_NAME,
+        f"{model_type} inference failed status={status_code} body={body}",
+    )
+
+
 async def predict_post_tower_batch(
     post_embeddings: list[list[float]],
+    author_dids: list[str],
     *,
     base_url: str,
     api_key: str,
@@ -65,16 +76,28 @@ async def predict_post_tower_batch(
     url = f"{base_url}/models/post-tower/predict"
     headers = _build_inference_headers(api_key)
 
+    if len(post_embeddings) != len(author_dids):
+        raise RankerExecutionError(
+            TWO_TOWER_MODEL_NAME,
+            f"number of post embeddings {len(post_embeddings)} does not match number of author DIDs {len(author_dids)}",
+        )
+
+    embeddings_and_authors = list(zip(post_embeddings, author_dids))
     chunks = [
-        post_embeddings[i : i + POST_TOWER_BATCH_SIZE]
+        embeddings_and_authors[i : i + POST_TOWER_BATCH_SIZE]
         for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE)
     ]
 
     client = get_http_client()
 
-    async def _call_chunk(chunk: list[list[float]]) -> list[list[float]]:
+    async def _call_chunk(chunk: list[tuple[list[float], str]]) -> list[list[float]]:
         resp = await client.post(
-            url, json={"post_embeddings": chunk}, headers=headers
+            url, 
+            json={
+                "post_embeddings": [emb for emb, _ in chunk],
+                "target_author_dids": [author_did for _, author_did in chunk]
+            },
+            headers=headers,
         )
         if resp.is_error:
             logger.error(
@@ -82,7 +105,7 @@ async def predict_post_tower_batch(
                 resp.status_code,
                 resp.text,
             )
-            resp.raise_for_status()
+            _raise_inference_response_error("post-tower", resp.status_code, resp.text)
         return resp.json()["outputs"]
 
     async with timed(
@@ -94,18 +117,28 @@ async def predict_post_tower_batch(
 
 async def predict_user_tower_single(
     history_embeddings: list[list[float]],
+    history_author_dids: list[str],
     *,
     base_url: str,
     api_key: str,
 ) -> list[list[float]]:
     url = f"{base_url}/models/user-tower/predict"
     headers = _build_inference_headers(api_key)
-    payload = {"history_embeddings": history_embeddings}
+    payload = {
+        "history_embeddings": history_embeddings,
+        "history_author_dids": history_author_dids,
+    }
 
     client = get_http_client()
     async with timed(logger, "user_tower_http", n_history=len(history_embeddings)):
         resp = await client.post(url, json=payload, headers=headers)
-    resp.raise_for_status()
+    if resp.is_error:
+        logger.error(
+            "user-tower predict failed status=%s body=%s",
+            resp.status_code,
+            resp.text,
+        )
+        _raise_inference_response_error("user-tower", resp.status_code, resp.text)
     return resp.json()["outputs"]
 
 
@@ -133,13 +166,14 @@ class TwoTowerRanker(Ranker):
         async def _compute_user_embedding() -> list[float]:
             async with timed(logger, "two_tower_user_side", user_did=user_did):
                 user_history_vectors: list[list[float]] = []
+                history_author_dids: list[str] = []
                 user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
                 if not user_history_liked_uris:
                     logger.info("No likes found for user %s", user_did)
                 else:
-                    user_history_embedding_pairs: list[tuple[str, list[float]]] = await fetch_post_embeddings(
-                        es, user_history_liked_uris
+                    user_history_embedding_pairs: list[tuple[str, list[float], str]] = await fetch_post_embeddings_and_authors(
+                        es, user_history_liked_uris,
                     )
                     if not user_history_embedding_pairs:
                         logger.info(
@@ -148,10 +182,12 @@ class TwoTowerRanker(Ranker):
                             user_did,
                         )
                     else:
-                        user_history_vectors = [embedding for _, embedding in user_history_embedding_pairs]
+                        user_history_vectors = [embedding for _, embedding, _ in user_history_embedding_pairs]
+                        history_author_dids = [author_did for _, _, author_did in user_history_embedding_pairs]
 
                 output_user_embedding_list = await predict_user_tower_single(
                     user_history_vectors,
+                    history_author_dids,
                     base_url=inference_base_url,
                     api_key=inference_api_key,
                 )
@@ -169,20 +205,20 @@ class TwoTowerRanker(Ranker):
                 logger, "two_tower_post_side", n_candidates=len(candidates_by_uri)
             ):
                 # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
-                candidate_embedding_pairs: list[tuple[str, list[float]]] = []
+                candidate_embedding_pairs: list[tuple[str, list[float], str]] = []
                 missing_uris: list[str] = []
                 for uri, candidate in candidates_by_uri.items():
-                    if candidate.minilm_l12_embedding:
+                    if candidate.minilm_l12_embedding and candidate.author_did:
                         try:
                             vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                            candidate_embedding_pairs.append((uri, vec))
+                            candidate_embedding_pairs.append((uri, vec, candidate.author_did))
                             continue
                         except Exception:
                             pass
                     missing_uris.append(uri)
 
                 if missing_uris:
-                    fetched = await fetch_post_embeddings(es, missing_uris)
+                    fetched = await fetch_post_embeddings_and_authors(es, missing_uris)
                     candidate_embedding_pairs.extend(fetched)
 
                 if not candidate_embedding_pairs:
@@ -190,15 +226,19 @@ class TwoTowerRanker(Ranker):
 
                 ranked_candidates_input = [
                     candidates_by_uri[at_uri]
-                    for at_uri, _ in candidate_embedding_pairs
+                    for at_uri, _, _ in candidate_embedding_pairs
                     if at_uri in candidates_by_uri
                 ]
                 input_post_embeddings = [
-                    embedding for _, embedding in candidate_embedding_pairs
+                    embedding for _, embedding, _ in candidate_embedding_pairs
+                ]
+                author_dids = [
+                    author_did for _, _, author_did in candidate_embedding_pairs
                 ]
 
                 output_post_embeddings = await predict_post_tower_batch(
                     input_post_embeddings,
+                    author_dids,
                     base_url=inference_base_url,
                     api_key=inference_api_key,
                 )

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -205,13 +205,13 @@ class TwoTowerRanker(Ranker):
                 logger, "two_tower_post_side", n_candidates=len(candidates_by_uri)
             ):
                 # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
-                candidate_embedding_pairs: list[tuple[str, list[float], str]] = []
+                uris_embs_authors: list[tuple[str, list[float], str]] = []
                 missing_uris: list[str] = []
                 for uri, candidate in candidates_by_uri.items():
                     if candidate.minilm_l12_embedding and candidate.author_did:
                         try:
                             vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                            candidate_embedding_pairs.append((uri, vec, candidate.author_did))
+                            uris_embs_authors.append((uri, vec, candidate.author_did))
                             continue
                         except Exception:
                             pass
@@ -219,21 +219,21 @@ class TwoTowerRanker(Ranker):
 
                 if missing_uris:
                     fetched = await fetch_post_embeddings_and_authors(es, missing_uris)
-                    candidate_embedding_pairs.extend(fetched)
+                    uris_embs_authors.extend(fetched)
 
-                if not candidate_embedding_pairs:
+                if not uris_embs_authors:
                     return None
 
                 ranked_candidates_input = [
                     candidates_by_uri[at_uri]
-                    for at_uri, _, _ in candidate_embedding_pairs
+                    for at_uri, _, _ in uris_embs_authors
                     if at_uri in candidates_by_uri
                 ]
                 input_post_embeddings = [
-                    embedding for _, embedding, _ in candidate_embedding_pairs
+                    embedding for _, embedding, _ in uris_embs_authors
                 ]
                 author_dids = [
-                    author_did for _, _, author_did in candidate_embedding_pairs
+                    author_did for _, _, author_did in uris_embs_authors
                 ]
 
                 output_post_embeddings = await predict_post_tower_batch(

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -42,21 +42,24 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
         fake_fetch_recent_liked_post_uris,
     )
 
-    async def fake_fetch_post_embeddings(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
         if at_uris == ["at://liked/1"]:
-            return [("at://liked/1", [0.5, 0.5])]
+            return [("at://liked/1", [0.5, 0.5], "did:plc:liked")]
         return [
-            ("at://post/b", [0.0, 1.0]),
-            ("at://post/a", [1.0, 0.0]),
+            ("at://post/b", [0.0, 1.0], "did:plc:b"),
+            ("at://post/a", [1.0, 0.0], "did:plc:a"),
         ]
 
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_authors", fake_fetch_post_embeddings_and_authors)
 
-    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+        assert history_embeddings == [[0.5, 0.5]]
+        assert history_author_dids == ["did:plc:liked"]
         return [[1.0, 0.0]]
 
-    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+    async def fake_predict_post_tower_batch(post_embeddings, author_dids, *, base_url, api_key):
         assert post_embeddings == [[0.0, 1.0], [1.0, 0.0]]
+        assert author_dids == ["did:plc:b", "did:plc:a"]
         return post_embeddings
 
     monkeypatch.setattr(
@@ -96,15 +99,17 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return []
 
-    async def fake_fetch_post_embeddings(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
         seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
-        return [("at://post/a", [2.0, 0.0])]
+        return [("at://post/a", [2.0, 0.0], "did:plc:a")]
 
-    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
         seen["history_embeddings"] = history_embeddings
+        seen["history_author_dids"] = history_author_dids
         return [[1.0, 0.0]]
 
-    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+    async def fake_predict_post_tower_batch(post_embeddings, author_dids, *, base_url, api_key):
+        assert author_dids == ["did:plc:a"]
         return post_embeddings
 
     monkeypatch.setattr(
@@ -112,7 +117,7 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
         "fetch_recent_liked_post_uris",
         fake_fetch_recent_liked_post_uris,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_authors", fake_fetch_post_embeddings_and_authors)
     monkeypatch.setattr(
         two_tower_module,
         "predict_user_tower_single",
@@ -129,6 +134,7 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
     )
 
     assert seen["history_embeddings"] == []
+    assert seen["history_author_dids"] == []
     assert seen["fetch_post_embeddings_calls"] == [["at://post/a"]]
     assert [ranking.model_dump() for ranking in result.result.rankings] == [
         {"at_uri": "at://post/a", "rank": 1, "rank_score": 2.0},
@@ -146,17 +152,19 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return ["at://liked/1"]
 
-    async def fake_fetch_post_embeddings(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
         seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
         if at_uris == ["at://liked/1"]:
             return []
-        return [("at://post/a", [2.0, 0.0])]
+        return [("at://post/a", [2.0, 0.0], "did:plc:a")]
 
-    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
         seen["history_embeddings"] = history_embeddings
+        seen["history_author_dids"] = history_author_dids
         return [[1.0, 0.0]]
 
-    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+    async def fake_predict_post_tower_batch(post_embeddings, author_dids, *, base_url, api_key):
+        assert author_dids == ["did:plc:a"]
         return post_embeddings
 
     monkeypatch.setattr(
@@ -164,7 +172,7 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
         "fetch_recent_liked_post_uris",
         fake_fetch_recent_liked_post_uris,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_authors", fake_fetch_post_embeddings_and_authors)
     monkeypatch.setattr(
         two_tower_module,
         "predict_user_tower_single",
@@ -181,6 +189,7 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
     )
 
     assert seen["history_embeddings"] == []
+    assert seen["history_author_dids"] == []
     assert seen["fetch_post_embeddings_calls"] == [
         ["at://liked/1"],
         ["at://post/a"],
@@ -200,13 +209,14 @@ def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missi
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return []
 
-    async def fake_fetch_post_embeddings(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
         return []
 
-    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+        assert history_author_dids == []
         return [[1.0, 0.0]]
 
-    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+    async def fake_predict_post_tower_batch(post_embeddings, author_dids, *, base_url, api_key):
         raise AssertionError("post tower should not be called without candidate embeddings")
 
     monkeypatch.setattr(
@@ -214,7 +224,7 @@ def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missi
         "fetch_recent_liked_post_uris",
         fake_fetch_recent_liked_post_uris,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_authors", fake_fetch_post_embeddings_and_authors)
     monkeypatch.setattr(
         two_tower_module,
         "predict_user_tower_single",
@@ -249,15 +259,17 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return ["at://liked/1"]
 
-    async def fake_fetch_post_embeddings(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
         if at_uris == ["at://liked/1"]:
-            return [("at://liked/1", [0.5, 0.5])]
-        return [("at://post/a", [1.0, 0.0])]
+            return [("at://liked/1", [0.5, 0.5], "did:plc:liked")]
+        return [("at://post/a", [1.0, 0.0], "did:plc:a")]
 
-    async def fake_predict_user_tower_single(history_embeddings, *, base_url, api_key):
+    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+        assert history_author_dids == ["did:plc:liked"]
         return []
 
-    async def fake_predict_post_tower_batch(post_embeddings, *, base_url, api_key):
+    async def fake_predict_post_tower_batch(post_embeddings, author_dids, *, base_url, api_key):
+        assert author_dids == ["did:plc:a"]
         return post_embeddings
 
     monkeypatch.setattr(
@@ -265,7 +277,7 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
         "fetch_recent_liked_post_uris",
         fake_fetch_recent_liked_post_uris,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings", fake_fetch_post_embeddings)
+    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_authors", fake_fetch_post_embeddings_and_authors)
     monkeypatch.setattr(
         two_tower_module,
         "predict_user_tower_single",


### PR DESCRIPTION
Closes #50 

## This PR
This update makes it so that the two tower ranker will always attempt to look up the author did of each target post and user liked history post, and pass it to the inference service (both the post tower and user tower respectively). If the author did is missing from the ES query, it passes an empty string, which will map to the "unknown" author index inside of the inference service. Note I added `fetch_post_embeddings_and_authors()` to elastcisearch.py instead of trying to extend the functionality of `fetch_post_embeddings()`. So the tradeoff is that the latter stays focused, but there is now a little bit of duplicated code, since both functions fetch the embeddings.

## Testing
Added tests and ran pytest. Ran API locally with updated inference-service successfully. Manually compared calcs for a few post embeddings, both with and without author did's, to calling the model directly.