### PR TITLE
Don't use embeddings for posts with no usable content

### DIFF
--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -111,8 +111,17 @@ async def knn_search_posts(
         candidates.append(candidate_post_from_hit(hit, generator_name=generator_name))
         if len(candidates) >= num_candidates:
             break
-
-    return candidates
+    
+    # drop candidates without embeddings
+    candidates_with_embeddings = [
+        candidate for candidate in candidates if candidate.minilm_l12_embedding
+    ]
+    if len(candidates_with_embeddings) < len(candidates):
+        logger.info(
+            "Dropped %d post-similarity candidates without embeddings",
+            len(candidates) - len(candidates_with_embeddings),
+        )
+    return candidates_with_embeddings
 
 
 class PostSimilarityCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -9,6 +9,7 @@ from ..candidates.post_similarity import (
     fetch_recent_liked_post_uris,
     knn_search_posts,
 )
+from ..candidates.utils import candidate_post_from_hit
 from ..elasticsearch import fetch_post_embeddings_and_authors
 from ..embeddings import MINILM_L12_EMBEDDING_FIELD, MINILM_L12_EMBEDDING_KEY
 
@@ -104,12 +105,14 @@ class TestFetchPostEmbeddings:
                         {
                             "_source": {
                                 "at_uri": "at://2",
+                                "content": "two",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
                             }
                         },
                         {
                             "_source": {
                                 "at_uri": "at://1",
+                                "content": "one",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
                             }
                         },
@@ -121,6 +124,11 @@ class TestFetchPostEmbeddings:
         assert vecs == [
             ("at://1", [0.1, 0.2]),
             ("at://2", [0.3, 0.4]),
+        ]
+        assert es.calls[0]["_source"] == [
+            "at_uri",
+            MINILM_L12_EMBEDDING_FIELD,
+            "content",
         ]
 
     @pytest.mark.asyncio
@@ -139,6 +147,7 @@ class TestFetchPostEmbeddings:
                         {
                             "_source": {
                                 "at_uri": "at://1",
+                                "content": "one",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
                             }
                         },
@@ -156,6 +165,37 @@ class TestFetchPostEmbeddings:
         vecs = await fetch_post_embeddings(es, ["at://1", "at://2", "at://3"])
         assert vecs == [("at://1", [0.1, 0.2])]
 
+    @pytest.mark.asyncio
+    async def test_skips_embeddings_without_source_text(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "at_uri": "at://1",
+                                "content": "one",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                        {
+                            "_source": {
+                                "at_uri": "at://2",
+                                "content": "   ",
+                                "media": [{"alt_text": ""}],
+                                "video_transcript": None,
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                            }
+                        },
+                    ]
+                }
+            }
+        })
+        vecs = await fetch_post_embeddings(es, ["at://1", "at://2", "at://3"])
+        assert vecs == [
+            ("at://1", [0.1, 0.2]),
+        ]
+
 
 class TestFetchPostEmbeddingsAndAuthors:
     @pytest.mark.asyncio
@@ -168,6 +208,7 @@ class TestFetchPostEmbeddingsAndAuthors:
                             "_source": {
                                 "at_uri": "at://2",
                                 "author_did": "did:plc:two",
+                                "content": "two",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
                             }
                         },
@@ -175,6 +216,7 @@ class TestFetchPostEmbeddingsAndAuthors:
                             "_source": {
                                 "at_uri": "at://1",
                                 "author_did": "did:plc:one",
+                                "content": "one",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
                             }
                         },
@@ -191,6 +233,7 @@ class TestFetchPostEmbeddingsAndAuthors:
             "at_uri",
             MINILM_L12_EMBEDDING_FIELD,
             "author_did",
+            "content",
         ]
 
     @pytest.mark.asyncio
@@ -202,6 +245,7 @@ class TestFetchPostEmbeddingsAndAuthors:
                         {
                             "_source": {
                                 "at_uri": "at://1",
+                                "content": "one",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
                             }
                         },
@@ -209,6 +253,7 @@ class TestFetchPostEmbeddingsAndAuthors:
                             "_source": {
                                 "at_uri": "at://2",
                                 "author_did": 123,
+                                "content": "two",
                                 "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
                             }
                         },
@@ -230,11 +275,66 @@ class TestFetchPostEmbeddingsAndAuthors:
         ]
 
     @pytest.mark.asyncio
+    async def test_skips_embeddings_without_source_text_even_with_author_did(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_source": {
+                                "at_uri": "at://1",
+                                "author_did": "did:plc:one",
+                                "content": "some content",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                        {
+                            "_source": {
+                                "at_uri": "at://2",
+                                "author_did": "did:plc:two",
+                                "content": "",
+                                "media": [{"alt_text": "   "}],
+                                "video_transcript": "",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                            }
+                        },
+                    ]
+                }
+            }
+        })
+        vecs = await fetch_post_embeddings_and_authors(es, ["at://1", "at://2"])
+        assert vecs == [("at://1", [0.1, 0.2], "did:plc:one")]
+
+    @pytest.mark.asyncio
     async def test_returns_empty_for_empty_input(self):
         es = FakeEs()
         vecs = await fetch_post_embeddings_and_authors(es, [])
         assert vecs == []
         assert len(es.calls) == 0
+
+
+class TestCandidatePostFromHit:
+    def test_keeps_embedding_with_content_source(self):
+        candidate = candidate_post_from_hit({
+            "_source": {
+                "at_uri": "at://post/1",
+                "content": "hello",
+                "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+            }
+        })
+        assert candidate.minilm_l12_embedding is not None
+
+    def test_strips_embedding_without_nonblank_source_text(self):
+        candidate = candidate_post_from_hit({
+            "_source": {
+                "at_uri": "at://post/1",
+                "content": "   ",
+                "media": [{"alt_text": ""}, {"alt_text": "  "}, "bad"],
+                "video_transcript": 123,
+                "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+            }
+        })
+        assert candidate.minilm_l12_embedding is None
 
 
 class TestAverageVectors:
@@ -463,12 +563,14 @@ class TestPostSimilarityGenerator:
                                     {
                                         "_source": {
                                             "at_uri": "at://post/2",
+                                            "content": "liked post two",
                                             "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
                                         }
                                     },
                                     {
                                         "_source": {
                                             "at_uri": "at://post/1",
+                                            "content": "liked post one",
                                             "embeddings": {MINILM_L12_EMBEDDING_KEY: [1.0, 0.0]},
                                         }
                                     },

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -462,6 +462,7 @@ class TestKnnSearchPosts:
                             "_source": {
                                 "at_uri": "at://post/1",
                                 "content": "original",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
                             },
                         },
                         {
@@ -470,6 +471,7 @@ class TestKnnSearchPosts:
                                 "at_uri": "at://post/2",
                                 "content": "reply",
                                 "thread_parent_post": "at://parent/x",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
                             },
                         },
                         {
@@ -477,6 +479,7 @@ class TestKnnSearchPosts:
                             "_source": {
                                 "at_uri": "at://post/3",
                                 "content": "another original",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
                             },
                         },
                     ]
@@ -492,9 +495,32 @@ class TestKnnSearchPosts:
             "posts_recent": {
                 "hits": {
                     "hits": [
-                        {"_score": 0.9, "_source": {"at_uri": "at://a", "contains_video": True}},
-                        {"_score": 0.8, "_source": {"at_uri": "at://b"}},
-                        {"_score": 0.7, "_source": {"at_uri": "at://c", "contains_video": True}},
+                        {
+                            "_score": 0.9,
+                            "_source": {
+                                "at_uri": "at://a",
+                                "content": "some content",
+                                "contains_video": True,
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                        {
+                            "_score": 0.8,
+                            "_source": {
+                                "at_uri": "at://b",
+                                "content": "some content",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
+                        {
+                            "_score": 0.7,
+                            "_source": {
+                                "at_uri": "at://c",
+                                "content": "some content",
+                                "contains_video": True,
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            }
+                        },
                     ]
                 }
             }
@@ -519,7 +545,14 @@ class TestKnnSearchPosts:
             "posts_recent": {
                 "hits": {
                     "hits": [
-                        {"_score": 1.0 - i / 100, "_source": {"at_uri": f"at://p/{i}"}}
+                        {
+                            "_score": 1.0 - i / 100,
+                            "_source": {
+                                "at_uri": f"at://p/{i}",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                "content": "some content",
+                            }
+                        }
                         for i in range(20)
                     ]
                 }

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -278,6 +278,35 @@ class TestKnnSearchPosts:
         assert candidates[0].generator_name is None
 
     @pytest.mark.asyncio
+    async def test_drops_candidates_without_embeddings(self):
+        es = FakeEs(responses={
+            "posts_recent": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_score": 0.95,
+                            "_source": {
+                                "at_uri": "at://post/1",
+                                "content": "hello",
+                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                            },
+                        },
+                        {
+                            "_score": 0.8,
+                            "_source": {
+                                "at_uri": "at://post/2",
+                                "content": "missing embedding",
+                            },
+                        },
+                    ]
+                }
+            }
+        })
+        candidates = await knn_search_posts(es, [0.1, 0.2], num_candidates=10)
+        assert len(candidates) == 1
+        assert candidates[0].at_uri == "at://post/1"
+
+    @pytest.mark.asyncio
     async def test_passes_generator_name(self):
         es = FakeEs(responses={
             "posts_recent": {

--- a/src/app/lib/candidates/utils.py
+++ b/src/app/lib/candidates/utils.py
@@ -1,5 +1,5 @@
 from ...models import CandidatePost
-from ..elasticsearch import unwrap_es_response
+from ..elasticsearch import post_has_embedding_source, unwrap_es_response
 from ..embeddings import MINILM_L12_EMBEDDING_KEY, encode_float32_b64
 
 
@@ -44,7 +44,7 @@ def candidate_post_from_hit(
     )
 
     encoded = None
-    if l12 is not None:
+    if l12 is not None and post_has_embedding_source(src):
         try:
             encoded = encode_float32_b64(l12)
         except Exception:

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -22,6 +22,20 @@ DEFAULT_LIKED_POSTS_LIMIT = 50
 POSTS_KNN_INDEX = "posts_recent"
 
 
+POST_EMBEDDING_SOURCE_FIELDS = [ "content" ]
+
+
+def _has_nonblank_string(value) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def post_has_embedding_source(src: dict) -> bool:
+    """Return whether a post has source text that can justify an embedding."""
+    if _has_nonblank_string(src.get("content")):
+        return True
+    return False
+
+
 def unwrap_es_response(resp) -> dict:
     """Unwrap an Elasticsearch response, handling both ObjectApiResponse and dict.
 
@@ -97,7 +111,7 @@ async def fetch_post_embeddings(
     """Fetch MiniLM L12 embeddings for a list of post AT URIs.
 
     Returns ``(at_uri, embedding)`` pairs in the same order as ``at_uris``.
-    Posts without embeddings are silently skipped.
+    Posts without embeddings or embedding source text are silently skipped.
 
     When a request cache is active the result is memoized so repeat
     calls within the same request share a single ES round-trip.
@@ -113,7 +127,11 @@ async def fetch_post_embeddings(
                 index="posts",
                 query=query,
                 size=len(at_uris),
-                _source=["at_uri", MINILM_L12_EMBEDDING_FIELD],
+                _source=[
+                    "at_uri",
+                    MINILM_L12_EMBEDDING_FIELD,
+                    *POST_EMBEDDING_SOURCE_FIELDS,
+                ],
             )
 
             data = unwrap_es_response(resp)
@@ -122,6 +140,8 @@ async def fetch_post_embeddings(
                 src = hit.get("_source") or {}
                 at_uri = src.get("at_uri")
                 if not at_uri:
+                    continue
+                if not post_has_embedding_source(src):
                     continue
                 emb = src.get("embeddings")
                 if isinstance(emb, dict):
@@ -150,7 +170,7 @@ async def fetch_post_embeddings_and_authors(
     """Fetch MiniLM L12 embeddings for a list of post AT URIs, as well as their author DIDs.
 
     Returns ``(at_uri, embedding, author_did)`` triples in the same order as ``at_uris``.
-    Posts without embeddings are silently skipped.
+    Posts without embeddings or embedding source text are silently skipped.
     Posts without author DIDs are kept, with an empty string ("") author_did.
 
     When a request cache is active the result is memoized so repeat
@@ -167,7 +187,12 @@ async def fetch_post_embeddings_and_authors(
                 index="posts",
                 query=query,
                 size=len(at_uris),
-                _source=["at_uri", MINILM_L12_EMBEDDING_FIELD, "author_did"],
+                _source=[
+                    "at_uri",
+                    MINILM_L12_EMBEDDING_FIELD,
+                    "author_did",
+                    *POST_EMBEDDING_SOURCE_FIELDS,
+                ],
             )
 
             data = unwrap_es_response(resp)
@@ -177,6 +202,8 @@ async def fetch_post_embeddings_and_authors(
                 src = hit.get("_source") or {}
                 at_uri = src.get("at_uri")
                 if not at_uri:
+                    continue
+                if not post_has_embedding_source(src):
                     continue
                 emb = src.get("embeddings")
                 if isinstance(emb, dict):

--- a/src/app/routers/candidates_test.py
+++ b/src/app/routers/candidates_test.py
@@ -36,12 +36,14 @@ def fake_app_es():
                                 {
                                     "_source": {
                                         "at_uri": "at://post/2",
+                                        "content": "liked post two",
                                         "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
                                     }
                                 },
                                 {
                                     "_source": {
                                         "at_uri": "at://post/1",
+                                        "content": "liked post one",
                                         "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
                                     }
                                 },


### PR DESCRIPTION
Closes #109 

We have some posts with embeddings but no usable content. We were told by Graze that embeddings could be based on `media.alt_text` or `video_transcript` - but in practice this does not seem to be true: posts without the `content` field but one of those other two (or `external_embed.description`) seem to have meaningless embeddings. So let's not use them as a result of post similarity candidate generation, and let's not pass those embeddings to the ranking stage. See below for the distribution of posts by the 5 fields. Thankfully, about 96% of posts have something in the `content` field and also have embeddings. 

Changes:
- The post similarity candidate generator now will no longer return posts without embeddings.
- For the other candidate generators (which use utils.py:candidate_posts_from_es_response() ), it will not attach an embedding if the `content` field is missing or empty.
- For fetch_post_embeddings() (used by post_similarity) and fetch_post_embeddings_and_authors() (used by two_tower), posts with embeddings but no `content` field will not be returned (those functions already do not return posts with missing embeddings). 

<img width="1163" height="299" alt="Screenshot 2026-06-02 at 2 22 14 PM" src="https://github.com/user-attachments/assets/db1ada15-623e-45a4-8e36-3bbb3b3da7c5" />