### PR TITLE
Add pyright/Pylance type checking to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,5 +26,8 @@ jobs:
     - name: Install dependencies
       run: pipenv install --dev
 
+    - name: Type check (pyright)
+      run: pipenv run pyright
+
     - name: Run tests
       run: pipenv run pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ ignore = []
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.pyright]
+include = ["src"]
+pythonVersion = "3.13"
+typeCheckingMode = "standard"

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -91,6 +91,7 @@ class FakeEs:
             return likes_response([])
 
         if index == "posts":
+            assert query is not None
             requested_uris = post_terms_from_query(query)
             return_order = self.posts_return_order or requested_uris
             hits = [

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -219,9 +219,12 @@ def test_raw_similarity_agrees_with_similarity_for_same_inputs():
     vec_b = [4.0, 3.0]
     a = _post_with_embed("at://a/1", 1.0, "did:plc:alice", vec_a)
     b = _post_with_embed("at://b/1", 0.9, "did:plc:bob", vec_b)
+    a_emb = a.minilm_l12_embedding
+    b_emb = b.minilm_l12_embedding
+    assert a_emb is not None and b_emb is not None
     from .embeddings import decode_float32_b64
     assert _raw_similarity(
         a.author_did, b.author_did,
-        decode_float32_b64(a.minilm_l12_embedding),
-        decode_float32_b64(b.minilm_l12_embedding),
+        decode_float32_b64(a_emb),
+        decode_float32_b64(b_emb),
     ) == pytest.approx(_similarity(a, b), rel=1e-6)

--- a/src/app/lib/rankers/predict_test.py
+++ b/src/app/lib/rankers/predict_test.py
@@ -86,7 +86,7 @@ def test_run_predict_preserves_duplicate_candidates(monkeypatch):
 
 def test_rank_predict_request_requires_user_did():
     with pytest.raises(ValidationError, match="user_did"):
-        RankPredictRequest(
+        RankPredictRequest(  # pyright: ignore[reportCallIssue]
             model="two_tower",
             candidates=[CandidatePost(at_uri="at://post/1", score=0.5)],
         )

--- a/src/app/routers/rank_test.py
+++ b/src/app/routers/rank_test.py
@@ -180,7 +180,7 @@ def test_rank_predict_maps_ranker_execution_error_to_502(monkeypatch):
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        asyncio.run(rank_module.rank_predict(request, payload))
+        asyncio.run(rank_module.rank_predict(request, payload))  # pyright: ignore[reportArgumentType]
 
     assert exc_info.value.status_code == 502
     assert exc_info.value.detail == "Ranker 'two_tower' failed: downstream boom"


### PR DESCRIPTION
We have types in our code, but nothing that makes sure they're correct. So naturally there were errors, which I kept seeing in vscode.

Adds pyright in standard mode to the Python CI workflow so type errors are caught on every PR. Fixes the handful of pre-existing errors in test files that were exposed once checking was enforced.

