### PR TITLE
Add feed context secret to setup/deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -208,12 +208,14 @@ deploy_api_service() {
     local inference_api_key_secret="inference-api-key-stage"
     local api_key_secret="api-key"
     local firestore_api_key_secret="firestore-api-key-stage"
+    local feed_context_secret="feed-context-secret-stage"
     local firestore_database="greenearth-stage"
     if [ "$ENVIRONMENT" = "prod" ]; then
         es_api_key_secret="elasticsearch-api-key-readonly-prod"
         inference_api_key_secret="inference-api-key-prod"
         api_key_secret="api-key-prod"
         firestore_api_key_secret="firestore-api-key-prod"
+        feed_context_secret="feed-context-secret-prod"
         firestore_database="greenearth-prod"
     fi
 
@@ -246,6 +248,7 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-secrets=GE_INFERENCE_API_KEY=$inference_api_key_secret:latest"
     deploy_cmd="$deploy_cmd --set-secrets=API_KEY=$api_key_secret:latest"
     deploy_cmd="$deploy_cmd --set-secrets=GE_FIRESTORE_API_KEY=$firestore_api_key_secret:latest"
+    deploy_cmd="$deploy_cmd --set-secrets=GE_FEED_CONTEXT_SECRET=$feed_context_secret:latest"
 
     # Resource and scaling configuration
     deploy_cmd="$deploy_cmd --min-instances=$API_INSTANCES_MIN"

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -144,6 +144,14 @@ get_inference_api_key_secret() {
     fi
 }
 
+get_feed_context_secret() {
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        echo "feed-context-secret-prod"
+    else
+        echo "feed-context-secret-stage"
+    fi
+}
+
 ensure_firestore_database() {
     local firestore_db
     firestore_db="$(get_firestore_database)"
@@ -271,6 +279,32 @@ ensure_inference_api_key_secret_access() {
         --member="serviceAccount:$sa_email" \
         --role="roles/secretmanager.secretAccessor" \
         --condition=None > /dev/null 2>&1 || log_info "Service account already has access to $inference_secret"
+}
+
+ensure_feed_context_secret() {
+    # The feed context secret signs the feedContext tokens we embed in feed
+    # skeletons and verify when interactions come back via sendInteractions.
+    # If the secret already exists we leave its value alone -- rotating it would
+    # invalidate any in-flight tokens already in client apps.
+    local sa_email="api-runner-$ENVIRONMENT@$PROJECT_ID.iam.gserviceaccount.com"
+    local key_secret
+    key_secret="$(get_feed_context_secret)"
+
+    log_info "Ensuring feed context secret exists: $key_secret"
+
+    if ! gcloud secrets describe "$key_secret" > /dev/null 2>&1; then
+        local value
+        value=$(openssl rand -hex 32)
+        echo -n "$value" | gcloud secrets create "$key_secret" --data-file=-
+        log_info "Feed context secret created: $key_secret"
+    else
+        log_info "Feed context secret already exists: $key_secret (preserving value)"
+    fi
+
+    gcloud secrets add-iam-policy-binding "$key_secret" \
+        --member="serviceAccount:$sa_email" \
+        --role="roles/secretmanager.secretAccessor" \
+        --condition=None > /dev/null 2>&1 || log_info "Service account already has access to $key_secret"
 }
 
 create_service_account() {
@@ -501,6 +535,7 @@ main() {
     ensure_feed_cache_ttl_policy
     ensure_firestore_api_key_secret
     ensure_inference_api_key_secret_access
+    ensure_feed_context_secret
 
     # Fetch ES API key from K8s unless disabled or already provided
     if [ "$FETCH_ES_KEY" = true ] && [ -z "$GE_ELASTICSEARCH_API_KEY" ]; then


### PR DESCRIPTION
I forgot to add feed context secret creation/deployment to the sendInteractions PR. Here's that last bit.