### PR TITLE
Candidate generation only feeds for testing

### DIFF
--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -214,7 +214,7 @@ class TestPublishFeed:
         record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
         assert record["$type"] == "app.bsky.feed.generator"
         assert record["did"] == GENERATOR_DID
-        assert record["displayName"] == "Unranked Your Feed"  # from FEEDS config
+        assert record["displayName"] == "Unranked YF"  # from FEEDS config
 
         captured = capsys.readouterr()
         assert "Published feed record:" in captured.out
@@ -294,7 +294,7 @@ class TestPublishFeed:
 
         put_call = client.post.call_args_list[1]
         record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
-        assert record["displayName"] == "GE Stg Unranked Your Feed"
+        assert record["displayName"] == "GE Stg Unranked YF"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -36,7 +36,7 @@ PDS = "https://pds.example.com"
 REPO_DID = "did:plc:alice123"
 ACCESS_JWT = "fake-jwt-token"
 GENERATOR_DID = "did:web:feed.example.com"
-FEED_NAME = "basic-similarity"
+FEED_NAME = "unranked-your-feed"
 
 SESSION_RESPONSE = {"did": REPO_DID, "accessJwt": ACCESS_JWT}
 
@@ -214,7 +214,7 @@ class TestPublishFeed:
         record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
         assert record["$type"] == "app.bsky.feed.generator"
         assert record["did"] == GENERATOR_DID
-        assert record["displayName"] == "Similarity"  # from FEEDS config
+        assert record["displayName"] == "Unranked Your Feed"  # from FEEDS config
 
         captured = capsys.readouterr()
         assert "Published feed record:" in captured.out
@@ -294,7 +294,7 @@ class TestPublishFeed:
 
         put_call = client.post.call_args_list[1]
         record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
-        assert record["displayName"] == "GE Stg Similarity"
+        assert record["displayName"] == "GE Stg Unranked Your Feed"
 
 
 # ---------------------------------------------------------------------------
@@ -624,7 +624,7 @@ class TestSyncFeeds:
         )
 
         captured = capsys.readouterr()
-        assert "Published: basic-similarity" in captured.out
+        assert "Published: unranked-your-feed" in captured.out
         assert "Published: random" in captured.out
         assert "Best of Friends" in captured.out
         assert "Deleted stale: old-feed" in captured.out
@@ -705,7 +705,7 @@ class TestResolveFeedPublishParams:
         return FEEDS["best-of-friends"]
 
     def _internal_feed(self):
-        return FEEDS["basic-similarity"]
+        return FEEDS["unranked-your-feed"]
 
     def test_prod_public_uses_greenearth_path(self):
         feed = self._public_feed()
@@ -716,7 +716,7 @@ class TestResolveFeedPublishParams:
 
     def test_prod_internal_uses_caterpie_path(self):
         feed = self._internal_feed()
-        rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "prod")
+        rkey, name, desc = _resolve_feed_publish_params("unranked-your-feed", feed, "prod")
         assert rkey == feed.internal_rkey
         assert name == feed.internal_display_name
         assert desc == "Built by Caterpie"
@@ -730,7 +730,7 @@ class TestResolveFeedPublishParams:
 
     def test_stage_any_uses_caterpie_with_ge_prefix(self):
         feed = self._internal_feed()
-        rkey, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "stage")
+        rkey, name, desc = _resolve_feed_publish_params("unranked-your-feed", feed, "stage")
         assert rkey == feed.internal_rkey
         assert name.startswith("GE ")
         assert desc == "Built by Caterpie"
@@ -749,8 +749,8 @@ class TestSearchability:
         assert "greenearth" in desc.lower()
 
     def test_caterpie_display_name_excludes_original(self):
-        feed = FEEDS["basic-similarity"]
-        _, name, desc = _resolve_feed_publish_params("basic-similarity", feed, "prod")
+        feed = FEEDS["unranked-your-feed"]
+        _, name, desc = _resolve_feed_publish_params("unranked-your-feed", feed, "prod")
         assert feed.display_name not in name
         assert desc == "Built by Caterpie"
 

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -17,7 +17,7 @@ from .models import CandidateGenerateRequest, FeedConfig, GeneratorSpec, RankPre
 # NOTE: display_name is limited to 24 chars, including the prefix ("GreenEarth, GE Dev, or GE Stg")
 FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
-        display_name="Unranked Your Feed",
+        display_name="Unranked YF",
         description="Development feed — post-similarity and followed-users candidate with popularity infill. No ranking.",
         internal_rkey="e2-uyf",
         internal_display_name="e2 UYF",

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -18,7 +18,7 @@ from .models import CandidateGenerateRequest, FeedConfig, GeneratorSpec, RankPre
 FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
         display_name="Unranked Your Feed",
-        description="Development feed — post similarity and followed users candidate generation with popularity infill. No ranking.",
+        description="Development feed — post-similarity and followed-users candidate with popularity infill. No ranking.",
         internal_rkey="e2-uyf",
         internal_display_name="e2 UYF",
         gen_request_template=CandidateGenerateRequest.model_construct(

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -23,8 +23,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="e2 S",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="post_similarity", weight=0.5),
-                GeneratorSpec(name="followed_users", weight=0.5),
+                GeneratorSpec(name="post_similarity", weight=1.0),
             ],
             infill="popularity",
             num_candidates=30,
@@ -82,6 +81,68 @@ FEEDS: dict[str, FeedConfig] = {
         ),
         rank_request_template=RankPredictRequest.model_construct(
             model="two_tower",
+        ),
+    ),
+
+    ### (Private) Pure Candidate Generator Feeds, mostly for testing and debugging ###
+    "post-similarity": FeedConfig(
+        display_name="Post Similarity",
+        description="Development feed — post-similarity candidates only.",
+        internal_rkey="gh-ps",
+        internal_display_name="gh PS",
+        diversify=False,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="post_similarity", weight=1.0),
+            ],
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
+        ),
+    ),
+    "followed-users": FeedConfig(
+        display_name="Followed Users",
+        description="Development feed — followed-users candidates only.",
+        internal_rkey="ij-fu",
+        internal_display_name="ij FU",
+        diversify=False,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="followed_users", weight=1.0),
+            ],
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
+        ),
+    ),
+    "network-likes": FeedConfig(
+        display_name="Network Likes",
+        description="Development feed — network-likes candidates only.",
+        internal_rkey="kl-nl",
+        internal_display_name="kl NL",
+        diversify=False,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="network_likes", weight=1.0),
+            ],
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
+        ),
+    ),
+    "popularity": FeedConfig(
+        display_name="Popularity",
+        description="Development feed — popularity candidates only.",
+        internal_rkey="mn-p",
+        internal_display_name="mn P",
+        diversify=False,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="popularity", weight=1.0),
+            ],
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
         ),
     ),
 }

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -19,8 +19,8 @@ FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
         display_name="Unranked YF",
         description="Development feed — post-similarity and followed-users candidate with popularity infill. No ranking.",
-        internal_rkey="e2-uyf",
-        internal_display_name="e2 UYF",
+        internal_rkey="e2-s",
+        internal_display_name="e2 S",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=0.5),

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -16,14 +16,15 @@ from .models import CandidateGenerateRequest, FeedConfig, GeneratorSpec, RankPre
 
 # NOTE: display_name is limited to 24 chars, including the prefix ("GreenEarth, GE Dev, or GE Stg")
 FEEDS: dict[str, FeedConfig] = {
-    "basic-similarity": FeedConfig(
-        display_name="Similarity",
-        description="Development feed — post-similarity candidates with popularity infill.",
-        internal_rkey="e2-s",
-        internal_display_name="e2 S",
+    "unranked-your-feed": FeedConfig(
+        display_name="Unranked Your Feed",
+        description="Development feed — post similarity and followed users candidate generation with popularity infill. No ranking.",
+        internal_rkey="e2-uyf",
+        internal_display_name="e2 UYF",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="post_similarity", weight=1.0),
+                GeneratorSpec(name="post_similarity", weight=0.5),
+                GeneratorSpec(name="followed_users", weight=0.5),
             ],
             infill="popularity",
             num_candidates=30,

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -1,5 +1,12 @@
 from app.feeds import FEEDS
 
+CANDIDATE_ONLY_FEEDS = {
+    "post-similarity": "post_similarity",
+    "followed-users": "followed_users",
+    "network-likes": "network_likes",
+    "popularity": "popularity",
+}
+
 
 class TestFeedsRegistry:
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
@@ -11,3 +18,13 @@ class TestFeedsRegistry:
         }
         overlap = primary_rkeys & internal_rkeys
         assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"
+
+    def test_candidate_only_feeds_are_direct_unranked_generators(self):
+        for feed_name, generator_name in CANDIDATE_ONLY_FEEDS.items():
+            cfg = FEEDS[feed_name]
+            generators = cfg.gen_request_template.generators
+            assert len(generators) == 1
+            assert generators[0].name == generator_name
+            assert cfg.gen_request_template.infill is None
+            assert cfg.rank_request_template is None
+            assert cfg.diversify is False

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -26,7 +26,7 @@ from ..lib.firestore import (
 
 USER_DID = "did:plc:testuser123"
 USERNAME = "testuser.bsky.app"
-FEED_NAME = "basic-similarity"
+FEED_NAME = "unranked-your-feed"
 
 
 def _mock_feed_activity_client():

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -29,6 +29,12 @@ BEST_OF_FRIENDS_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{BEST_OF
 # The AppView sends the publisher DID in the feed URI, not the service DID.
 FEED_URI_FROM_APPVIEW = f"at://{PUBLISHER_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 TEST_USERNAME = "testuser.bsky.app"
+CANDIDATE_ONLY_FEEDS = (
+    ("post-similarity", "post_similarity"),
+    ("followed-users", "followed_users"),
+    ("network-likes", "network_likes"),
+    ("popularity", "popularity"),
+)
 
 
 def _make_candidates(prefix: str, n: int, generator_name: str = "test") -> list[CandidatePost]:
@@ -223,6 +229,12 @@ class TestDescribeFeedGenerator:
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
         uris = [f["uri"] for f in data["feeds"]]
         assert BEST_OF_FRIENDS_FEED_URI in uris
+
+    @pytest.mark.parametrize("feed_name", [feed_name for feed_name, _ in CANDIDATE_ONLY_FEEDS])
+    def test_feeds_list_contains_candidate_only_feed(self, feed_name):
+        data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
+        uris = [f["uri"] for f in data["feeds"]]
+        assert f"at://{SERVICE_DID}/app.bsky.feed.generator/{feed_name}" in uris
 
     def test_feeds_list_length(self):
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
@@ -491,6 +503,65 @@ class TestGetFeedSkeleton:
             data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
         assert len(data["feed"]) == 1
         assert data["feed"][0]["post"] == "at://good/1"
+
+
+# ---------------------------------------------------------------------------
+# Candidate-generator-only feeds
+# ---------------------------------------------------------------------------
+
+class TestCandidateGeneratorOnlyFeeds:
+    """Tests for private feeds that expose one candidate generator directly."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_authenticated_user(self):
+        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_firestore_upsert(self):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+            yield
+
+    @pytest.mark.parametrize("feed_name,expected_generator", CANDIDATE_ONLY_FEEDS)
+    def test_routes_to_expected_generator(self, feed_name, expected_generator):
+        generator_mocks = {}
+        for _, generator_name in CANDIDATE_ONLY_FEEDS:
+            gen = AsyncMock()
+            gen.generate.return_value = CandidateResult(
+                generator_name=generator_name,
+                candidates=[
+                    CandidatePost(
+                        at_uri=f"at://{generator_name}/{i}",
+                        content=f"post {i}",
+                        minilm_l12_embedding="fake-embedding",
+                        score=None,
+                        generator_name=generator_name,
+                    )
+                    for i in range(2)
+                ],
+            )
+            generator_mocks[generator_name] = gen
+
+        with patch(
+            "app.lib.candidates.generate.get_generator",
+            side_effect=lambda name: generator_mocks.get(name),
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={
+                    "feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/{feed_name}",
+                    "limit": 3,
+                },
+            )
+
+        assert resp.status_code == 200
+        posts = [item["post"] for item in resp.json()["feed"]]
+        assert posts == [f"at://{expected_generator}/0", f"at://{expected_generator}/1"]
+        generator_mocks[expected_generator].generate.assert_awaited_once()
+        for generator_name, gen in generator_mocks.items():
+            if generator_name != expected_generator:
+                gen.generate.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -420,24 +420,6 @@ class TestGetFeedSkeleton:
         infill_gen = mock_get.side_effect("popularity")
         infill_gen.generate.assert_not_called()
 
-    def test_basic_similarity_uses_followed_users_generator(self):
-        similarity = _make_candidates("sim", 3, "post_similarity")
-        followed = _make_candidates("followed", 3, "followed_users")
-
-        with _patch_basic_similarity_generators(
-            similarity,
-            followed_users_candidates=followed,
-        ) as mock_get:
-            data = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton",
-                params={"feed": FEED_URI, "limit": 6},
-            ).json()
-
-        posts = [item["post"] for item in data["feed"]]
-        assert "at://sim/0" in posts
-        assert "at://followed/0" in posts
-        mock_get.side_effect("followed_users").generate.assert_awaited_once()
-
     # --- primary generator failure ---
 
     def test_primary_failure_falls_back_to_infill(self):

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -787,15 +787,10 @@ class TestFeedSkeletonCursor:
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[],
         )
-        followed_users_gen = AsyncMock()
-        followed_users_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
-        )
 
         def fake_get(name):
             return {
                 "post_similarity": primary_gen,
-                "followed_users": followed_users_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -809,10 +804,6 @@ class TestFeedSkeletonCursor:
         # containing the 5 initial URIs.
         call_kwargs = primary_gen.generate.call_args
         assert call_kwargs.kwargs.get("exclude_uris") == [
-            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
-        ]
-        followed_call_kwargs = followed_users_gen.generate.call_args
-        assert followed_call_kwargs.kwargs.get("exclude_uris") == [
             "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
         ]
 

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -44,12 +44,12 @@ def _make_candidates(prefix: str, n: int, generator_name: str = "test") -> list[
     ]
 
 
-def _patch_basic_similarity_generators(
+def _patch_unranked_your_feed_generators(
     post_similarity_candidates,
     followed_users_candidates=None,
     infill_candidates=None,
 ):
-    """Patch generators used by the basic-similarity feed.
+    """Patch generators used by the unranked-your-feed feed.
 
     Most tests care about feed endpoint behavior rather than the exact mix of
     candidate sources, so followed_users defaults to the same candidates as
@@ -210,7 +210,7 @@ class TestDescribeFeedGenerator:
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
         assert data["did"] == SERVICE_DID
 
-    def test_feeds_list_contains_basic_similarity(self):
+    def test_feeds_list_contains_unranked_your_feed(self):
         data = client.get("/xrpc/app.bsky.feed.describeFeedGenerator").json()
         uris = [f["uri"] for f in data["feeds"]]
         assert FEED_URI in uris
@@ -267,7 +267,7 @@ class TestGetFeedSkeleton:
         ``primary_candidates`` and ``infill_candidates`` are lists of
         ``CandidatePost`` (or ``None`` to simulate an unregistered generator).
         """
-        return _patch_basic_similarity_generators(
+        return _patch_unranked_your_feed_generators(
             primary_candidates,
             infill_candidates=infill_candidates,
         )
@@ -432,11 +432,11 @@ class TestGetFeedSkeleton:
         infill_gen = mock_get.side_effect("popularity")
         infill_gen.generate.assert_not_called()
 
-    def test_basic_similarity_uses_followed_users_generator(self):
+    def test_unranked_your_feed_uses_followed_users_generator(self):
         similarity = _make_candidates("sim", 3, "post_similarity")
         followed = _make_candidates("followed", 3, "followed_users")
 
-        with _patch_basic_similarity_generators(
+        with _patch_unranked_your_feed_generators(
             similarity,
             followed_users_candidates=followed,
         ) as mock_get:
@@ -601,7 +601,7 @@ class TestFeedSkeletonCursor:
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
-        return _patch_basic_similarity_generators(
+        return _patch_unranked_your_feed_generators(
             primary_candidates,
             infill_candidates=infill_candidates,
         )
@@ -909,7 +909,7 @@ class TestGetFeedSkeletonAuth:
     """Tests that getFeedSkeleton correctly passes through the authenticated DID."""
 
     def _patch_generators(self, primary_candidates):
-        return _patch_basic_similarity_generators(primary_candidates)
+        return _patch_unranked_your_feed_generators(primary_candidates)
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -18,7 +18,7 @@ from ..lib.feed_cache import FeedCache
 
 SERVICE_DID = "did:web:test.example.com"
 PUBLISHER_DID = "did:plc:publisherabc123"
-FEED_RKEY = "basic-similarity"
+FEED_RKEY = "unranked-your-feed"
 FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{FEED_RKEY}"
 RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
@@ -328,7 +328,7 @@ class TestGetFeedSkeleton:
 
     def test_matches_feed_by_internal_rkey(self):
         """Feeds published under their Caterpie internal_rkey are still served."""
-        feed_cfg = FEEDS["basic-similarity"]
+        feed_cfg = FEEDS["unranked-your-feed"]
         internal_uri = f"at://{SERVICE_DID}/app.bsky.feed.generator/{feed_cfg.internal_rkey}"
         with self._patch_generators(_make_candidates("p", 2)):
             resp = client.get(
@@ -431,6 +431,24 @@ class TestGetFeedSkeleton:
         # Infill generator's generate method should not have been called
         infill_gen = mock_get.side_effect("popularity")
         infill_gen.generate.assert_not_called()
+
+    def test_basic_similarity_uses_followed_users_generator(self):
+        similarity = _make_candidates("sim", 3, "post_similarity")
+        followed = _make_candidates("followed", 3, "followed_users")
+
+        with _patch_basic_similarity_generators(
+            similarity,
+            followed_users_candidates=followed,
+        ) as mock_get:
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI, "limit": 6},
+            ).json()
+
+        posts = [item["post"] for item in data["feed"]]
+        assert "at://sim/0" in posts
+        assert "at://followed/0" in posts
+        mock_get.side_effect("followed_users").generate.assert_awaited_once()
 
     # --- primary generator failure ---
 
@@ -858,10 +876,15 @@ class TestFeedSkeletonCursor:
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[],
         )
+        followed_users_gen = AsyncMock()
+        followed_users_gen.generate.return_value = CandidateResult(
+            generator_name="followed_users", candidates=[],
+        )
 
         def fake_get(name):
             return {
                 "post_similarity": primary_gen,
+                "followed_users": followed_users_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -875,6 +898,10 @@ class TestFeedSkeletonCursor:
         # containing the 5 initial URIs.
         call_kwargs = primary_gen.generate.call_args
         assert call_kwargs.kwargs.get("exclude_uris") == [
+            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
+        ]
+        followed_call_kwargs = followed_users_gen.generate.call_args
+        assert followed_call_kwargs.kwargs.get("exclude_uris") == [
             "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
         ]
 


### PR DESCRIPTION
Closes #113 

Create a new private feed for each of the candidate generators, basically for testing and debugging purposes. Each feed is just pure candidate generation with no ranking or diversification. The random candidate generator already has its own (public) feed, so I did not create a duplicate private one. 

Also renamed the "basic-similarity" to be "unranked-your-feed" because that is what it is - the "your-feed" feed, but without the ranker. 

Note that I did not change the rkey for the new "unranked-your-feed" feed, so that it will update in place when we deploy. I think the other option is to change it so it matches the name, and then delete the old feed when we deploy. Happy to do either one, so if you (kind reviewer) think the second option is better, let me know and I'll do that.