### PR TITLE
Suppress already-seen posts

### DIFF
--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -184,6 +184,21 @@ ensure_feed_cache_ttl_policy() {
         || log_warn "TTL policy may already exist or could not be updated (non-fatal)"
 }
 
+ensure_seen_posts_ttl_policy() {
+    local firestore_db
+    firestore_db="$(get_firestore_database)"
+
+    log_info "Ensuring TTL policy on seen_posts.expires_at..."
+    gcloud firestore fields ttls update expires_at \
+        --collection-group=seen_posts \
+        --database="$firestore_db" \
+        --project="$PROJECT_ID" \
+        --enable-ttl \
+        --quiet 2>/dev/null \
+        && log_info "TTL policy enabled on seen_posts.expires_at" \
+        || log_warn "TTL policy may already exist or could not be updated (non-fatal)"
+}
+
 ensure_firestore_api_key_secret() {
     local sa_email="api-runner-$ENVIRONMENT@$PROJECT_ID.iam.gserviceaccount.com"
     local key_display_name
@@ -539,6 +554,7 @@ main() {
     create_service_account
     ensure_firestore_database
     ensure_feed_cache_ttl_policy
+    ensure_seen_posts_ttl_policy
     ensure_firestore_api_key_secret
     ensure_inference_api_key_secret_access
     ensure_feed_context_secret

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -47,6 +47,18 @@ class FeedCacheDocument(BaseModel):
     expires_at: datetime = Field(..., description="UTC expiration timestamp for this cache entry")
 
 
+class SeenPostsDocument(BaseModel):
+    """Post URIs a user has seen on a given UTC day.
+
+    One document per user per day under the ``seen_posts`` subcollection; the
+    document ID is the ``YYYY-MM-DD`` date.  ``expires_at`` anchors the native
+    Firestore TTL policy so buckets self-delete ~5 days after the day they cover.
+    """
+
+    post_uris: list[str] = Field(default_factory=list, description="Seen post AT URIs for this day")
+    expires_at: datetime = Field(..., description="UTC expiration timestamp; drives native TTL")
+
+
 class FeedActivityDocument(BaseModel):
     feed_name: str = Field(..., description="AT Protocol rkey of the feed (also the document ID)")
     first_seen_at: datetime = Field(default_factory=_utcnow, description="When the user first loaded this feed")

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from google.cloud.firestore import AsyncClient  # type: ignore[import-untyped]
+from google.cloud.firestore import ArrayUnion, AsyncClient  # type: ignore[import-untyped]
 
 from ..documents import FeedActivityDocument, InteractionDocument, UserDocument
 
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 USERS_COLLECTION = "users"
 FEED_ACTIVITY_COLLECTION = "feed_activity"
 INTERACTIONS_COLLECTION = "interactions"
+SEEN_POSTS_COLLECTION = "seen_posts"
+
+# How long a seen-posts bucket lives before native Firestore TTL deletes it.
+SEEN_POSTS_RETENTION_DAYS = 5
 
 
 def init_firestore_client() -> AsyncClient:
@@ -175,3 +179,73 @@ async def record_interaction(db: AsyncClient, interaction: InteractionDocument) 
     collection so the data is easy to query and export (e.g. to Elasticsearch).
     """
     await db.collection(INTERACTIONS_COLLECTION).add(interaction.model_dump())
+
+
+# ---------------------------------------------------------------------------
+# Seen posts
+# ---------------------------------------------------------------------------
+
+
+async def record_seen_posts(db: AsyncClient, user_did: str, post_uris: list[str]) -> None:
+    """Append seen post URIs to the user's bucket for the current UTC day.
+
+    Buckets are keyed by ``YYYY-MM-DD`` under the user's ``seen_posts``
+    subcollection.  ``ArrayUnion`` appends without duplicating within the bucket,
+    and ``expires_at`` (re-stamped on each write) drives the native Firestore TTL
+    so the bucket self-deletes ~``SEEN_POSTS_RETENTION_DAYS`` days after its last
+    update.  No-op when there is nothing to record.
+    """
+    if not post_uris:
+        return
+
+    now = datetime.now(timezone.utc)
+    bucket_id = now.strftime("%Y-%m-%d")
+    expires_at = now + timedelta(days=SEEN_POSTS_RETENTION_DAYS)
+
+    ref = (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(SEEN_POSTS_COLLECTION)
+        .document(bucket_id)
+    )
+    await ref.set(
+        {"post_uris": ArrayUnion(post_uris), "expires_at": expires_at},
+        merge=True,
+    )
+
+
+async def get_recent_seen_uris(
+    db: AsyncClient, user_did: str, *, max_uris: int = 1000
+) -> list[str]:
+    """Return the user's most-recently-seen post URIs, de-duped and capped.
+
+    Reads the non-expired daily buckets (filtering on ``expires_at`` so buckets
+    not yet reaped by TTL are still excluded once stale) and walks them
+    newest-first, collecting URIs until ``max_uris`` is reached.  Within a day
+    ``ArrayUnion`` preserves append order, so the result is roughly the most
+    recent URIs.
+    """
+    now = datetime.now(timezone.utc)
+    query = (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(SEEN_POSTS_COLLECTION)
+        .where("expires_at", ">", now)
+    )
+
+    buckets = [doc async for doc in query.stream()]
+    # Doc IDs are YYYY-MM-DD, so lexical sort == chronological; newest first.
+    buckets.sort(key=lambda doc: doc.id, reverse=True)
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for doc in buckets:
+        data = doc.to_dict() or {}
+        for uri in data.get("post_uris", []):
+            if uri in seen:
+                continue
+            seen.add(uri)
+            result.append(uri)
+            if len(result) >= max_uris:
+                return result
+    return result

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -7,14 +7,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from google.cloud.firestore import ArrayUnion
+
 from ..documents import InteractionDocument, UserDocument
 from ..lib.firestore import (
     INTERACTIONS_COLLECTION,
+    SEEN_POSTS_COLLECTION,
     USERS_COLLECTION,
     get_feed_activity,
+    get_recent_seen_uris,
     get_user,
     init_firestore_client,
     record_interaction,
+    record_seen_posts,
     upsert_feed_activity,
     upsert_user,
 )
@@ -34,6 +39,38 @@ def _mock_feed_activity_client():
     doc_ref = AsyncMock()
     db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
     return db, doc_ref
+
+
+def _mock_seen_posts_write_client():
+    """Mock the users/{did}/seen_posts/{bucket} document-write chain."""
+    db = MagicMock()
+    doc_ref = AsyncMock()
+    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    return db, doc_ref
+
+
+def _async_iter(items):
+    async def _gen():
+        for item in items:
+            yield item
+
+    return _gen()
+
+
+def _mock_seen_posts_query_client(buckets):
+    """Mock the seen_posts subcollection query chain; ``buckets`` stream out."""
+    db = MagicMock()
+    query = MagicMock()
+    query.stream.return_value = _async_iter(buckets)
+    db.collection.return_value.document.return_value.collection.return_value.where.return_value = query
+    return db, query
+
+
+def _mock_bucket(doc_id: str, post_uris: list[str]) -> MagicMock:
+    snap = MagicMock()
+    snap.id = doc_id
+    snap.to_dict.return_value = {"post_uris": post_uris}
+    return snap
 
 
 def _mock_doc_snapshot(exists: bool, data: dict | None = None) -> MagicMock:
@@ -345,3 +382,79 @@ class TestRecordInteraction:
         assert written["feed_name"] == FEED_NAME
         assert written["request_id"] == "req-1"
         assert "created_at" in written
+
+
+# ---------------------------------------------------------------------------
+# record_seen_posts
+# ---------------------------------------------------------------------------
+
+
+class TestRecordSeenPosts:
+    @pytest.mark.asyncio
+    async def test_writes_today_bucket_with_array_union_and_expiry(self):
+        db, doc_ref = _mock_seen_posts_write_client()
+
+        await record_seen_posts(db, USER_DID, ["at://post/1", "at://post/2"])
+
+        # Subcollection is keyed under the user document.
+        db.collection.assert_called_with(USERS_COLLECTION)
+        db.collection.return_value.document.return_value.collection.assert_called_with(
+            SEEN_POSTS_COLLECTION
+        )
+        # Bucket id is the current UTC date.
+        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
+            bucket_id
+        )
+
+        doc_ref.set.assert_called_once()
+        written, kwargs = doc_ref.set.call_args
+        payload = written[0]
+        assert kwargs == {"merge": True}
+        assert isinstance(payload["post_uris"], ArrayUnion)
+        assert payload["post_uris"].values == ["at://post/1", "at://post/2"]
+        assert payload["expires_at"] > datetime.now(timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_noop_on_empty(self):
+        db, doc_ref = _mock_seen_posts_write_client()
+
+        await record_seen_posts(db, USER_DID, [])
+
+        doc_ref.set.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_recent_seen_uris
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentSeenUris:
+    @pytest.mark.asyncio
+    async def test_unions_buckets_newest_first_and_dedups(self):
+        buckets = [
+            _mock_bucket("2026-06-01", ["at://a", "at://b"]),
+            _mock_bucket("2026-06-02", ["at://b", "at://c"]),
+        ]
+        db, query = _mock_seen_posts_query_client(buckets)
+
+        uris = await get_recent_seen_uris(db, USER_DID)
+
+        # Newest bucket first, duplicate "at://b" collapsed.
+        assert uris == ["at://b", "at://c", "at://a"]
+        # Query filters on a future expiry.
+        where_args = db.collection.return_value.document.return_value.collection.return_value.where.call_args[0]
+        assert where_args[0] == "expires_at"
+        assert where_args[1] == ">"
+
+    @pytest.mark.asyncio
+    async def test_caps_at_max_uris(self):
+        many = [f"at://post/{i}" for i in range(1500)]
+        buckets = [_mock_bucket("2026-06-02", many)]
+        db, _ = _mock_seen_posts_query_client(buckets)
+
+        uris = await get_recent_seen_uris(db, USER_DID, max_uris=1000)
+
+        assert len(uris) == 1000
+        assert uris[0] == "at://post/0"
+        assert uris[-1] == "at://post/999"

--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -2,7 +2,9 @@
 
 When ``ENVIRONMENT`` is ``stage`` or ``prod``, metrics are exported to GCP
 Cloud Monitoring under the prefix ``custom.googleapis.com/greenearth-api/``.
-Otherwise the stdout exporter is used for local development.
+In local/dev environments metrics are still recorded but not exported anywhere
+-- the console exporter dumps a large ``resource_metrics`` JSON blob on every
+interval, which is just noise during local development.
 
 Instrument type is inferred from the metric name suffix:
   - ``_count`` → Int64Counter  (cumulative sum)
@@ -16,10 +18,7 @@ import asyncio
 from typing import Any
 
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import (
-    ConsoleMetricExporter,
-    PeriodicExportingMetricReader,
-)
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
 _metric_collector: "MetricCollector | None" = None
@@ -54,13 +53,16 @@ class MetricCollector:
             exporter = CloudMonitoringMetricsExporter(
                 prefix="custom.googleapis.com/greenearth-api",
             )
+            reader: Any | None = PeriodicExportingMetricReader(
+                exporter,
+                export_interval_millis=export_interval_sec * 1000,
+            )
         else:
-            exporter = ConsoleMetricExporter()
+            # Local/dev: record metrics but don't export them. A console
+            # exporter would print a big resource_metrics JSON blob each
+            # interval, which is just noise locally.
+            reader = None
 
-        reader = PeriodicExportingMetricReader(
-            exporter,
-            export_interval_millis=export_interval_sec * 1000,
-        )
         self._init(reader, service_name, env)
 
     @classmethod
@@ -74,7 +76,7 @@ class MetricCollector:
         instance._init(reader, service_name, env)
         return instance
 
-    def _init(self, reader: Any, service_name: str, env: str) -> None:
+    def _init(self, reader: Any | None, service_name: str, env: str) -> None:
         resource = Resource.create(
             {
                 "service.name": service_name,
@@ -83,7 +85,7 @@ class MetricCollector:
         )
         self._provider = MeterProvider(
             resource=resource,
-            metric_readers=[reader],
+            metric_readers=[reader] if reader is not None else [],
         )
         self._meter = self._provider.get_meter("greenearth/api")
         self._histograms: dict[str, Any] = {}

--- a/src/app/lib/metrics_test.py
+++ b/src/app/lib/metrics_test.py
@@ -129,18 +129,24 @@ def test_same_instrument_reused_across_calls():
 
 
 # ---------------------------------------------------------------------------
-# Stdout fallback (non-deployed environment)
+# Local/dev (non-deployed environment)
 # ---------------------------------------------------------------------------
 
-def test_stdout_fallback_for_local_env(capsys):
-    """Non-stage/prod environments should construct without error using stdout exporter."""
+@pytest.mark.asyncio
+async def test_local_env_records_without_exporting(capsys):
+    """Local/dev should record metrics without printing a resource_metrics blob."""
     collector = MetricCollector(
         service_name="test-svc",
         env="local",
         export_interval_sec=60,
     )
     collector.record("some.metric_ms", 1.0)
-    # No exception means stdout fallback worked
+    # Force a flush; nothing should be written to stdout/stderr in dev.
+    await collector.shutdown()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "resource_metrics" not in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -34,7 +34,13 @@ from ..lib.rankers import run_predict
 from ..models import CandidateGenerateRequest, CandidatePost, FeedConfig, FeedCursor
 
 from ..lib.atproto_auth import verify_auth_header
-from ..lib.firestore import record_interaction, upsert_feed_activity, upsert_user
+from ..lib.firestore import (
+    get_recent_seen_uris,
+    record_interaction,
+    record_seen_posts,
+    upsert_feed_activity,
+    upsert_user,
+)
 from ..lib.request_cache import request_cache_scope
 from ..lib.telemetry import timed
 from ..feeds import FEEDS
@@ -350,6 +356,19 @@ def _spawn_background(coro) -> asyncio.Task:
     return task
 
 
+async def _seen_exclusions(db, user_did: str) -> list[str]:
+    """Fetch the user's recently-seen post URIs to exclude from generation.
+
+    Fail-soft: a Firestore hiccup should degrade the feature (possible repeats)
+    rather than break feed serving, so errors are logged and yield an empty list.
+    """
+    try:
+        return await get_recent_seen_uris(db, user_did)
+    except Exception:
+        logger.exception("Failed to fetch seen posts for user '%s'", user_did)
+        return []
+
+
 async def _record_session(request: Request, user_did: str, feed_name: str, db) -> None:
     """Resolve the caller's handle and upsert user + feed-activity docs.
 
@@ -382,7 +401,14 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
     The signed feedContext is the trust anchor: interactions with a missing or
     forged token are dropped (and logged) rather than written, so the public
     endpoint can't be used to poison the data. Runs as a background task.
+
+    ``interactionSeen`` items are additionally appended to the user's seen-posts
+    buckets so they can be excluded from future feed generations.
     """
+    # Seen URIs collected per user so we can record them with a single write
+    # per user after the per-interaction loop.
+    seen_by_user: dict[str, list[str]] = {}
+
     for ix in interactions:
         payload = decode_feed_context(ix.feed_context or "")
         if payload is None:
@@ -392,6 +418,9 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
         event = _short_event(ix.event)
         if event and event not in INTERACTION_EVENTS:
             logger.warning("Recording interaction with unrecognized event: %s", event)
+
+        if event == "interactionSeen" and ix.item:
+            seen_by_user.setdefault(payload.did, []).append(ix.item)
 
         doc = InteractionDocument(
             user_did=payload.did,
@@ -405,6 +434,12 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
             await record_interaction(db, doc)
         except Exception:
             logger.exception("Failed to record interaction for user '%s'", payload.did)
+
+    for did, uris in seen_by_user.items():
+        try:
+            await record_seen_posts(db, did, uris)
+        except Exception:
+            logger.exception("Failed to record seen posts for user '%s'", did)
 
 
 # ---------------------------------------------------------------------------
@@ -557,11 +592,15 @@ async def get_feed_skeleton(
 
                 # Offset is at or past the end — regenerate with exclusions.
                 batch = _batch_size(limit)
+                seen_uris = await _seen_exclusions(db, user_did)
+                # Dedup while preserving order; the cached batch and seen posts
+                # can overlap.
+                exclude_uris = list(dict.fromkeys(cached_uris + seen_uris))
                 gen_request = feed_cfg.gen_request_template.model_copy(
                     update={
                         "user_did": user_did,
                         "num_candidates": batch,
-                        "exclude_uris": cached_uris,
+                        "exclude_uris": exclude_uris,
                     }
                 )
 
@@ -590,8 +629,9 @@ async def get_feed_skeleton(
         # No cursor or cache miss — generate a fresh batch.
         # ------------------------------------------------------------------
         batch = _batch_size(limit)
+        seen_uris = await _seen_exclusions(db, user_did)
         gen_request = feed_cfg.gen_request_template.model_copy(
-            update={"user_did": user_did, "num_candidates": batch}
+            update={"user_did": user_did, "num_candidates": batch, "exclude_uris": seen_uris}
         )
 
         all_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -273,6 +273,46 @@ class TestGetFeedSkeleton:
         assert len(data["feed"]) == 3
         assert data["feed"][0]["post"] == "at://p/0"
 
+    def test_seen_uris_excluded_on_fresh_request(self):
+        """A fresh feed load excludes the user's recently-seen posts."""
+        primary_gen = AsyncMock()
+        primary_gen.generate.return_value = CandidateResult(
+            generator_name="post_similarity", candidates=_make_candidates("p", 2),
+        )
+        followed_gen = AsyncMock()
+        followed_gen.generate.return_value = CandidateResult(
+            generator_name="followed_users", candidates=[],
+        )
+        infill_gen = AsyncMock()
+        infill_gen.generate.return_value = CandidateResult(
+            generator_name="popularity", candidates=[],
+        )
+
+        def fake_get(name):
+            return {
+                "post_similarity": primary_gen,
+                "followed_users": followed_gen,
+                "popularity": infill_gen,
+            }.get(name)
+
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get),
+            patch(
+                "app.routers.xrpc.get_recent_seen_uris",
+                new_callable=AsyncMock,
+                return_value=["at://seen/1", "at://seen/2"],
+            ),
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            )
+
+        assert resp.status_code == 200
+        assert primary_gen.generate.call_args.kwargs.get("exclude_uris") == [
+            "at://seen/1",
+            "at://seen/2",
+        ]
+
     # --- feedContext ---
 
     def test_items_carry_signed_feed_context(self):
@@ -1399,3 +1439,36 @@ class TestSendInteractions:
             await _record_interactions(db, interactions)
 
         assert rec.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_seen_event_records_seen_posts(self):
+        from app.routers.xrpc import Interaction, _record_interactions
+
+        seen = "app.bsky.feed.defs#interactionSeen"
+        interactions = [
+            Interaction(item="at://post/1", event=seen, feed_context=_make_token(did="did:plc:u")),
+            Interaction(item="at://post/2", event=seen, feed_context=_make_token(did="did:plc:u")),
+        ]
+        db = MagicMock()
+        with (
+            patch("app.routers.xrpc.record_interaction", new_callable=AsyncMock),
+            patch("app.routers.xrpc.record_seen_posts", new_callable=AsyncMock) as seen_rec,
+        ):
+            await _record_interactions(db, interactions)
+
+        seen_rec.assert_called_once_with(db, "did:plc:u", ["at://post/1", "at://post/2"])
+
+    @pytest.mark.asyncio
+    async def test_non_seen_events_do_not_record_seen_posts(self):
+        from app.routers.xrpc import Interaction, _record_interactions
+
+        like = "app.bsky.feed.defs#interactionLike"
+        ix = Interaction(item="at://post/1", event=like, feed_context=_make_token())
+        db = MagicMock()
+        with (
+            patch("app.routers.xrpc.record_interaction", new_callable=AsyncMock),
+            patch("app.routers.xrpc.record_seen_posts", new_callable=AsyncMock) as seen_rec,
+        ):
+            await _record_interactions(db, [ix])
+
+        seen_rec.assert_not_called()


### PR DESCRIPTION
We now ingest `sendInteractions` data, so we know which posts a user has actually viewed (`interactionSeen`). Previously a user could be re-served the same posts across feed loads — only within-batch repeats were avoided via the cursor. This excludes recently-seen posts from generation so the feed keeps moving forward.

### Approach

Reuses the existing `exclude_uris` mechanism that cursor pagination already relies on:

- **Persist** seen post URIs per user in Firestore, in daily buckets under `users/{did}/seen_posts/{YYYY-MM-DD}` (one array per UTC day). Appends use `ArrayUnion` (dedupes within a bucket); a native Firestore TTL on `expires_at` reaps buckets ~5 days out, mirroring the existing `feed_cache` TTL.
- **Write** happens in the existing background interactions task — `interactionSeen` items are collected per DID and recorded with no added request latency.
- **Read** happens on fresh feed generation (and regenerate-past-end-of-cache): the user's recent seen URIs are merged into `exclude_uris`. The read is fail-soft — a Firestore hiccup degrades the feature (possible repeats) rather than breaking feed serving.

### Tradeoffs (intentional)

- The exclude set is capped at the **1000 most-recent** seen URIs to bound the ES `must_not` payload; posts older than the cap may occasionally reappear. This is acceptable — accuracy is traded for performance here.
- The read filters on `expires_at > now`, which keeps reads bounded even before the TTL policy is enabled or while TTL deletion lags. (Discussed: the filter is essentially free at this scale and is the safety net that makes correctness independent of TTL being live.)

### Deploy note

Run `./scripts/gcp_setup.sh --environment stage` (and `prod`) once to enable the new `seen_posts` TTL policy. Until then buckets linger but are still filtered out at read time, so correctness does not depend on it.

### Incidental cleanup

Stopped the metrics collector from dumping a large `resource_metrics` JSON blob to stdout in local/dev. The console exporter is replaced with no exporter in non-deployed environments (metrics are still recorded; stage/prod export to Cloud Monitoring unchanged). Added a regression test asserting dev produces no stdout output.

Closes #107 