### PR TITLE
Make seen-post exclusion configurable per feed

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -39,6 +39,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="67-r",
         internal_display_name="67 R",
         diversify=False,
+        exclude_seen_posts=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
@@ -92,6 +93,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="gh-ps",
         internal_display_name="gh PS",
         diversify=False,
+        exclude_seen_posts=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="post_similarity", weight=1.0),
@@ -107,6 +109,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="ij-fu",
         internal_display_name="ij FU",
         diversify=False,
+        exclude_seen_posts=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="followed_users", weight=1.0),
@@ -122,6 +125,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="kl-nl",
         internal_display_name="kl NL",
         diversify=False,
+        exclude_seen_posts=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="network_likes", weight=1.0),
@@ -137,6 +141,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="mn-p",
         internal_display_name="mn P",
         diversify=False,
+        exclude_seen_posts=False,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="popularity", weight=1.0),

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -170,3 +170,10 @@ class FeedConfig(BaseModel):
         description="When True, the published record declares acceptsInteractions so the "
         "AppView forwards interaction signals to sendInteractions.",
     )
+    exclude_seen_posts: bool = Field(
+        True,
+        description="When True, posts the user has already seen (reported via "
+        "interactionSeen) are excluded from generation, and seen post URIs are "
+        "denormalized onto the user record. When False, neither happens (the raw "
+        "interactions are still stored).",
+    )

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -356,12 +356,16 @@ def _spawn_background(coro) -> asyncio.Task:
     return task
 
 
-async def _seen_exclusions(db, user_did: str) -> list[str]:
+async def _seen_exclusions(db, user_did: str, feed_cfg: FeedConfig) -> list[str]:
     """Fetch the user's recently-seen post URIs to exclude from generation.
 
-    Fail-soft: a Firestore hiccup should degrade the feature (possible repeats)
-    rather than break feed serving, so errors are logged and yield an empty list.
+    Returns an empty list for feeds with ``exclude_seen_posts`` disabled.
+    Fail-soft otherwise: a Firestore hiccup should degrade the feature (possible
+    repeats) rather than break feed serving, so errors are logged and yield an
+    empty list.
     """
+    if not feed_cfg.exclude_seen_posts:
+        return []
     try:
         return await get_recent_seen_uris(db, user_did)
     except Exception:
@@ -403,7 +407,9 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
     endpoint can't be used to poison the data. Runs as a background task.
 
     ``interactionSeen`` items are additionally appended to the user's seen-posts
-    buckets so they can be excluded from future feed generations.
+    buckets so they can be excluded from future feed generations -- but only for
+    feeds whose config has ``exclude_seen_posts`` enabled. The raw interaction is
+    always stored regardless.
     """
     # Seen URIs collected per user so we can record them with a single write
     # per user after the per-interaction loop.
@@ -419,7 +425,13 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
         if event and event not in INTERACTION_EVENTS:
             logger.warning("Recording interaction with unrecognized event: %s", event)
 
-        if event == "interactionSeen" and ix.item:
+        feed_cfg = FEEDS.get(payload.feed)
+        if (
+            event == "interactionSeen"
+            and ix.item
+            and feed_cfg is not None
+            and feed_cfg.exclude_seen_posts
+        ):
             seen_by_user.setdefault(payload.did, []).append(ix.item)
 
         doc = InteractionDocument(
@@ -592,7 +604,7 @@ async def get_feed_skeleton(
 
                 # Offset is at or past the end — regenerate with exclusions.
                 batch = _batch_size(limit)
-                seen_uris = await _seen_exclusions(db, user_did)
+                seen_uris = await _seen_exclusions(db, user_did, feed_cfg)
                 # Dedup while preserving order; the cached batch and seen posts
                 # can overlap.
                 exclude_uris = list(dict.fromkeys(cached_uris + seen_uris))
@@ -629,7 +641,7 @@ async def get_feed_skeleton(
         # No cursor or cache miss — generate a fresh batch.
         # ------------------------------------------------------------------
         batch = _batch_size(limit)
-        seen_uris = await _seen_exclusions(db, user_did)
+        seen_uris = await _seen_exclusions(db, user_did, feed_cfg)
         gen_request = feed_cfg.gen_request_template.model_copy(
             update={"user_did": user_did, "num_candidates": batch, "exclude_uris": seen_uris}
         )

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -325,6 +325,44 @@ class TestGetFeedSkeleton:
             "at://seen/2",
         ]
 
+    def test_seen_not_excluded_when_feed_disables_it(self, monkeypatch):
+        """A feed with exclude_seen_posts off neither fetches nor excludes seen posts."""
+        monkeypatch.setattr(FEEDS[FEED_RKEY], "exclude_seen_posts", False)
+
+        primary_gen = AsyncMock()
+        primary_gen.generate.return_value = CandidateResult(
+            generator_name="post_similarity", candidates=_make_candidates("p", 2),
+        )
+        followed_gen = AsyncMock()
+        followed_gen.generate.return_value = CandidateResult(
+            generator_name="followed_users", candidates=[],
+        )
+        infill_gen = AsyncMock()
+        infill_gen.generate.return_value = CandidateResult(
+            generator_name="popularity", candidates=[],
+        )
+
+        def fake_get(name):
+            return {
+                "post_similarity": primary_gen,
+                "followed_users": followed_gen,
+                "popularity": infill_gen,
+            }.get(name)
+
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get),
+            patch(
+                "app.routers.xrpc.get_recent_seen_uris", new_callable=AsyncMock
+            ) as seen_fetch,
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            )
+
+        assert resp.status_code == 200
+        seen_fetch.assert_not_called()
+        assert not primary_gen.generate.call_args.kwargs.get("exclude_uris")
+
     # --- feedContext ---
 
     def test_items_carry_signed_feed_context(self):
@@ -1543,3 +1581,25 @@ class TestSendInteractions:
             await _record_interactions(db, [ix])
 
         seen_rec.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_seen_not_denormalized_when_feed_disables_it(self, monkeypatch):
+        """A feed with exclude_seen_posts off still stores the interaction but
+        does not denormalize seen posts onto the user record."""
+        from app.feeds import FEEDS
+        from app.routers.xrpc import Interaction, _record_interactions
+
+        monkeypatch.setattr(FEEDS["your-feed"], "exclude_seen_posts", False)
+        seen = "app.bsky.feed.defs#interactionSeen"
+        ix = Interaction(
+            item="at://post/1", event=seen, feed_context=_make_token(feed="your-feed"),
+        )
+        db = MagicMock()
+        with (
+            patch("app.routers.xrpc.record_interaction", new_callable=AsyncMock) as rec,
+            patch("app.routers.xrpc.record_seen_posts", new_callable=AsyncMock) as seen_rec,
+        ):
+            await _record_interactions(db, [ix])
+
+        rec.assert_called_once()  # raw interaction is still stored
+        seen_rec.assert_not_called()  # but not denormalized


### PR DESCRIPTION
The seen-post exclusion feature (already on `main`) is applied to every feed. That isn't right for all of them — the **random** feed should stay random rather than march forward through a user's unseen backlog, and the private candidate-generator feeds (post-similarity, followed-users, network-likes, popularity) exist for testing/debugging where we want raw, repeatable generator output. This makes the behavior opt-out per feed.

### Scope

- New `FeedConfig.exclude_seen_posts` flag, **defaulting to `True`** so the behavior stays on for the personalized feeds (`unranked-your-feed`, `your-feed`, `best-of-friends`) without any change.
- When a feed sets it to `False`:
  - **Read:** `_seen_exclusions` returns early, so we neither query Firestore for the user's seen posts nor add them to `exclude_uris`.
  - **Write:** `interactionSeen` items from that feed are not denormalized onto the user record. The raw `InteractionDocument` is **still stored as normal** — only the denormalized seen-posts buckets are skipped. The feed is identified from the signed `feedContext` (`payload.feed`).
- Turned the flag off for `random` and the four private candidate-only feeds.
