### PR TITLE
Collect and show feed debug data

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ httpx = "*"
 ruff = "*"
 pyinstrument = "*"
 pyright = "*"
+rich = "*"
 
 [requires]
 python_version = "3.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c0fa3825b6769ff20a651ce726b4c53bc546b026933299bdae6a04167ef98a40"
+            "sha256": "9ff84c947cb3ddb764c00f804eb2d4089d00b291826f603ee9c1ad73fbf8a158"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2035,11 +2035,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c",
-                "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"
+                "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+                "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.17"
+            "version": "==3.18"
         },
         "iniconfig": {
             "hashes": [
@@ -2048,6 +2048,22 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==2.3.0"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49",
+                "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.2.0"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
         },
         "nodeenv": {
             "hashes": [
@@ -2179,6 +2195,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==1.4.0"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
+                "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==15.0.0"
         },
         "ruff": {
             "hashes": [

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -22,6 +22,14 @@ import argparse
 import asyncio
 import os
 import sys
+from datetime import datetime, timezone
+from typing import NoReturn
+
+from rich import box
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -34,6 +42,8 @@ from app.lib.firestore import (
     set_user_debug_flag,
 )
 
+console = Console()
+
 
 async def _resolve_user_did(db, user: str) -> str | None:
     """Resolve a handle or DID argument to a user DID."""
@@ -43,79 +53,241 @@ async def _resolve_user_did(db, user: str) -> str | None:
     return doc.user_did if doc else None
 
 
+def _die(message: str) -> NoReturn:
+    console.print(f"[red]{message}[/red]")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _relative_time(dt: datetime) -> str:
+    """Compact relative-time string for a tz-aware datetime."""
+    try:
+        delta = datetime.now(timezone.utc) - dt
+        secs = delta.total_seconds()
+        if secs < 60:
+            return "just now"
+        if secs < 3_600:
+            return f"{int(secs / 60)}m ago"
+        if secs < 86_400:
+            return f"{int(secs / 3_600)}h ago"
+        if delta.days < 30:
+            return f"{delta.days}d ago"
+        return dt.strftime("%b %d, %Y")
+    except Exception:
+        return str(dt)
+
+
+def _fmt_score(score: float | None) -> str:
+    return f"{score:.4f}" if score is not None else "—"
+
+
+def _media_summary(c) -> Text | None:
+    """Yellow media badges for a candidate, or None when it has no media."""
+    parts = []
+    if c.image_count:
+        parts.append(f"{c.image_count} image{'s' if c.image_count != 1 else ''}")
+    elif c.contains_images:
+        parts.append("image")
+    if c.video_count:
+        parts.append(f"{c.video_count} video{'s' if c.video_count != 1 else ''}")
+    elif c.contains_video:
+        parts.append("video")
+    if c.external_uri:
+        parts.append("link")
+    if not parts:
+        return None
+    return Text(f"[{', '.join(parts)}]", style="dim yellow")
+
+
+# ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+
 async def cmd_enable(user: str, enabled: bool) -> None:
     db = init_firestore_client()
     user_did = await _resolve_user_did(db, user)
     if user_did is None:
-        print(f"No user found for '{user}'.", file=sys.stderr)
-        sys.exit(1)
+        _die(f"No user found for '{user}'.")
     try:
         await set_user_debug_flag(db, user_did, enabled)
     except ValueError as exc:
-        print(str(exc), file=sys.stderr)
-        sys.exit(1)
+        _die(str(exc))
     state = "enabled" if enabled else "disabled"
-    print(f"Feed debugging {state} for {user_did}.")
+    color = "green" if enabled else "yellow"
+    console.print(f"Feed debugging [{color}]{state}[/{color}] for [bold]{user_did}[/bold].")
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
 
 
 async def cmd_list(user: str, limit: int) -> None:
     db = init_firestore_client()
     user_did = await _resolve_user_did(db, user)
     if user_did is None:
-        print(f"No user found for '{user}'.", file=sys.stderr)
-        sys.exit(1)
+        _die(f"No user found for '{user}'.")
     docs = await get_recent_feed_debug(db, user_did, limit=limit)
     if not docs:
-        print(f"No feed-debug records for {user_did}.")
+        console.print(f"[yellow]No feed-debug records for {user_did}.[/yellow]")
         return
-    print(f"{'request_id':<34} {'feed':<16} {'items':<6} {'generated_at'}")
-    print("-" * 80)
+
+    table = Table(
+        box=box.SIMPLE_HEAVY, title=f"Recent feed loads — {user_did}", title_justify="left"
+    )
+    table.add_column("request_id", style="cyan", no_wrap=True)
+    table.add_column("feed", style="magenta")
+    table.add_column("items", justify="right", style="green")
+    table.add_column("ranker")
+    table.add_column("when", style="dim")
     for d in docs:
-        generated = d.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-        print(f"{d.request_id:<34} {d.feed_name:<16} {len(d.final_order):<6} {generated}")
+        table.add_row(
+            d.request_id,
+            d.feed_name,
+            str(len(d.final_order)),
+            d.ranker_model or "—",
+            _relative_time(d.generated_at),
+        )
+    console.print(table)
 
 
-def _media_summary(c) -> str:
-    parts = []
-    if c.image_count:
-        parts.append(f"img:{c.image_count}")
-    elif c.contains_images:
-        parts.append("img")
-    if c.video_count:
-        parts.append(f"vid:{c.video_count}")
-    elif c.contains_video:
-        parts.append("vid")
-    if c.external_uri:
-        parts.append("link")
-    return ",".join(parts) if parts else "-"
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
 
 
-def _print_show(doc: FeedDebugDocument) -> None:
-    print(f"request_id  : {doc.request_id}")
-    print(f"user        : {doc.username or doc.user_did}")
-    print(f"feed        : {doc.feed_name}")
-    print(f"generated_at: {doc.generated_at.strftime('%Y-%m-%dT%H:%M:%SZ')}")
-    print(f"regenerated : {doc.regenerated}")
-    print(f"ranker      : {doc.ranker_model or '(none)'}    diversify: {doc.diversify}")
-
+def _header_panel(doc: FeedDebugDocument) -> Panel:
     req = doc.generate_request
-    gen_specs = ", ".join(f"{g.name}({g.weight})" for g in req.generators)
-    print()
-    print("--- generation request ---")
-    print(f"generators  : {gen_specs}")
-    print(f"infill      : {req.infill or '(none)'}")
-    print(f"num_candidates: {req.num_candidates}    video_only: {req.video_only}")
-    print(f"excluded    : {len(req.exclude_uris)} uris")
+    gen_specs = ", ".join(f"{g.name}({g.weight:g})" for g in req.generators)
+
+    body = Text()
+    body.append("user        ", style="dim")
+    body.append(f"{doc.username or doc.user_did}\n", style="bold white")
+    body.append("feed        ", style="dim")
+    body.append(f"{doc.feed_name}", style="magenta")
+    body.append(f"   {_relative_time(doc.generated_at)}", style="dim cyan")
+    if doc.regenerated:
+        body.append("   (regenerated)", style="dim yellow")
+    body.append("\n")
+    body.append("ranker      ", style="dim")
+    body.append(f"{doc.ranker_model or '(none)'}", style="white")
+    body.append("   diversify=", style="dim")
+    body.append(f"{doc.diversify}\n", style="white")
+    body.append("generators  ", style="dim")
+    body.append(f"{gen_specs}\n", style="white")
+    body.append("infill      ", style="dim")
+    body.append(f"{req.infill or '(none)'}", style="white")
+    body.append("   candidates=", style="dim")
+    body.append(f"{req.num_candidates}", style="white")
+    if req.video_only:
+        body.append("   video_only", style="yellow")
+    if req.exclude_uris:
+        body.append(f"   excluded={len(req.exclude_uris)}", style="dim")
 
     if doc.user_features:
-        print()
-        print("--- user features ---")
+        body.append("\n")
         for uf in doc.user_features:
-            print(
+            body.append("\nuser feats  ", style="dim")
+            body.append(
                 f"{uf.source}: {len(uf.liked_post_uris)} liked posts, "
-                f"{uf.num_embeddings} with embeddings"
+                f"{uf.num_embeddings} with embeddings",
+                style="white",
             )
 
+    return Panel(
+        body,
+        title=f"[bold]feed debug[/bold]  [dim cyan]{doc.request_id}[/dim cyan]",
+        title_align="left",
+        box=box.ROUNDED,
+        border_style="blue",
+        padding=(0, 2),
+    )
+
+
+def _item_panel(
+    uri: str,
+    pos: int,
+    total: int,
+    generators_by_uri: dict,
+    rank_by_uri: dict,
+    after_rank_pos: dict,
+    meta: dict,
+) -> Panel:
+    c = meta.get(uri)
+
+    # --- author / media line ---
+    author_line = Text()
+    handle = (getattr(c, "author_username", None) if c else None) or (
+        getattr(c, "author_did", None) if c else None
+    )
+    author_line.append(f"@{handle}" if handle else "unknown author", style="bold white")
+    media = _media_summary(c) if c is not None else None
+    if media is not None:
+        author_line.append("  ")
+        author_line.append_text(media)
+
+    # --- pipeline journey: retrieval → ranking → diversification ---
+    # ``rank`` is the model's 1-based position with a model score; it only
+    # exists when the feed has a ranker. ``order_after_rank`` is the order
+    # entering MMR — identical to ``rank`` when a ranker ran, so it's only
+    # worth showing in the no-ranker case (where it's the generator-score sort).
+    gens = generators_by_uri.get(uri, [])
+    gen_str = ", ".join(f"{n} (gen {_fmt_score(s)})" for n, s in gens) or "infill/unknown"
+    rank, rank_score = rank_by_uri.get(uri, (None, None))
+    ar = after_rank_pos.get(uri)
+
+    journey = Text()
+    journey.append("retrieved by ", style="dim")
+    journey.append(gen_str, style="cyan")
+    if rank is not None:
+        journey.append("  →  ranked ", style="dim")
+        journey.append(f"#{rank}", style="yellow")
+        journey.append(f" (model {_fmt_score(rank_score)})", style="dim")
+    elif ar is not None:
+        journey.append("  →  by score ", style="dim")
+        journey.append(f"#{ar}", style="white")
+    journey.append("  →  final ", style="dim")
+    journey.append(f"#{pos}", style="bold green")
+
+    # --- content ---
+    content = (getattr(c, "content", None) or "").replace("\n", " ") if c else ""
+
+    group_items = [journey, author_line]
+    if content:
+        group_items.append(Text(content, style="default"))
+
+    return Panel(
+        Group(*group_items),
+        title=f"[dim]{pos}/{total - 1}[/dim]  [dim cyan]{uri}[/dim cyan]",
+        title_align="left",
+        box=box.ROUNDED,
+        border_style="grey23",
+        padding=(0, 2),
+    )
+
+
+def _discarded_table(discarded: list[str], generators_by_uri: dict) -> Table:
+    table = Table(
+        box=box.SIMPLE,
+        title=f"discarded — {len(discarded)} candidates not in final feed",
+        title_justify="left",
+        title_style="bold yellow",
+    )
+    table.add_column("uri", style="dim cyan", no_wrap=True)
+    table.add_column("generators")
+    for uri in discarded:
+        gens = generators_by_uri.get(uri, [])
+        gen_str = ", ".join(f"{n} ({_fmt_score(s)})" for n, s in gens)
+        table.add_row(uri, gen_str)
+    return table
+
+
+def _render_show(doc: FeedDebugDocument) -> None:
     # Assemble the per-item view by joining stage outputs on at_uri.
     generators_by_uri: dict[str, list[tuple[str, float | None]]] = {}
     for result in doc.generator_outputs:
@@ -139,56 +311,38 @@ def _print_show(doc: FeedDebugDocument) -> None:
         if c.at_uri:
             meta[c.at_uri] = c
 
-    print()
-    print(f"--- final feed ({len(doc.final_order)} items) ---")
+    console.print()
+    console.print(_header_panel(doc))
+
+    total = len(doc.final_order)
+    console.print(f"\n[bold]final feed[/bold] — {total} item{'s' if total != 1 else ''}")
+    legend = (
+        "ranked # = model rank (pre-diversification); final # = served position"
+        if doc.ranking
+        else "by score # = generator-score order (pre-diversification); final # = served position"
+    )
+    console.print(f"[dim]journey: retrieved by generator (gen score) → {legend}[/dim]\n")
     for pos, uri in enumerate(doc.final_order):
-        _print_item(uri, pos, generators_by_uri, rank_by_uri, after_rank_pos, meta)
+        console.print(
+            _item_panel(uri, pos, total, generators_by_uri, rank_by_uri, after_rank_pos, meta)
+        )
 
     discarded = sorted(set(generators_by_uri) - set(final_pos))
     if discarded:
-        print()
-        print(f"--- discarded ({len(discarded)} candidates not in final feed) ---")
-        for uri in discarded:
-            gens = generators_by_uri.get(uri, [])
-            gen_str = ", ".join(f"{n}:{_fmt_score(s)}" for n, s in gens)
-            print(f"  {uri}  [{gen_str}]")
-
-
-def _fmt_score(score: float | None) -> str:
-    return f"{score:.4f}" if score is not None else "-"
-
-
-def _print_item(uri, pos, generators_by_uri, rank_by_uri, after_rank_pos, meta) -> None:
-    c = meta.get(uri)
-    gens = generators_by_uri.get(uri, [])
-    gen_str = ", ".join(f"{n}:{_fmt_score(s)}" for n, s in gens) or "(infill/unknown)"
-    rank, rank_score = rank_by_uri.get(uri, (None, None))
-    ar = after_rank_pos.get(uri)
-    author = getattr(c, "author_username", None) or getattr(c, "author_did", None) or "?"
-    media = _media_summary(c) if c is not None else "-"
-    content = (getattr(c, "content", None) or "").replace("\n", " ")
-
-    print(f"[{pos}] {uri}")
-    print(f"     author: {author}   media: {media}")
-    print(
-        f"     generators: {gen_str}   rank: {rank} (score {_fmt_score(rank_score)})"
-        f"   after_rank_pos: {ar}"
-    )
-    if content:
-        print(f"     content: {content}")
+        console.print()
+        console.print(_discarded_table(discarded, generators_by_uri))
+    console.print()
 
 
 async def cmd_show(user: str, request_id: str) -> None:
     db = init_firestore_client()
     user_did = await _resolve_user_did(db, user)
     if user_did is None:
-        print(f"No user found for '{user}'.", file=sys.stderr)
-        sys.exit(1)
+        _die(f"No user found for '{user}'.")
     doc = await get_feed_debug(db, user_did, request_id)
     if doc is None:
-        print(f"No feed-debug record {request_id} for {user_did}.", file=sys.stderr)
-        sys.exit(1)
-    _print_show(doc)
+        _die(f"No feed-debug record {request_id} for {user_did}.")
+    _render_show(doc)
 
 
 def main() -> None:

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -12,6 +12,12 @@ Run from the api/ directory:
     pipenv run python scripts/feed_debug.py alice.bsky.social --list --limit 50
     pipenv run python scripts/feed_debug.py alice.bsky.social --show <request_id>
 
+Defaults to the local Firestore emulator (``--environment dev``). Target a
+deployed environment with ``--environment stage`` / ``--environment prod``
+(requires GCP credentials, e.g. ``gcloud auth application-default login``);
+``--env`` is accepted as an alias:
+    pipenv run python scripts/feed_debug.py alice.bsky.social --list --environment stage
+
 Reads Firestore connection from the same env vars as the API server:
     GE_FIRESTORE_PROJECT, GE_FIRESTORE_DATABASE, GE_FIRESTORE_EMULATOR_HOST
 """
@@ -43,6 +49,31 @@ from app.lib.firestore import (
 )
 
 console = Console()
+
+# GCP project + Firestore database per environment. Both environments live in
+# the same project and are separated by database (see scripts/gcp_setup.sh).
+GCP_PROJECT = "greenearth-471522"
+_ENVIRONMENTS = {
+    "stage": "greenearth-stage",
+    "prod": "greenearth-prod",
+}
+
+
+def _configure_environment(env: str) -> None:
+    """Point Firestore at the chosen environment, in-process.
+
+    ``dev`` (the default) leaves the environment untouched so the local
+    ``.env`` (Firestore emulator) is used. ``stage``/``prod`` set the project
+    and database explicitly and clear any emulator host — done here rather than
+    via shell env vars because ``pipenv`` loads ``.env`` over inline vars.
+    """
+    if env == "dev":
+        return
+    os.environ["GE_FIRESTORE_PROJECT"] = GCP_PROJECT
+    os.environ["GE_FIRESTORE_DATABASE"] = _ENVIRONMENTS[env]
+    os.environ.pop("GE_FIRESTORE_EMULATOR_HOST", None)
+    os.environ.pop("FIRESTORE_EMULATOR_HOST", None)
+    console.print(f"[dim]→ {env} (database {_ENVIRONMENTS[env]})[/dim]")
 
 
 async def _resolve_user_did(db, user: str) -> str | None:
@@ -358,8 +389,19 @@ def main() -> None:
     action.add_argument("--show", metavar="REQUEST_ID", help="Show one feed load in detail")
 
     parser.add_argument("--limit", type=int, default=20, help="Max rows for --list (default 20)")
+    parser.add_argument(
+        "--environment",
+        "--env",
+        dest="environment",
+        choices=["dev", "stage", "prod"],
+        default="dev",
+        help="Target environment: dev uses the local Firestore emulator (default); "
+        "stage/prod connect to the corresponding Firestore database",
+    )
 
     args = parser.parse_args()
+
+    _configure_environment(args.environment)
 
     if args.enable:
         asyncio.run(cmd_enable(args.user, True))

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -247,6 +247,7 @@ def _item_panel(
     generators_by_uri: dict,
     rank_by_uri: dict,
     after_rank_pos: dict,
+    div_by_uri: dict,
     meta: dict,
 ) -> Panel:
     c = meta.get(uri)
@@ -265,8 +266,8 @@ def _item_panel(
     # --- pipeline journey: retrieval → ranking → diversification ---
     # ``rank`` is the model's 1-based position with a model score; it only
     # exists when the feed has a ranker. ``order_after_rank`` is the order
-    # entering MMR — identical to ``rank`` when a ranker ran, so it's only
-    # worth showing in the no-ranker case (where it's the generator-score sort).
+    # entering diversification — identical to ``rank`` when a ranker ran, so it's
+    # only worth showing in the no-ranker case (where it's the generator-score sort).
     gens = generators_by_uri.get(uri, [])
     gen_str = ", ".join(f"{n} (gen {_fmt_score(s)})" for n, s in gens) or "infill/unknown"
     rank, rank_score = rank_by_uri.get(uri, (None, None))
@@ -285,10 +286,27 @@ def _item_panel(
     journey.append("  →  final ", style="dim")
     journey.append(f"#{pos}", style="bold green")
 
+    # --- diversification breakdown (only when diversification ran) ---
+    div = div_by_uri.get(uri)
+    diversify_line = None
+    if div is not None:
+        diversify_line = Text()
+        diversify_line.append("diversify    rel ", style="dim")
+        diversify_line.append(f"{div.relevance:.3f}", style="white")
+        diversify_line.append("   −author ", style="dim")
+        diversify_line.append(f"{div.author_penalty:.3f}", style="magenta")
+        diversify_line.append("   −content ", style="dim")
+        diversify_line.append(f"{div.content_penalty:.3f}", style="cyan")
+        diversify_line.append("   → score ", style="dim")
+        diversify_line.append(f"{div.score:.3f}", style="white")
+
     # --- content ---
     content = (getattr(c, "content", None) or "").replace("\n", " ") if c else ""
 
-    group_items = [journey, author_line]
+    group_items = [journey]
+    if diversify_line is not None:
+        group_items.append(diversify_line)
+    group_items.append(author_line)
     if content:
         group_items.append(Text(content, style="default"))
 
@@ -331,6 +349,7 @@ def _render_show(doc: FeedDebugDocument) -> None:
     }
     after_rank_pos = {uri: i for i, uri in enumerate(doc.order_after_rank)}
     final_pos = {uri: i for i, uri in enumerate(doc.final_order)}
+    div_by_uri = {e.at_uri: e for e in doc.diversification}
 
     # Candidate metadata: prefer the final (sanitized) candidate, else first seen.
     meta: dict[str, object] = {}
@@ -355,7 +374,9 @@ def _render_show(doc: FeedDebugDocument) -> None:
     console.print(f"[dim]journey: retrieved by generator (gen score) → {legend}[/dim]\n")
     for pos, uri in enumerate(doc.final_order):
         console.print(
-            _item_panel(uri, pos, total, generators_by_uri, rank_by_uri, after_rank_pos, meta)
+            _item_panel(
+                uri, pos, total, generators_by_uri, rank_by_uri, after_rank_pos, div_by_uri, meta
+            )
         )
 
     discarded = sorted(set(generators_by_uri) - set(final_pos))

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Feed-debug inspection CLI for Green Earth API.
+
+Everything happens in the context of one user, so the user is the first
+positional argument (a handle like ``alice.bsky.social`` or a ``did:`` DID),
+followed by exactly one action flag.
+
+Run from the api/ directory:
+    pipenv run python scripts/feed_debug.py alice.bsky.social --enable
+    pipenv run python scripts/feed_debug.py alice.bsky.social --disable
+    pipenv run python scripts/feed_debug.py alice.bsky.social --list
+    pipenv run python scripts/feed_debug.py alice.bsky.social --list --limit 50
+    pipenv run python scripts/feed_debug.py alice.bsky.social --show <request_id>
+
+Reads Firestore connection from the same env vars as the API server:
+    GE_FIRESTORE_PROJECT, GE_FIRESTORE_DATABASE, GE_FIRESTORE_EMULATOR_HOST
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from app.documents import FeedDebugDocument
+from app.lib.firestore import (
+    get_feed_debug,
+    get_recent_feed_debug,
+    get_user_by_username,
+    init_firestore_client,
+    set_user_debug_flag,
+)
+
+
+async def _resolve_user_did(db, user: str) -> str | None:
+    """Resolve a handle or DID argument to a user DID."""
+    if user.startswith("did:"):
+        return user
+    doc = await get_user_by_username(db, user)
+    return doc.user_did if doc else None
+
+
+async def cmd_enable(user: str, enabled: bool) -> None:
+    db = init_firestore_client()
+    user_did = await _resolve_user_did(db, user)
+    if user_did is None:
+        print(f"No user found for '{user}'.", file=sys.stderr)
+        sys.exit(1)
+    try:
+        await set_user_debug_flag(db, user_did, enabled)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    state = "enabled" if enabled else "disabled"
+    print(f"Feed debugging {state} for {user_did}.")
+
+
+async def cmd_list(user: str, limit: int) -> None:
+    db = init_firestore_client()
+    user_did = await _resolve_user_did(db, user)
+    if user_did is None:
+        print(f"No user found for '{user}'.", file=sys.stderr)
+        sys.exit(1)
+    docs = await get_recent_feed_debug(db, user_did, limit=limit)
+    if not docs:
+        print(f"No feed-debug records for {user_did}.")
+        return
+    print(f"{'request_id':<34} {'feed':<16} {'items':<6} {'generated_at'}")
+    print("-" * 80)
+    for d in docs:
+        generated = d.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        print(f"{d.request_id:<34} {d.feed_name:<16} {len(d.final_order):<6} {generated}")
+
+
+def _media_summary(c) -> str:
+    parts = []
+    if c.image_count:
+        parts.append(f"img:{c.image_count}")
+    elif c.contains_images:
+        parts.append("img")
+    if c.video_count:
+        parts.append(f"vid:{c.video_count}")
+    elif c.contains_video:
+        parts.append("vid")
+    if c.external_uri:
+        parts.append("link")
+    return ",".join(parts) if parts else "-"
+
+
+def _print_show(doc: FeedDebugDocument) -> None:
+    print(f"request_id  : {doc.request_id}")
+    print(f"user        : {doc.username or doc.user_did}")
+    print(f"feed        : {doc.feed_name}")
+    print(f"generated_at: {doc.generated_at.strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    print(f"regenerated : {doc.regenerated}")
+    print(f"ranker      : {doc.ranker_model or '(none)'}    diversify: {doc.diversify}")
+
+    req = doc.generate_request
+    gen_specs = ", ".join(f"{g.name}({g.weight})" for g in req.generators)
+    print()
+    print("--- generation request ---")
+    print(f"generators  : {gen_specs}")
+    print(f"infill      : {req.infill or '(none)'}")
+    print(f"num_candidates: {req.num_candidates}    video_only: {req.video_only}")
+    print(f"excluded    : {len(req.exclude_uris)} uris")
+
+    if doc.user_features:
+        print()
+        print("--- user features ---")
+        for uf in doc.user_features:
+            print(
+                f"{uf.source}: {len(uf.liked_post_uris)} liked posts, "
+                f"{uf.num_embeddings} with embeddings"
+            )
+
+    # Assemble the per-item view by joining stage outputs on at_uri.
+    generators_by_uri: dict[str, list[tuple[str, float | None]]] = {}
+    for result in doc.generator_outputs:
+        for c in result.candidates:
+            if c.at_uri:
+                generators_by_uri.setdefault(c.at_uri, []).append((result.generator_name, c.score))
+
+    rank_by_uri = {
+        r.at_uri: (r.rank, r.rank_score) for r in (doc.ranking.rankings if doc.ranking else [])
+    }
+    after_rank_pos = {uri: i for i, uri in enumerate(doc.order_after_rank)}
+    final_pos = {uri: i for i, uri in enumerate(doc.final_order)}
+
+    # Candidate metadata: prefer the final (sanitized) candidate, else first seen.
+    meta: dict[str, object] = {}
+    for result in doc.generator_outputs:
+        for c in result.candidates:
+            if c.at_uri:
+                meta.setdefault(c.at_uri, c)
+    for c in doc.final_candidates:
+        if c.at_uri:
+            meta[c.at_uri] = c
+
+    print()
+    print(f"--- final feed ({len(doc.final_order)} items) ---")
+    for pos, uri in enumerate(doc.final_order):
+        _print_item(uri, pos, generators_by_uri, rank_by_uri, after_rank_pos, meta)
+
+    discarded = sorted(set(generators_by_uri) - set(final_pos))
+    if discarded:
+        print()
+        print(f"--- discarded ({len(discarded)} candidates not in final feed) ---")
+        for uri in discarded:
+            gens = generators_by_uri.get(uri, [])
+            gen_str = ", ".join(f"{n}:{_fmt_score(s)}" for n, s in gens)
+            print(f"  {uri}  [{gen_str}]")
+
+
+def _fmt_score(score: float | None) -> str:
+    return f"{score:.4f}" if score is not None else "-"
+
+
+def _print_item(uri, pos, generators_by_uri, rank_by_uri, after_rank_pos, meta) -> None:
+    c = meta.get(uri)
+    gens = generators_by_uri.get(uri, [])
+    gen_str = ", ".join(f"{n}:{_fmt_score(s)}" for n, s in gens) or "(infill/unknown)"
+    rank, rank_score = rank_by_uri.get(uri, (None, None))
+    ar = after_rank_pos.get(uri)
+    author = getattr(c, "author_username", None) or getattr(c, "author_did", None) or "?"
+    media = _media_summary(c) if c is not None else "-"
+    content = (getattr(c, "content", None) or "").replace("\n", " ")
+
+    print(f"[{pos}] {uri}")
+    print(f"     author: {author}   media: {media}")
+    print(
+        f"     generators: {gen_str}   rank: {rank} (score {_fmt_score(rank_score)})"
+        f"   after_rank_pos: {ar}"
+    )
+    if content:
+        print(f"     content: {content}")
+
+
+async def cmd_show(user: str, request_id: str) -> None:
+    db = init_firestore_client()
+    user_did = await _resolve_user_did(db, user)
+    if user_did is None:
+        print(f"No user found for '{user}'.", file=sys.stderr)
+        sys.exit(1)
+    doc = await get_feed_debug(db, user_did, request_id)
+    if doc is None:
+        print(f"No feed-debug record {request_id} for {user_did}.", file=sys.stderr)
+        sys.exit(1)
+    _print_show(doc)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Green Earth feed-debug inspection")
+    parser.add_argument("user", help="User handle (e.g. alice.bsky.social) or did:...")
+
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--enable", action="store_true", help="Enable feed debugging for the user")
+    action.add_argument(
+        "--disable", action="store_true", help="Disable feed debugging for the user"
+    )
+    action.add_argument("--list", action="store_true", help="List recent feed loads")
+    action.add_argument("--show", metavar="REQUEST_ID", help="Show one feed load in detail")
+
+    parser.add_argument("--limit", type=int, default=20, help="Max rows for --list (default 20)")
+
+    args = parser.parse_args()
+
+    if args.enable:
+        asyncio.run(cmd_enable(args.user, True))
+    elif args.disable:
+        asyncio.run(cmd_enable(args.user, False))
+    elif args.list:
+        asyncio.run(cmd_list(args.user, args.limit))
+    elif args.show:
+        asyncio.run(cmd_show(args.user, args.show))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -43,6 +43,7 @@ from app.documents import FeedDebugDocument
 from app.lib.firestore import (
     get_feed_debug,
     get_recent_feed_debug,
+    get_user,
     get_user_by_username,
     init_firestore_client,
     set_user_debug_flag,
@@ -163,6 +164,15 @@ async def cmd_list(user: str, limit: int) -> None:
     user_did = await _resolve_user_did(db, user)
     if user_did is None:
         _die(f"No user found for '{user}'.")
+
+    # Surface the current flag state, but still list any existing records.
+    user_doc = await get_user(db, user_did)
+    if user_doc is None or not user_doc.debug_feeds:
+        console.print(
+            "[yellow]Feed debugging is not currently enabled for this user; "
+            "no new records will be captured (enable with --enable).[/yellow]"
+        )
+
     docs = await get_recent_feed_debug(db, user_did, limit=limit)
     if not docs:
         console.print(f"[yellow]No feed-debug records for {user_did}.[/yellow]")
@@ -312,7 +322,7 @@ def _item_panel(
 
     return Panel(
         Group(*group_items),
-        title=f"[dim]{pos}/{total - 1}[/dim]  [dim cyan]{uri}[/dim cyan]",
+        title=f"[grey23]{pos}/{total - 1}[/grey23]  [dim cyan]{uri}[/dim cyan]",
         title_align="left",
         box=box.ROUNDED,
         border_style="grey23",

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -199,6 +199,21 @@ ensure_seen_posts_ttl_policy() {
         || log_warn "TTL policy may already exist or could not be updated (non-fatal)"
 }
 
+ensure_feed_debug_ttl_policy() {
+    local firestore_db
+    firestore_db="$(get_firestore_database)"
+
+    log_info "Ensuring TTL policy on feed_debug.expires_at..."
+    gcloud firestore fields ttls update expires_at \
+        --collection-group=feed_debug \
+        --database="$firestore_db" \
+        --project="$PROJECT_ID" \
+        --enable-ttl \
+        --quiet 2>/dev/null \
+        && log_info "TTL policy enabled on feed_debug.expires_at" \
+        || log_warn "TTL policy may already exist or could not be updated (non-fatal)"
+}
+
 ensure_firestore_api_key_secret() {
     local sa_email="api-runner-$ENVIRONMENT@$PROJECT_ID.iam.gserviceaccount.com"
     local key_display_name
@@ -555,6 +570,7 @@ main() {
     ensure_firestore_database
     ensure_feed_cache_ttl_policy
     ensure_seen_posts_ttl_policy
+    ensure_feed_debug_ttl_policy
     ensure_firestore_api_key_secret
     ensure_inference_api_key_secret_access
     ensure_feed_context_secret

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -35,9 +35,15 @@ class UserDocument(BaseModel):
         default=None,
         description="AT Protocol handle (e.g. foobar.bsky.app)",
     )
-    created_at: datetime = Field(default_factory=_utcnow, description="When the user was first seen")
-    updated_at: datetime = Field(default_factory=_utcnow, description="Last time the document was modified")
-    last_seen_at: datetime = Field(default_factory=_utcnow, description="Most recent feed request from this user")
+    created_at: datetime = Field(
+        default_factory=_utcnow, description="When the user was first seen"
+    )
+    updated_at: datetime = Field(
+        default_factory=_utcnow, description="Last time the document was modified"
+    )
+    last_seen_at: datetime = Field(
+        default_factory=_utcnow, description="Most recent feed request from this user"
+    )
     debug_feeds: bool = Field(
         default=False,
         description="When True, feed loads for this user capture pipeline debugging "
@@ -69,8 +75,12 @@ class SeenPostsDocument(BaseModel):
 
 class FeedActivityDocument(BaseModel):
     feed_name: str = Field(..., description="AT Protocol rkey of the feed (also the document ID)")
-    first_seen_at: datetime = Field(default_factory=_utcnow, description="When the user first loaded this feed")
-    last_seen_at: datetime = Field(default_factory=_utcnow, description="Most recent time the user loaded this feed")
+    first_seen_at: datetime = Field(
+        default_factory=_utcnow, description="When the user first loaded this feed"
+    )
+    last_seen_at: datetime = Field(
+        default_factory=_utcnow, description="Most recent time the user loaded this feed"
+    )
 
 
 class ApiKeyDocument(BaseModel):
@@ -85,9 +95,17 @@ class ApiKeyDocument(BaseModel):
     email: str = Field(..., description="Owner email address")
     is_active: bool = Field(default=True, description="Whether this API key is valid and usable")
     created_at: datetime = Field(default_factory=_utcnow, description="When the key was created")
-    last_used_at: datetime = Field(default_factory=_utcnow, description="Last time this key was used for an API request")
-    monthly_call_count: int = Field(default=0, description="Number of API calls made this billing month")
-    monthly_period: str = Field(default="", description="YYYY-MM of the current call counters; resets each month")
+    last_used_at: datetime = Field(
+        default_factory=_utcnow, description="Last time this key was used for an API request"
+    )
+    monthly_call_count: int = Field(
+        default=0, description="Number of API calls made this billing month"
+    )
+    monthly_period: str = Field(
+        default="", description="YYYY-MM of the current call counters; resets each month"
+    )
+
+
 class InteractionDocument(BaseModel):
     """A single user interaction reported via ``app.bsky.feed.sendInteractions``.
 
@@ -96,15 +114,25 @@ class InteractionDocument(BaseModel):
     time and is the anchor for any future TTL/expiry policy.
     """
 
-    user_did: str = Field(..., description="AT Protocol DID of the user (from the signed feedContext)")
-    item_uri: str | None = Field(default=None, description="AT URI of the post the interaction relates to")
-    event: str = Field(..., description="Interaction event name, e.g. 'interactionLike' (defs# prefix stripped)")
+    user_did: str = Field(
+        ..., description="AT Protocol DID of the user (from the signed feedContext)"
+    )
+    item_uri: str | None = Field(
+        default=None, description="AT URI of the post the interaction relates to"
+    )
+    event: str = Field(
+        ..., description="Interaction event name, e.g. 'interactionLike' (defs# prefix stripped)"
+    )
     feed_name: str = Field(..., description="Feed rkey the interaction originated from")
-    request_id: str = Field(..., description="Request id of the feed response (also the feed-cache key)")
+    request_id: str = Field(
+        ..., description="Request id of the feed response (also the feed-cache key)"
+    )
     feed_generated_at: datetime | None = Field(
         default=None, description="When the feed response was served (from the feedContext iat)"
     )
-    created_at: datetime = Field(default_factory=_utcnow, description="When the interaction was received")
+    created_at: datetime = Field(
+        default_factory=_utcnow, description="When the interaction was received"
+    )
 
 
 class FeedDebugUserFeatures(BaseModel):
@@ -115,12 +143,38 @@ class FeedDebugUserFeatures(BaseModel):
     can see which liked posts drove the result.
     """
 
-    source: str = Field(..., description="Pipeline stage that built these features, e.g. 'two_tower'")
+    source: str = Field(
+        ..., description="Pipeline stage that built these features, e.g. 'two_tower'"
+    )
     liked_post_uris: list[str] = Field(
         default_factory=list, description="Liked-post AT URIs used as user history"
     )
     num_embeddings: int = Field(
         default=0, description="How many of the liked posts had usable embeddings"
+    )
+
+
+class FeedDebugDiversificationEntry(BaseModel):
+    """Per-item diversification breakdown, in final selection order.
+
+    Explains why an item's final position differs from its ranked order: the
+    diversification penalty is split into the portion driven by same-author
+    similarity vs. embedding (content) similarity to already-selected items.
+    Fields are algorithm-agnostic (currently produced by MMR reranking).
+    """
+
+    at_uri: str = Field(..., description="AT URI of the post")
+    relevance: float = Field(
+        ..., description="Normalized relevance entering diversification (0..1)"
+    )
+    score: float = Field(
+        ..., description="Score the item was selected on (relevance minus diversity penalties)"
+    )
+    author_penalty: float = Field(
+        default=0.0, description="Penalty from same-author similarity to selected items"
+    )
+    content_penalty: float = Field(
+        default=0.0, description="Penalty from embedding (content) similarity to selected items"
     )
 
 
@@ -137,7 +191,9 @@ class FeedDebugDocument(BaseModel):
     ``generator_outputs``, ``ranking``, and ``final_order`` on ``at_uri``.
     """
 
-    request_id: str = Field(..., description="Feed-cache key / feedContext id (also the document ID)")
+    request_id: str = Field(
+        ..., description="Feed-cache key / feedContext id (also the document ID)"
+    )
     user_did: str = Field(..., description="AT Protocol DID of the user the feed was served to")
     username: str | None = Field(default=None, description="Resolved handle of the user")
     feed_name: str = Field(..., description="Feed rkey that was loaded")
@@ -147,19 +203,23 @@ class FeedDebugDocument(BaseModel):
     )
 
     # Inputs
-    generate_request: CandidateGenerateRequest = Field(..., description="The candidate-generation request used")
+    generate_request: CandidateGenerateRequest = Field(
+        ..., description="The candidate-generation request used"
+    )
     ranker_model: str | None = Field(default=None, description="Ranking model applied, if any")
-    diversify: bool = Field(default=False, description="Whether MMR diversification was applied")
+    diversify: bool = Field(default=False, description="Whether diversification was applied")
     user_features: list[FeedDebugUserFeatures] = Field(
         default_factory=list, description="User-side feature inputs captured per stage"
     )
 
     # Stage outputs (reused pipeline types)
     generator_outputs: list[CandidateResult] = Field(
-        default_factory=list, description="Raw per-generator output (embeddings stripped, content truncated)"
+        default_factory=list,
+        description="Raw per-generator output (embeddings stripped, content truncated)",
     )
     final_candidates: list[CandidatePost] = Field(
-        default_factory=list, description="Deduped candidate set that entered ranking (embeddings stripped)"
+        default_factory=list,
+        description="Deduped candidate set that entered ranking (embeddings stripped)",
     )
     ranking: RankPredictResult | None = Field(
         default=None, description="Ranker output, when a ranker ran"
@@ -170,7 +230,13 @@ class FeedDebugDocument(BaseModel):
     final_order: list[str] = Field(
         default_factory=list, description="AT URIs in final served order, after diversification"
     )
+    diversification: list[FeedDebugDiversificationEntry] = Field(
+        default_factory=list,
+        description="Per-item diversification breakdown in final order (empty when diversify was off)",
+    )
 
-    created_at: datetime = Field(default_factory=_utcnow, description="When this debug record was written")
+    created_at: datetime = Field(
+        default_factory=_utcnow, description="When this debug record was written"
+    )
     generated_at: datetime = Field(default_factory=_utcnow, description="When the feed was served")
     expires_at: datetime = Field(..., description="UTC expiration timestamp; drives native TTL")

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -16,6 +16,9 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field
 
+from .lib.candidates.base import CandidateResult
+from .models import CandidateGenerateRequest, CandidatePost, RankPredictResult
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -35,6 +38,11 @@ class UserDocument(BaseModel):
     created_at: datetime = Field(default_factory=_utcnow, description="When the user was first seen")
     updated_at: datetime = Field(default_factory=_utcnow, description="Last time the document was modified")
     last_seen_at: datetime = Field(default_factory=_utcnow, description="Most recent feed request from this user")
+    debug_feeds: bool = Field(
+        default=False,
+        description="When True, feed loads for this user capture pipeline debugging "
+        "information into the feed_debug subcollection (has a perf cost).",
+    )
 
 
 class FeedCacheDocument(BaseModel):
@@ -97,3 +105,72 @@ class InteractionDocument(BaseModel):
         default=None, description="When the feed response was served (from the feedContext iat)"
     )
     created_at: datetime = Field(default_factory=_utcnow, description="When the interaction was received")
+
+
+class FeedDebugUserFeatures(BaseModel):
+    """Inputs used to assemble a user-side representation during a feed load.
+
+    Captured per pipeline stage that builds user features (e.g. the
+    ``post_similarity`` search vector and the two-tower user embedding) so we
+    can see which liked posts drove the result.
+    """
+
+    source: str = Field(..., description="Pipeline stage that built these features, e.g. 'two_tower'")
+    liked_post_uris: list[str] = Field(
+        default_factory=list, description="Liked-post AT URIs used as user history"
+    )
+    num_embeddings: int = Field(
+        default=0, description="How many of the liked posts had usable embeddings"
+    )
+
+
+class FeedDebugDocument(BaseModel):
+    """Captured debugging information for a single feed load.
+
+    Stored at ``users/{user_did}/feed_debug/{request_id}``.  This is a thin
+    container around the real pipeline objects (``CandidateGenerateRequest``,
+    ``CandidateResult``, ``RankPredictResult``, ``CandidatePost``) so it keeps
+    capturing new fields as the ranking pipeline evolves.  Embeddings are
+    stripped and post content is truncated before storage.
+
+    The per-item "why this item?" view is assembled at display time by joining
+    ``generator_outputs``, ``ranking``, and ``final_order`` on ``at_uri``.
+    """
+
+    request_id: str = Field(..., description="Feed-cache key / feedContext id (also the document ID)")
+    user_did: str = Field(..., description="AT Protocol DID of the user the feed was served to")
+    username: str | None = Field(default=None, description="Resolved handle of the user")
+    feed_name: str = Field(..., description="Feed rkey that was loaded")
+    regenerated: bool = Field(
+        default=False,
+        description="True when this capture came from the cursor-regeneration path rather than a fresh load",
+    )
+
+    # Inputs
+    generate_request: CandidateGenerateRequest = Field(..., description="The candidate-generation request used")
+    ranker_model: str | None = Field(default=None, description="Ranking model applied, if any")
+    diversify: bool = Field(default=False, description="Whether MMR diversification was applied")
+    user_features: list[FeedDebugUserFeatures] = Field(
+        default_factory=list, description="User-side feature inputs captured per stage"
+    )
+
+    # Stage outputs (reused pipeline types)
+    generator_outputs: list[CandidateResult] = Field(
+        default_factory=list, description="Raw per-generator output (embeddings stripped, content truncated)"
+    )
+    final_candidates: list[CandidatePost] = Field(
+        default_factory=list, description="Deduped candidate set that entered ranking (embeddings stripped)"
+    )
+    ranking: RankPredictResult | None = Field(
+        default=None, description="Ranker output, when a ranker ran"
+    )
+    order_after_rank: list[str] = Field(
+        default_factory=list, description="AT URIs in order after ranking, before diversification"
+    )
+    final_order: list[str] = Field(
+        default_factory=list, description="AT URIs in final served order, after diversification"
+    )
+
+    created_at: datetime = Field(default_factory=_utcnow, description="When this debug record was written")
+    generated_at: datetime = Field(default_factory=_utcnow, description="When the feed was served")
+    expires_at: datetime = Field(..., description="UTC expiration timestamp; drives native TTL")

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -17,6 +17,7 @@ from ...models import (
     GeneratorSpec,
 )
 from .base import CandidateGenerator, CandidateResult, get_generator
+from ..feed_debug import current_recorder
 from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
@@ -139,10 +140,14 @@ async def run_generate(
         *(_run_one(spec, count, gen) for spec, count, gen in active)
     )
 
+    rec = current_recorder()
+
     all_candidates: list[CandidatePost] = []
     for result in results:
         if result is None:
             continue
+        if rec is not None:
+            rec.record_generator_output(result)
         all_candidates.extend(result.candidates)
 
     deduped = dedup_candidates(all_candidates)
@@ -170,6 +175,11 @@ async def run_generate(
             else:
                 raise GeneratorError(request.infill, exc, is_infill=True) from exc
 
+        if rec is not None:
+            rec.record_generator_output(infill_result)
         deduped = dedup_candidates(deduped + infill_result.candidates)
 
-    return CandidateGenerateResult(candidates=deduped[:request.num_candidates])
+    final = deduped[:request.num_candidates]
+    if rec is not None:
+        rec.record_final_candidates(final)
+    return CandidateGenerateResult(candidates=final)

--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -13,6 +13,7 @@ import logging
 from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings, POSTS_KNN_INDEX, unwrap_es_response
+from ..feed_debug import current_recorder
 from ..embeddings import (
     MINILM_L12_EMBEDDING_FIELD,
 )
@@ -143,15 +144,22 @@ class PostSimilarityCandidateGenerator(CandidateGenerator):
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
     ) -> CandidateResult:
+        rec = current_recorder()
+
         # 1. Get recently liked post URIs
         liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
         if not liked_uris:
             logger.info("No likes found for user %s", user_did)
+            if rec is not None:
+                rec.record_user_features(self.name, [], 0)
             return CandidateResult(generator_name=self.name, candidates=[])
 
         # 2. Fetch embeddings for those posts
         embedding_pairs = await fetch_post_embeddings(es, liked_uris)
+
+        if rec is not None:
+            rec.record_user_features(self.name, liked_uris, len(embedding_pairs))
 
         if not embedding_pairs:
             logger.info(

--- a/src/app/lib/candidates/utils.py
+++ b/src/app/lib/candidates/utils.py
@@ -16,6 +16,10 @@ CANDIDATE_SOURCE_FIELDS = [
     "content",
     "thread_parent_post",   # used for Python-side reply filtering
     "contains_video",       # used for video_only filtering
+    "contains_images",      # media metadata (feed debugging)
+    "image_count",          # media metadata (feed debugging)
+    "video_count",          # media metadata (feed debugging)
+    "external_embed",       # link embed metadata (feed debugging)
 ]
 
 
@@ -50,6 +54,11 @@ def candidate_post_from_hit(
         except Exception:
             encoded = None
 
+    external_embed = src.get("external_embed")
+    external_uri = (
+        external_embed.get("uri") if isinstance(external_embed, dict) else None
+    )
+
     return CandidatePost(
         author_did=src.get("author_did"),
         at_uri=src.get("at_uri"),
@@ -57,4 +66,9 @@ def candidate_post_from_hit(
         minilm_l12_embedding=encoded,
         score=hit.get("_score"),
         generator_name=generator_name,
+        contains_images=src.get("contains_images"),
+        contains_video=src.get("contains_video"),
+        image_count=src.get("image_count"),
+        video_count=src.get("video_count"),
+        external_uri=external_uri,
     )

--- a/src/app/lib/candidates/utils_test.py
+++ b/src/app/lib/candidates/utils_test.py
@@ -1,0 +1,47 @@
+"""Tests for shared candidate construction helpers."""
+
+from __future__ import annotations
+
+from .utils import CANDIDATE_SOURCE_FIELDS, candidate_post_from_hit
+
+
+def test_candidate_post_from_hit_populates_media_fields():
+    hit = {
+        "_score": 1.5,
+        "_source": {
+            "at_uri": "at://post/1",
+            "author_did": "did:plc:author",
+            "content": "hello world",
+            "contains_images": True,
+            "contains_video": False,
+            "image_count": 2,
+            "video_count": 0,
+            "external_embed": {"uri": "https://example.com", "title": "x"},
+        },
+    }
+
+    c = candidate_post_from_hit(hit, generator_name="popularity")
+
+    assert c.at_uri == "at://post/1"
+    assert c.author_did == "did:plc:author"
+    assert c.contains_images is True
+    assert c.contains_video is False
+    assert c.image_count == 2
+    assert c.video_count == 0
+    assert c.external_uri == "https://example.com"
+    assert c.generator_name == "popularity"
+
+
+def test_candidate_post_from_hit_handles_missing_media():
+    hit = {"_score": 0.1, "_source": {"at_uri": "at://post/2", "content": "no media"}}
+
+    c = candidate_post_from_hit(hit)
+
+    assert c.contains_images is None
+    assert c.image_count is None
+    assert c.external_uri is None
+
+
+def test_media_fields_requested_from_es():
+    for field in ("contains_images", "image_count", "video_count", "external_embed"):
+        assert field in CANDIDATE_SOURCE_FIELDS

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -3,6 +3,7 @@
 import math
 
 from .embeddings import decode_float32_b64
+from .feed_debug import current_recorder
 from ..models import CandidatePost
 
 BETA = 0.5
@@ -18,11 +19,7 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     shift = min(0.0, min(raw_scores))
     shifted_scores = [s - shift for s in raw_scores]
     shifted_max = max(shifted_scores)
-    norm_scores = (
-        [s / shifted_max for s in shifted_scores]
-        if shifted_max > 0.0
-        else [1.0] * n
-    )
+    norm_scores = [s / shifted_max for s in shifted_scores] if shifted_max > 0.0 else [1.0] * n
 
     # Pre-decode embeddings once so the inner loop never repeats base64 work.
     vecs: list[list[float] | None] = []
@@ -42,25 +39,77 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     # candidate so far. Updated incrementally — one new comparison per remaining
     # item each round instead of recomputing the full max from scratch.
     max_sim = [-math.inf] * n
+    # Author/content split of the neighbour that currently drives max_sim[i], so
+    # the diversification penalty can be attributed when debugging is enabled.
+    max_components: list[tuple[float, float]] = [(0.0, 0.0)] * n
+
+    rec = current_recorder()
+    # (at_uri, relevance, score, author_penalty, content_penalty) per pick, for
+    # the algorithm-agnostic diversification debug record.
+    diag: list[tuple[str, float, float, float, float]] | None = [] if rec is not None else None
 
     while remaining:
         if not selected:
             best = max(remaining, key=lambda i: norm_scores[i])
+            if diag is not None:
+                diag.append(
+                    (candidates[best].at_uri or "", norm_scores[best], norm_scores[best], 0.0, 0.0)
+                )
         else:
             best = max(
                 remaining,
                 key=lambda i: (1 - BETA) * norm_scores[i] - BETA * max_sim[i],
             )
+            if diag is not None:
+                author_match, cosine = max_components[best]
+                author_penalty = BETA * AUTHOR_WEIGHT * author_match
+                content_penalty = BETA * (1 - AUTHOR_WEIGHT) * cosine
+                score = (1 - BETA) * norm_scores[best] - BETA * max_sim[best]
+                diag.append(
+                    (
+                        candidates[best].at_uri or "",
+                        norm_scores[best],
+                        score,
+                        author_penalty,
+                        content_penalty,
+                    )
+                )
 
         selected.append(best)
         remaining.remove(best)
 
         for i in remaining:
-            s = _raw_similarity(author_dids[i], author_dids[best], vecs[i], vecs[best])
+            s, author_match, cosine = _similarity_components(
+                author_dids[i], author_dids[best], vecs[i], vecs[best]
+            )
             if s > max_sim[i]:
                 max_sim[i] = s
+                max_components[i] = (author_match, cosine)
+
+    if rec is not None and diag is not None:
+        rec.record_diversification(diag)
 
     return [candidates[i] for i in selected]
+
+
+def _similarity_components(
+    author_a: str | None,
+    author_b: str | None,
+    vec_a: list[float] | None,
+    vec_b: list[float] | None,
+) -> tuple[float, float, float]:
+    """Return (combined_similarity, author_match, cosine) from pre-decoded inputs.
+
+    The combined value is what MMR penalises; the author_match/cosine parts let
+    the penalty be attributed to author vs. content diversity when debugging.
+    """
+    author_match = 1.0 if (author_a is not None and author_a == author_b) else 0.0
+    if AUTHOR_WEIGHT < 1.0 and vec_a is not None and vec_b is not None:
+        cosine = _cosine_similarity(vec_a, vec_b)
+    else:
+        cosine = 0.0
+    combined = AUTHOR_WEIGHT * author_match + (1 - AUTHOR_WEIGHT) * cosine
+    return combined, author_match, cosine
 
 
 def _raw_similarity(
@@ -70,12 +119,8 @@ def _raw_similarity(
     vec_b: list[float] | None,
 ) -> float:
     """Compute similarity from pre-decoded components; no CandidatePost needed."""
-    author_match = 1.0 if (author_a is not None and author_a == author_b) else 0.0
-    if AUTHOR_WEIGHT < 1.0 and vec_a is not None and vec_b is not None:
-        cosine = _cosine_similarity(vec_a, vec_b)
-    else:
-        cosine = 0.0
-    return AUTHOR_WEIGHT * author_match + (1 - AUTHOR_WEIGHT) * cosine
+    combined, _, _ = _similarity_components(author_a, author_b, vec_a, vec_b)
+    return combined
 
 
 def _similarity(a: CandidatePost, b: CandidatePost) -> float:

--- a/src/app/lib/feed_debug.py
+++ b/src/app/lib/feed_debug.py
@@ -61,6 +61,9 @@ class FeedDebugRecorder:
         self.ranking: "RankPredictResult | None" = None
         self.order_after_rank: list[str] = []
         self.final_order: list[str] = []
+        # (at_uri, relevance, score, author_penalty, content_penalty) in final
+        # selection order; populated only when diversification runs.
+        self.diversification: list[tuple[str, float, float, float, float]] = []
 
     # -- recording -------------------------------------------------------
 
@@ -87,6 +90,11 @@ class FeedDebugRecorder:
     def record_final_order(self, uris: list[str]) -> None:
         self.final_order = list(uris)
 
+    def record_diversification(self, entries: list[tuple[str, float, float, float, float]]) -> None:
+        """Record per-item diversification breakdown: (at_uri, relevance, score,
+        author_penalty, content_penalty) in final selection order."""
+        self.diversification = list(entries)
+
     # -- assembly --------------------------------------------------------
 
     def build_document(
@@ -103,7 +111,11 @@ class FeedDebugRecorder:
         """
         # Imported here (not at module top) to avoid an import cycle:
         # documents -> candidates.base -> ... -> feed_debug -> documents.
-        from ..documents import FeedDebugDocument, FeedDebugUserFeatures
+        from ..documents import (
+            FeedDebugDiversificationEntry,
+            FeedDebugDocument,
+            FeedDebugUserFeatures,
+        )
         from .candidates.base import CandidateResult
 
         if self.generate_request is None:
@@ -138,6 +150,16 @@ class FeedDebugRecorder:
             FeedDebugUserFeatures(source=source, liked_post_uris=uris, num_embeddings=n)
             for source, uris, n in self.user_features
         ]
+        diversification = [
+            FeedDebugDiversificationEntry(
+                at_uri=at_uri,
+                relevance=relevance,
+                score=score,
+                author_penalty=author_penalty,
+                content_penalty=content_penalty,
+            )
+            for at_uri, relevance, score, author_penalty, content_penalty in self.diversification
+        ]
 
         return FeedDebugDocument(
             request_id=request_id,
@@ -154,6 +176,7 @@ class FeedDebugRecorder:
             ranking=self.ranking,
             order_after_rank=self.order_after_rank,
             final_order=self.final_order,
+            diversification=diversification,
             generated_at=generated_at,
             expires_at=expires_at,
         )

--- a/src/app/lib/feed_debug.py
+++ b/src/app/lib/feed_debug.py
@@ -1,0 +1,186 @@
+"""Per-request capture of feed-pipeline debugging information.
+
+A ``ContextVar`` holds the current request's :class:`FeedDebugRecorder` so the
+candidate, ranking, and diversification stages can record what they did without
+threading a recorder argument through every layer.  This mirrors the
+``request_cache_scope`` pattern in :mod:`app.lib.request_cache`: the scope is
+per-task, so concurrent requests get independent recorders and child tasks
+spawned via ``asyncio.gather`` inherit the parent's recorder automatically.
+
+When no recorder is installed (the default), the ``current_recorder()`` accessor
+returns ``None`` and every record helper at the call site is skipped — so the
+feature has zero cost unless a debug-enabled user triggers it.
+
+The recorder holds the *real* pipeline objects (``CandidateGenerateRequest``,
+``CandidateResult``, ``RankPredictResult``, ``CandidatePost``); the per-item
+"why this item?" view is assembled at display time by the CLI.  ``build_document``
+strips embeddings and truncates post content before storage.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from contextvars import ContextVar
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..documents import FeedDebugDocument
+    from ..models import (
+        CandidateGenerateRequest,
+        CandidatePost,
+        RankPredictResult,
+    )
+    from .candidates.base import CandidateResult
+
+# Maximum number of content characters stored per candidate (a snippet, not the
+# full post) so debug documents stay well under Firestore's 1 MB limit.
+CONTENT_SNIPPET_MAX = 300
+
+_recorder: ContextVar["FeedDebugRecorder | None"] = ContextVar(
+    "ge_feed_debug_recorder", default=None
+)
+
+
+class FeedDebugRecorder:
+    """Accumulates pipeline stage outputs for one feed load.
+
+    All record methods are cheap appends/assignments.  Stage instrumentation
+    only calls them when ``current_recorder()`` is non-``None``.
+    """
+
+    def __init__(self, *, feed_name: str, regenerated: bool) -> None:
+        self.feed_name = feed_name
+        self.regenerated = regenerated
+        self.ranker_model: str | None = None
+        self.diversify: bool = False
+        self.generate_request: "CandidateGenerateRequest | None" = None
+        self.generator_outputs: list["CandidateResult"] = []
+        self.final_candidates: list["CandidatePost"] = []
+        self.user_features: list[tuple[str, list[str], int]] = []
+        self.ranking: "RankPredictResult | None" = None
+        self.order_after_rank: list[str] = []
+        self.final_order: list[str] = []
+
+    # -- recording -------------------------------------------------------
+
+    def set_generate_request(self, request: "CandidateGenerateRequest") -> None:
+        self.generate_request = request
+
+    def record_generator_output(self, result: "CandidateResult") -> None:
+        self.generator_outputs.append(result)
+
+    def record_final_candidates(self, candidates: list["CandidatePost"]) -> None:
+        self.final_candidates = list(candidates)
+
+    def record_user_features(
+        self, source: str, liked_post_uris: list[str], num_embeddings: int
+    ) -> None:
+        self.user_features.append((source, list(liked_post_uris), num_embeddings))
+
+    def record_ranking(self, ranking: "RankPredictResult") -> None:
+        self.ranking = ranking
+
+    def record_order_after_rank(self, uris: list[str]) -> None:
+        self.order_after_rank = list(uris)
+
+    def record_final_order(self, uris: list[str]) -> None:
+        self.final_order = list(uris)
+
+    # -- assembly --------------------------------------------------------
+
+    def build_document(
+        self,
+        *,
+        request_id: str,
+        username: str | None,
+        generated_at: datetime,
+        expires_at: datetime,
+        author_usernames: dict[str, str] | None = None,
+    ) -> "FeedDebugDocument":
+        """Assemble a :class:`FeedDebugDocument`, stripping embeddings, truncating
+        content, and stamping resolved author handles onto stored candidates.
+        """
+        # Imported here (not at module top) to avoid an import cycle:
+        # documents -> candidates.base -> ... -> feed_debug -> documents.
+        from ..documents import FeedDebugDocument, FeedDebugUserFeatures
+        from .candidates.base import CandidateResult
+
+        if self.generate_request is None:
+            raise ValueError("FeedDebugRecorder has no generate_request to build from")
+
+        authors = author_usernames or {}
+
+        def sanitize(c: "CandidatePost") -> "CandidatePost":
+            content = c.content
+            if content is not None and len(content) > CONTENT_SNIPPET_MAX:
+                content = content[:CONTENT_SNIPPET_MAX]
+            username_for_author = c.author_username
+            if c.author_did and c.author_did in authors:
+                username_for_author = authors[c.author_did]
+            return c.model_copy(
+                update={
+                    "minilm_l12_embedding": None,
+                    "content": content,
+                    "author_username": username_for_author,
+                }
+            )
+
+        generator_outputs = [
+            CandidateResult(
+                generator_name=r.generator_name,
+                candidates=[sanitize(c) for c in r.candidates],
+            )
+            for r in self.generator_outputs
+        ]
+        final_candidates = [sanitize(c) for c in self.final_candidates]
+        user_features = [
+            FeedDebugUserFeatures(source=source, liked_post_uris=uris, num_embeddings=n)
+            for source, uris, n in self.user_features
+        ]
+
+        return FeedDebugDocument(
+            request_id=request_id,
+            user_did=self.generate_request.user_did,
+            username=username,
+            feed_name=self.feed_name,
+            regenerated=self.regenerated,
+            generate_request=self.generate_request,
+            ranker_model=self.ranker_model,
+            diversify=self.diversify,
+            user_features=user_features,
+            generator_outputs=generator_outputs,
+            final_candidates=final_candidates,
+            ranking=self.ranking,
+            order_after_rank=self.order_after_rank,
+            final_order=self.final_order,
+            generated_at=generated_at,
+            expires_at=expires_at,
+        )
+
+    def author_dids(self) -> set[str]:
+        """All distinct author DIDs across stored candidates (for handle resolution)."""
+        dids: set[str] = set()
+        for c in self.final_candidates:
+            if c.author_did:
+                dids.add(c.author_did)
+        for r in self.generator_outputs:
+            for c in r.candidates:
+                if c.author_did:
+                    dids.add(c.author_did)
+        return dids
+
+
+def current_recorder() -> "FeedDebugRecorder | None":
+    """Return the recorder for the current request, or ``None`` if not debugging."""
+    return _recorder.get()
+
+
+@contextlib.contextmanager
+def feed_debug_scope(recorder: "FeedDebugRecorder"):
+    """Install *recorder* as the current feed-debug recorder for the block."""
+    token = _recorder.set(recorder)
+    try:
+        yield recorder
+    finally:
+        _recorder.reset(token)

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from .candidates.base import CandidateResult
+from .diversify import mmr_rerank
+from .embeddings import encode_float32_b64
 from .feed_debug import (
     CONTENT_SNIPPET_MAX,
     FeedDebugRecorder,
@@ -131,6 +135,16 @@ class TestBuildDocument:
         )
         assert all(c.author_username == "alice.bsky.app" for c in doc.final_candidates)
 
+    def test_includes_diversification(self):
+        rec = self._recorder()
+        rec.record_diversification(
+            [("at://p/2", 0.9, 0.4, 0.3, 0.1), ("at://p/1", 1.0, 1.0, 0.0, 0.0)]
+        )
+        doc = self._build(rec)
+        assert [e.at_uri for e in doc.diversification] == ["at://p/2", "at://p/1"]
+        assert doc.diversification[0].author_penalty == 0.3
+        assert doc.diversification[0].content_penalty == 0.1
+
     def test_author_dids_union(self):
         rec = FeedDebugRecorder(feed_name="f", regenerated=False)
         rec.set_generate_request(_request())
@@ -142,3 +156,57 @@ class TestBuildDocument:
         )
         rec.record_final_candidates([_candidate("at://p/2", author="did:plc:b")])
         assert rec.author_dids() == {"did:plc:a", "did:plc:b"}
+
+
+class TestDiversificationCapture:
+    """Diversification records the relevance + author/content penalty split."""
+
+    def test_author_penalty_recorded(self):
+        # Same author, no embeddings -> penalty is purely author similarity.
+        a = CandidatePost(
+            at_uri="at://a", score=1.0, author_did="did:plc:same", minilm_l12_embedding=None
+        )
+        b = CandidatePost(
+            at_uri="at://b", score=0.5, author_did="did:plc:same", minilm_l12_embedding=None
+        )
+        rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+        with feed_debug_scope(rec):
+            mmr_rerank([a, b])
+
+        assert [e[0] for e in rec.diversification] == ["at://a", "at://b"]
+        # First pick: selected on relevance alone, no penalty.
+        assert rec.diversification[0] == ("at://a", 1.0, 1.0, 0.0, 0.0)
+        # Second pick: author_penalty = BETA * AUTHOR_WEIGHT * 1 = 0.5 * 0.75.
+        _, rel, score, author_pen, content_pen = rec.diversification[1]
+        assert rel == pytest.approx(0.5)
+        assert author_pen == pytest.approx(0.375)
+        assert content_pen == pytest.approx(0.0)
+        assert score == pytest.approx(0.5 * 0.5 - 0.375)
+
+    def test_content_penalty_recorded(self):
+        # Different authors, identical embeddings -> penalty is purely content.
+        emb = encode_float32_b64([1.0, 0.0, 0.0])
+        a = CandidatePost(
+            at_uri="at://a", score=1.0, author_did="did:plc:x", minilm_l12_embedding=emb
+        )
+        b = CandidatePost(
+            at_uri="at://b", score=0.5, author_did="did:plc:y", minilm_l12_embedding=emb
+        )
+        rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+        with feed_debug_scope(rec):
+            mmr_rerank([a, b])
+
+        _, _, _, author_pen, content_pen = rec.diversification[1]
+        # content_penalty = BETA * (1 - AUTHOR_WEIGHT) * cosine(=1) = 0.5 * 0.25.
+        assert author_pen == pytest.approx(0.0)
+        assert content_pen == pytest.approx(0.125)
+
+    def test_no_recording_without_recorder(self):
+        a = CandidatePost(
+            at_uri="at://a", score=1.0, author_did="did:plc:x", minilm_l12_embedding=None
+        )
+        b = CandidatePost(
+            at_uri="at://b", score=0.5, author_did="did:plc:x", minilm_l12_embedding=None
+        )
+        out = mmr_rerank([a, b])  # no active recorder -> must not raise
+        assert [c.at_uri for c in out] == ["at://a", "at://b"]

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -25,6 +25,7 @@ def _request() -> CandidateGenerateRequest:
         generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
         user_did="did:plc:user",
         num_candidates=10,
+        video_only=False,
         infill="popularity",
     )
 
@@ -119,7 +120,9 @@ class TestBuildDocument:
         long = "x" * (CONTENT_SNIPPET_MAX + 50)
         rec.record_final_candidates([_candidate("at://p/1", content=long)])
         doc = self._build(rec)
-        assert len(doc.final_candidates[0].content) == CONTENT_SNIPPET_MAX
+        content = doc.final_candidates[0].content
+        assert content is not None
+        assert len(content) == CONTENT_SNIPPET_MAX
 
     def test_stamps_author_usernames(self):
         doc = self._build(

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -1,0 +1,141 @@
+"""Tests for the feed-debug ContextVar recorder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from .candidates.base import CandidateResult
+from .feed_debug import (
+    CONTENT_SNIPPET_MAX,
+    FeedDebugRecorder,
+    current_recorder,
+    feed_debug_scope,
+)
+from ..models import (
+    CandidateGenerateRequest,
+    CandidatePost,
+    GeneratorSpec,
+    RankedCandidate,
+    RankPredictResult,
+)
+
+
+def _request() -> CandidateGenerateRequest:
+    return CandidateGenerateRequest(
+        generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
+        user_did="did:plc:user",
+        num_candidates=10,
+        infill="popularity",
+    )
+
+
+def _candidate(
+    uri: str, *, embedding: str | None = "ZmFrZQ==", content: str = "hi", author: str = "did:plc:a"
+) -> CandidatePost:
+    return CandidatePost(
+        at_uri=uri,
+        content=content,
+        minilm_l12_embedding=embedding,
+        score=1.0,
+        generator_name="post_similarity",
+        author_did=author,
+    )
+
+
+class TestRecorderScope:
+    def test_no_recorder_by_default(self):
+        assert current_recorder() is None
+
+    def test_scope_installs_and_clears(self):
+        rec = FeedDebugRecorder(feed_name="your-feed", regenerated=False)
+        with feed_debug_scope(rec) as scoped:
+            assert scoped is rec
+            assert current_recorder() is rec
+        assert current_recorder() is None
+
+
+class TestBuildDocument:
+    def _recorder(self) -> FeedDebugRecorder:
+        rec = FeedDebugRecorder(feed_name="your-feed", regenerated=True)
+        rec.ranker_model = "two_tower"
+        rec.diversify = True
+        rec.set_generate_request(_request())
+        rec.record_generator_output(
+            CandidateResult(
+                generator_name="post_similarity",
+                candidates=[_candidate("at://p/1"), _candidate("at://p/2")],
+            )
+        )
+        rec.record_final_candidates([_candidate("at://p/1"), _candidate("at://p/2")])
+        rec.record_user_features("two_tower", ["at://like/1", "at://like/2"], 1)
+        rec.record_ranking(
+            RankPredictResult(
+                rankings=[
+                    RankedCandidate(at_uri="at://p/1", rank=1, rank_score=0.9),
+                    RankedCandidate(at_uri="at://p/2", rank=2, rank_score=0.5),
+                ]
+            )
+        )
+        rec.record_order_after_rank(["at://p/1", "at://p/2"])
+        rec.record_final_order(["at://p/2", "at://p/1"])
+        return rec
+
+    def _build(self, rec: FeedDebugRecorder, **kwargs):
+        now = datetime.now(timezone.utc)
+        return rec.build_document(
+            request_id="req123",
+            username="user.bsky.app",
+            generated_at=now,
+            expires_at=now + timedelta(days=7),
+            **kwargs,
+        )
+
+    def test_preserves_structure(self):
+        doc = self._build(self._recorder())
+        assert doc.request_id == "req123"
+        assert doc.user_did == "did:plc:user"
+        assert doc.feed_name == "your-feed"
+        assert doc.regenerated is True
+        assert doc.ranker_model == "two_tower"
+        assert doc.diversify is True
+        assert len(doc.generator_outputs) == 1
+        assert doc.generator_outputs[0].generator_name == "post_similarity"
+        assert len(doc.final_candidates) == 2
+        assert doc.ranking is not None and len(doc.ranking.rankings) == 2
+        assert doc.order_after_rank == ["at://p/1", "at://p/2"]
+        assert doc.final_order == ["at://p/2", "at://p/1"]
+        assert doc.user_features[0].source == "two_tower"
+        assert doc.user_features[0].num_embeddings == 1
+
+    def test_strips_embeddings(self):
+        doc = self._build(self._recorder())
+        assert all(c.minilm_l12_embedding is None for c in doc.final_candidates)
+        for result in doc.generator_outputs:
+            assert all(c.minilm_l12_embedding is None for c in result.candidates)
+
+    def test_truncates_content(self):
+        rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+        rec.set_generate_request(_request())
+        long = "x" * (CONTENT_SNIPPET_MAX + 50)
+        rec.record_final_candidates([_candidate("at://p/1", content=long)])
+        doc = self._build(rec)
+        assert len(doc.final_candidates[0].content) == CONTENT_SNIPPET_MAX
+
+    def test_stamps_author_usernames(self):
+        doc = self._build(
+            self._recorder(),
+            author_usernames={"did:plc:a": "alice.bsky.app"},
+        )
+        assert all(c.author_username == "alice.bsky.app" for c in doc.final_candidates)
+
+    def test_author_dids_union(self):
+        rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+        rec.set_generate_request(_request())
+        rec.record_generator_output(
+            CandidateResult(
+                generator_name="post_similarity",
+                candidates=[_candidate("at://p/1", author="did:plc:a")],
+            )
+        )
+        rec.record_final_candidates([_candidate("at://p/2", author="did:plc:b")])
+        assert rec.author_dids() == {"did:plc:a", "did:plc:b"}

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -11,7 +11,7 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 
-from google.cloud.firestore import ArrayUnion, AsyncClient, Query  # type: ignore[import-untyped]
+from google.cloud.firestore import ArrayUnion, AsyncClient, FieldFilter, Query  # type: ignore[import-untyped]
 
 from ..documents import (
     FeedActivityDocument,
@@ -124,7 +124,11 @@ async def get_user_by_username(db: AsyncClient, username: str) -> UserDocument |
     Usernames are not guaranteed unique over time (handles can be reused), so
     this returns the first match.
     """
-    query = db.collection(USERS_COLLECTION).where("username", "==", username).limit(1)
+    query = (
+        db.collection(USERS_COLLECTION)
+        .where(filter=FieldFilter("username", "==", username))
+        .limit(1)
+    )
     async for doc in query.stream():
         data = doc.to_dict()
         if data is not None:

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -11,9 +11,14 @@ import logging
 import os
 from datetime import datetime, timedelta, timezone
 
-from google.cloud.firestore import ArrayUnion, AsyncClient  # type: ignore[import-untyped]
+from google.cloud.firestore import ArrayUnion, AsyncClient, Query  # type: ignore[import-untyped]
 
-from ..documents import FeedActivityDocument, InteractionDocument, UserDocument
+from ..documents import (
+    FeedActivityDocument,
+    FeedDebugDocument,
+    InteractionDocument,
+    UserDocument,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,9 +26,13 @@ USERS_COLLECTION = "users"
 FEED_ACTIVITY_COLLECTION = "feed_activity"
 INTERACTIONS_COLLECTION = "interactions"
 SEEN_POSTS_COLLECTION = "seen_posts"
+FEED_DEBUG_COLLECTION = "feed_debug"
 
 # How long a seen-posts bucket lives before native Firestore TTL deletes it.
 SEEN_POSTS_RETENTION_DAYS = 5
+
+# How long a feed-debug record lives before native Firestore TTL deletes it.
+FEED_DEBUG_RETENTION_DAYS = 7
 
 
 def init_firestore_client() -> AsyncClient:
@@ -107,6 +116,33 @@ async def upsert_user(db: AsyncClient, user_did: str, username: str) -> UserDocu
     )
     await ref.set(user.model_dump())
     return user
+
+
+async def get_user_by_username(db: AsyncClient, username: str) -> UserDocument | None:
+    """Fetch a user document by handle, or return ``None`` if not found.
+
+    Usernames are not guaranteed unique over time (handles can be reused), so
+    this returns the first match.
+    """
+    query = db.collection(USERS_COLLECTION).where("username", "==", username).limit(1)
+    async for doc in query.stream():
+        data = doc.to_dict()
+        if data is not None:
+            return UserDocument.model_validate(data)
+    return None
+
+
+async def set_user_debug_flag(db: AsyncClient, user_did: str, enabled: bool) -> None:
+    """Set the ``debug_feeds`` flag on a user document.
+
+    The user document must already exist (users are created on their first feed
+    request); raises ``ValueError`` otherwise so the CLI can report it clearly.
+    """
+    ref = db.collection(USERS_COLLECTION).document(user_did)
+    doc = await ref.get()
+    if not doc.exists:
+        raise ValueError(f"No user document for {user_did}")
+    await ref.update({"debug_feeds": enabled, "updated_at": datetime.now(timezone.utc)})
 
 
 # ---------------------------------------------------------------------------
@@ -249,3 +285,61 @@ async def get_recent_seen_uris(
             if len(result) >= max_uris:
                 return result
     return result
+
+
+# ---------------------------------------------------------------------------
+# Feed debug
+# ---------------------------------------------------------------------------
+
+
+async def write_feed_debug(db: AsyncClient, doc: FeedDebugDocument) -> None:
+    """Persist a feed-debug record under ``users/{user_did}/feed_debug/{request_id}``.
+
+    ``expires_at`` on the document drives the native Firestore TTL so records
+    self-delete ~``FEED_DEBUG_RETENTION_DAYS`` days after the feed was served.
+    """
+    ref = (
+        db.collection(USERS_COLLECTION)
+        .document(doc.user_did)
+        .collection(FEED_DEBUG_COLLECTION)
+        .document(doc.request_id)
+    )
+    await ref.set(doc.model_dump())
+
+
+async def get_recent_feed_debug(
+    db: AsyncClient, user_did: str, *, limit: int = 20
+) -> list[FeedDebugDocument]:
+    """Return a user's most recent feed-debug records, newest first."""
+    query = (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(FEED_DEBUG_COLLECTION)
+        .order_by("generated_at", direction=Query.DESCENDING)
+        .limit(limit)
+    )
+    docs: list[FeedDebugDocument] = []
+    async for doc in query.stream():
+        data = doc.to_dict()
+        if data is not None:
+            docs.append(FeedDebugDocument.model_validate(data))
+    return docs
+
+
+async def get_feed_debug(
+    db: AsyncClient, user_did: str, request_id: str
+) -> FeedDebugDocument | None:
+    """Fetch a single feed-debug record, or ``None`` if not found."""
+    doc = await (
+        db.collection(USERS_COLLECTION)
+        .document(user_did)
+        .collection(FEED_DEBUG_COLLECTION)
+        .document(request_id)
+        .get()
+    )
+    if not doc.exists:
+        return None
+    data = doc.to_dict()
+    if data is None:
+        return None
+    return FeedDebugDocument.model_validate(data)

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -485,6 +485,8 @@ def _feed_debug_doc() -> FeedDebugDocument:
             generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
             user_did=USER_DID,
             num_candidates=10,
+            video_only=False,
+            infill=None,
         ),
         final_order=["at://p/1", "at://p/2"],
         generated_at=now,

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -2,26 +2,33 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from google.cloud.firestore import ArrayUnion
 
-from ..documents import InteractionDocument, UserDocument
+from ..documents import FeedDebugDocument, InteractionDocument, UserDocument
+from ..models import CandidateGenerateRequest, GeneratorSpec
 from ..lib.firestore import (
+    FEED_DEBUG_COLLECTION,
     INTERACTIONS_COLLECTION,
     SEEN_POSTS_COLLECTION,
     USERS_COLLECTION,
     get_feed_activity,
+    get_feed_debug,
+    get_recent_feed_debug,
     get_recent_seen_uris,
     get_user,
+    get_user_by_username,
     init_firestore_client,
     record_interaction,
     record_seen_posts,
+    set_user_debug_flag,
     upsert_feed_activity,
     upsert_user,
+    write_feed_debug,
 )
 
 
@@ -458,3 +465,133 @@ class TestGetRecentSeenUris:
         assert len(uris) == 1000
         assert uris[0] == "at://post/0"
         assert uris[-1] == "at://post/999"
+
+
+# ---------------------------------------------------------------------------
+# Feed debug flag + records
+# ---------------------------------------------------------------------------
+
+REQUEST_ID = "req-abc123"
+
+
+def _feed_debug_doc() -> FeedDebugDocument:
+    now = datetime.now(timezone.utc)
+    return FeedDebugDocument(
+        request_id=REQUEST_ID,
+        user_did=USER_DID,
+        username=USERNAME,
+        feed_name=FEED_NAME,
+        generate_request=CandidateGenerateRequest(
+            generators=[GeneratorSpec(name="post_similarity", weight=1.0)],
+            user_did=USER_DID,
+            num_candidates=10,
+        ),
+        final_order=["at://p/1", "at://p/2"],
+        generated_at=now,
+        expires_at=now + timedelta(days=7),
+    )
+
+
+class TestGetUserByUsername:
+    @pytest.mark.asyncio
+    async def test_returns_first_match(self):
+        now = datetime.now(timezone.utc)
+        snap = _mock_doc_snapshot(True, {
+            "user_did": USER_DID,
+            "username": USERNAME,
+            "created_at": now,
+            "updated_at": now,
+            "last_seen_at": now,
+        })
+        db = MagicMock()
+        query = MagicMock()
+        query.stream.return_value = _async_iter([snap])
+        db.collection.return_value.where.return_value.limit.return_value = query
+
+        user = await get_user_by_username(db, USERNAME)
+
+        assert user is not None
+        assert user.user_did == USER_DID
+        db.collection.assert_called_with(USERS_COLLECTION)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self):
+        db = MagicMock()
+        query = MagicMock()
+        query.stream.return_value = _async_iter([])
+        db.collection.return_value.where.return_value.limit.return_value = query
+
+        assert await get_user_by_username(db, USERNAME) is None
+
+
+class TestSetUserDebugFlag:
+    @pytest.mark.asyncio
+    async def test_updates_flag(self):
+        db, _, doc_ref = _mock_firestore_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(True, {"user_did": USER_DID})
+
+        await set_user_debug_flag(db, USER_DID, True)
+
+        doc_ref.update.assert_called_once()
+        written = doc_ref.update.call_args[0][0]
+        assert written["debug_feeds"] is True
+        assert "updated_at" in written
+
+    @pytest.mark.asyncio
+    async def test_raises_when_user_missing(self):
+        db, _, doc_ref = _mock_firestore_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        with pytest.raises(ValueError):
+            await set_user_debug_flag(db, USER_DID, True)
+
+
+class TestWriteFeedDebug:
+    @pytest.mark.asyncio
+    async def test_writes_to_subcollection(self):
+        db, doc_ref = _mock_feed_activity_client()
+
+        await write_feed_debug(db, _feed_debug_doc())
+
+        doc_ref.set.assert_called_once()
+        written = doc_ref.set.call_args[0][0]
+        assert written["request_id"] == REQUEST_ID
+        assert written["final_order"] == ["at://p/1", "at://p/2"]
+
+
+class TestGetRecentFeedDebug:
+    @pytest.mark.asyncio
+    async def test_returns_records(self):
+        doc = _feed_debug_doc()
+        snap = _mock_doc_snapshot(True, doc.model_dump())
+        db = MagicMock()
+        query = MagicMock()
+        query.stream.return_value = _async_iter([snap])
+        (
+            db.collection.return_value.document.return_value.collection.return_value.order_by.return_value.limit.return_value
+        ) = query
+
+        docs = await get_recent_feed_debug(db, USER_DID, limit=5)
+
+        assert len(docs) == 1
+        assert docs[0].request_id == REQUEST_ID
+
+
+class TestGetFeedDebug:
+    @pytest.mark.asyncio
+    async def test_returns_record(self):
+        doc = _feed_debug_doc()
+        db, doc_ref = _mock_feed_activity_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(True, doc.model_dump())
+
+        result = await get_feed_debug(db, USER_DID, REQUEST_ID)
+
+        assert result is not None
+        assert result.request_id == REQUEST_ID
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self):
+        db, doc_ref = _mock_feed_activity_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        assert await get_feed_debug(db, USER_DID, REQUEST_ID) is None

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -13,6 +13,7 @@ from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerExecutionError, RankerResult
 from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings_and_authors
 from ..embeddings import decode_float32_b64
+from ..feed_debug import current_recorder
 from ..http_client import get_http_client
 from ..request_context import get_request_id
 from ..telemetry import timed
@@ -169,12 +170,20 @@ class TwoTowerRanker(Ranker):
                 history_author_dids: list[str] = []
                 user_history_liked_uris = await fetch_recent_liked_post_uris(es, user_did)
 
+                rec = current_recorder()
+
                 if not user_history_liked_uris:
                     logger.info("No likes found for user %s", user_did)
+                    if rec is not None:
+                        rec.record_user_features(self.name, [], 0)
                 else:
                     user_history_embedding_pairs: list[tuple[str, list[float], str]] = await fetch_post_embeddings_and_authors(
                         es, user_history_liked_uris,
                     )
+                    if rec is not None:
+                        rec.record_user_features(
+                            self.name, user_history_liked_uris, len(user_history_embedding_pairs)
+                        )
                     if not user_history_embedding_pairs:
                         logger.info(
                             "No embeddings found for %d liked posts of user %s",

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -53,6 +53,26 @@ class CandidatePost(BaseModel):
     author_did: str | None = Field(
         default=None, description="AT Protocol DID of the post author"
     )
+    author_username: str | None = Field(
+        default=None,
+        description="AT Protocol handle of the post author (resolved from author_did; "
+        "not stored in Elasticsearch, populated lazily where needed)",
+    )
+    contains_images: bool | None = Field(
+        default=None, description="Whether the post embeds one or more images"
+    )
+    contains_video: bool | None = Field(
+        default=None, description="Whether the post embeds video"
+    )
+    image_count: int | None = Field(
+        default=None, description="Number of images embedded in the post"
+    )
+    video_count: int | None = Field(
+        default=None, description="Number of videos embedded in the post"
+    )
+    external_uri: str | None = Field(
+        default=None, description="URI of an external link embed, when present"
+    )
 
 
 class GeneratorSpec(BaseModel):

--- a/src/app/routers/skylight_test.py
+++ b/src/app/routers/skylight_test.py
@@ -80,6 +80,12 @@ def test_search_returns_embedding():
                 "score": 1.5,
                 "generator_name": None,
                 "author_did": None,
+                "author_username": None,
+                "contains_images": None,
+                "contains_video": None,
+                "image_count": None,
+                "video_count": None,
+                "external_uri": None,
             }
         ]
     }
@@ -100,6 +106,12 @@ def test_similar_with_at_uris():
                 "score": 1.5,
                 "generator_name": None,
                 "author_did": None,
+                "author_username": None,
+                "contains_images": None,
+                "contains_video": None,
+                "image_count": None,
+                "video_count": None,
+                "external_uri": None,
             }
         ]
     }
@@ -120,6 +132,12 @@ def test_similar_with_embeddings():
                 "score": 1.5,
                 "generator_name": None,
                 "author_did": None,
+                "author_username": None,
+                "contains_images": None,
+                "contains_video": None,
+                "image_count": None,
+                "video_count": None,
+                "external_uri": None,
             }
         ]
     }

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -58,6 +58,7 @@ router = APIRouter(tags=["xrpc"])
 # Configuration
 # ---------------------------------------------------------------------------
 
+
 def _get_service_did() -> str:
     """Return the DID of this feed generator service.
 
@@ -73,7 +74,7 @@ def _get_hostname() -> str:
     did = _get_service_did()
     # did:web:<hostname> → hostname
     if did.startswith("did:web:"):
-        return did[len("did:web:"):]
+        return did[len("did:web:") :]
     return "localhost"
 
 
@@ -110,6 +111,7 @@ async def _resolve_username(request: Request, user_did: str) -> str:
 # Response models
 # ---------------------------------------------------------------------------
 
+
 class FeedLink(BaseModel):
     uri: str = Field(..., description="AT URI of the feed")
 
@@ -134,6 +136,7 @@ class FeedSkeletonResponse(BaseModel):
     When ``cursor`` is ``None`` it is omitted from the JSON output — the
     AT Protocol spec requires the field to be absent rather than ``null``.
     """
+
     model_config = {"populate_by_name": True}
 
     feed: list[SkeletonItem] = Field(default_factory=list)
@@ -177,7 +180,9 @@ class Interaction(BaseModel):
     model_config = {"populate_by_name": True}
 
     item: str | None = Field(default=None, description="AT URI of the post interacted with")
-    event: str | None = Field(default=None, description="Interaction event type (app.bsky.feed.defs#...)")
+    event: str | None = Field(
+        default=None, description="Interaction event type (app.bsky.feed.defs#...)"
+    )
     feed_context: str | None = Field(
         default=None,
         validation_alias="feedContext",
@@ -198,9 +203,7 @@ class SendInteractionsResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-async def _hydrate_embeddings(
-    es, candidates: list[CandidatePost]
-) -> list[CandidatePost]:
+async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[CandidatePost]:
     """Fetch missing L12 embeddings in a single batched ES call.
 
     Candidate generators skip the embedding when reading from ES — the
@@ -210,9 +213,7 @@ async def _hydrate_embeddings(
     callers (e.g. the two-tower ranker re-asking for the same URIs)
     pay no additional ES cost.
     """
-    missing = [
-        c.at_uri for c in candidates if c.at_uri and not c.minilm_l12_embedding
-    ]
+    missing = [c.at_uri for c in candidates if c.at_uri and not c.minilm_l12_embedding]
     if not missing:
         return candidates
 
@@ -341,9 +342,7 @@ async def _run_pipeline_capturing(
     generated_at = datetime.now(timezone.utc)
     with feed_debug_scope(recorder):
         uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
-    _spawn_background(
-        _write_feed_debug(request, db, recorder, request_id, user_did, generated_at)
-    )
+    _spawn_background(_write_feed_debug(request, db, recorder, request_id, user_did, generated_at))
     return uris
 
 
@@ -483,8 +482,10 @@ async def _write_feed_debug(
 ) -> None:
     """Resolve author handles, assemble the debug document, and persist it.
 
-    Runs as a background task so handle resolution and the Firestore write stay
-    off the feed-serving hot path. Failures are logged, never surfaced.
+    This coroutine does the work but does *not* spawn its own task: the caller
+    (``_run_pipeline_capturing``) is responsible for running it via
+    ``_spawn_background`` so handle resolution and the Firestore write stay off
+    the feed-serving hot path. Failures are logged, never surfaced.
     """
     try:
         author_usernames = await _resolve_handles(request, recorder.author_dids())
@@ -561,6 +562,7 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
 # Endpoints
 # ---------------------------------------------------------------------------
 
+
 @router.get("/.well-known/did.json", response_class=JSONResponse)
 async def well_known_did() -> JSONResponse:
     """Serve the DID document for ``did:web`` resolution.
@@ -585,6 +587,7 @@ async def well_known_did() -> JSONResponse:
         },
         media_type="application/json",
     )
+
 
 @router.get(
     "/xrpc/app.bsky.feed.describeFeedGenerator",

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -16,7 +16,7 @@ import logging
 import os
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 from ..documents import InteractionDocument
 from ..lib.candidates import run_generate
 from ..lib.diversify import mmr_rerank
+from ..lib.feed_debug import FeedDebugRecorder, current_recorder, feed_debug_scope
 
 from ..lib.elasticsearch import fetch_post_embeddings
 from ..lib.embeddings import encode_float32_b64
@@ -35,11 +36,14 @@ from ..models import CandidateGenerateRequest, CandidatePost, FeedConfig, FeedCu
 
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.firestore import (
+    FEED_DEBUG_RETENTION_DAYS,
     get_recent_seen_uris,
+    get_user,
     record_interaction,
     record_seen_posts,
     upsert_feed_activity,
     upsert_user,
+    write_feed_debug,
 )
 from ..lib.request_cache import request_cache_scope
 from ..lib.telemetry import timed
@@ -252,6 +256,13 @@ async def _run_ranking_pipeline(
     both ``post_similarity`` and the two-tower ranker) collapse to a
     single round-trip.
     """
+    rec = current_recorder()
+    if rec is not None:
+        rec.set_generate_request(gen_request)
+        rec.diversify = feed_cfg.diversify
+        if feed_cfg.rank_request_template is not None:
+            rec.ranker_model = feed_cfg.rank_request_template.model
+
     async with request_cache_scope():
         async with timed(
             logger,
@@ -281,6 +292,8 @@ async def _run_ranking_pipeline(
                 model=rank_req.model,
             ):
                 rank_result = await run_predict(rank_req, es)
+            if rec is not None:
+                rec.record_ranking(rank_result)
             # Reorder CandidatePosts by model rank and stamp rank_score onto each
             # so MMR uses the model's relevance scores, not the generator scores.
             by_uri = {c.at_uri: c for c in candidates if c.at_uri}
@@ -292,8 +305,46 @@ async def _run_ranking_pipeline(
         else:
             ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
 
+        if rec is not None:
+            rec.record_order_after_rank([c.at_uri for c in ordered if c.at_uri])
+
         final = mmr_rerank(ordered) if feed_cfg.diversify else ordered
-        return [c.at_uri for c in final if c.at_uri]
+        final_uris = [c.at_uri for c in final if c.at_uri]
+        if rec is not None:
+            rec.record_final_order(final_uris)
+        return final_uris
+
+
+async def _run_pipeline_capturing(
+    request: Request,
+    db,
+    feed_cfg: FeedConfig,
+    gen_request: CandidateGenerateRequest,
+    *,
+    feed_name: str,
+    user_did: str,
+    request_id: str,
+    regenerated: bool,
+    debug_enabled: bool,
+) -> list[str]:
+    """Run the ranking pipeline, optionally capturing debug info for this user.
+
+    When ``debug_enabled``, a :class:`FeedDebugRecorder` is installed for the
+    duration of the pipeline and a background task persists the assembled
+    document afterwards (handle resolution + the Firestore write stay off the
+    hot path).
+    """
+    if not debug_enabled:
+        return await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
+
+    recorder = FeedDebugRecorder(feed_name=feed_name, regenerated=regenerated)
+    generated_at = datetime.now(timezone.utc)
+    with feed_debug_scope(recorder):
+        uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
+    _spawn_background(
+        _write_feed_debug(request, db, recorder, request_id, user_did, generated_at)
+    )
+    return uris
 
 
 # ---------------------------------------------------------------------------
@@ -397,6 +448,58 @@ async def _record_session(request: Request, user_did: str, feed_name: str, db) -
         logger.exception(
             "Failed to record feed activity for user '%s', feed '%s'", user_did, feed_name
         )
+
+
+async def _resolve_handles(request: Request, dids: set[str]) -> dict[str, str]:
+    """Best-effort batch DID→handle resolution; failures are skipped.
+
+    Used for feed-debug capture only, so a DID that fails to resolve is simply
+    omitted from the result rather than raising.
+    """
+    resolver = getattr(request.app.state, "id_resolver", None)
+    if resolver is None or not dids:
+        return {}
+
+    did_list = list(dids)
+
+    async def _one(did: str) -> str | None:
+        try:
+            did_doc = await resolver.did.resolve(did)
+            return did_doc.get_handle() if did_doc is not None else None
+        except Exception:
+            return None
+
+    handles = await asyncio.gather(*(_one(did) for did in did_list))
+    return {did: handle for did, handle in zip(did_list, handles) if handle}
+
+
+async def _write_feed_debug(
+    request: Request,
+    db,
+    recorder: FeedDebugRecorder,
+    request_id: str,
+    user_did: str,
+    generated_at: datetime,
+) -> None:
+    """Resolve author handles, assemble the debug document, and persist it.
+
+    Runs as a background task so handle resolution and the Firestore write stay
+    off the feed-serving hot path. Failures are logged, never surfaced.
+    """
+    try:
+        author_usernames = await _resolve_handles(request, recorder.author_dids())
+        username = author_usernames.get(user_did)
+        expires_at = generated_at + timedelta(days=FEED_DEBUG_RETENTION_DAYS)
+        doc = recorder.build_document(
+            request_id=request_id,
+            username=username,
+            generated_at=generated_at,
+            expires_at=expires_at,
+            author_usernames=author_usernames,
+        )
+        await write_feed_debug(db, doc)
+    except Exception:
+        logger.exception("Failed to write feed debug record for user '%s'", user_did)
 
 
 async def _record_interactions(db, interactions: list["Interaction"]) -> None:
@@ -565,6 +668,16 @@ async def get_feed_skeleton(
 
     _spawn_background(_record_session(request, user_did, feed_name, db))
 
+    # Per-user opt-in: capture pipeline debugging info for this feed load. This
+    # costs one extra Firestore read per request; fail-soft so a hiccup degrades
+    # to no-debug rather than breaking feed serving.
+    debug_enabled = False
+    try:
+        user_doc = await get_user(db, user_did)
+        debug_enabled = bool(user_doc and user_doc.debug_feeds)
+    except Exception:
+        logger.exception("Failed to read debug flag for user '%s'", user_did)
+
     feed_cache = _get_feed_cache(request)
 
     async with timed(
@@ -616,7 +729,17 @@ async def get_feed_skeleton(
                     }
                 )
 
-                new_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
+                new_uris = await _run_pipeline_capturing(
+                    request,
+                    db,
+                    feed_cfg,
+                    gen_request,
+                    feed_name=feed_name,
+                    user_did=user_did,
+                    request_id=parsed.id,
+                    regenerated=True,
+                    debug_enabled=debug_enabled,
+                )
                 if new_uris:
                     async with timed(logger, "feedcache_append", cache_id=parsed.id):
                         updated = await feed_cache.append(parsed.id, new_uris)
@@ -646,22 +769,32 @@ async def get_feed_skeleton(
             update={"user_did": user_did, "num_candidates": batch, "exclude_uris": seen_uris}
         )
 
-        all_uris = await _run_ranking_pipeline(feed_cfg, gen_request, request.app.state.es)
+        # The request id identifies this response; when we cache a batch it doubles
+        # as the cache key so the served order can be recovered from interactions.
+        # Generated up front so it can key the debug record too.
+        request_id = uuid.uuid4().hex
+
+        all_uris = await _run_pipeline_capturing(
+            request,
+            db,
+            feed_cfg,
+            gen_request,
+            feed_name=feed_name,
+            user_did=user_did,
+            request_id=request_id,
+            regenerated=False,
+            debug_enabled=debug_enabled,
+        )
 
         # First page to return immediately.
         page = all_uris[:limit]
 
         # Store the full batch and issue a cursor only when there are more pages.
-        # The request id identifies this response; when we cache a batch it doubles
-        # as the cache key so the served order can be recovered from interactions.
         next_cursor = None
         if len(all_uris) > limit:
-            request_id = uuid.uuid4().hex
             async with timed(logger, "feedcache_store", cache_id=request_id):
                 await feed_cache.store(request_id, all_uris)
             next_cursor = FeedCursor(id=request_id, offset=limit).encode()
-        else:
-            request_id = uuid.uuid4().hex
 
         feed_context = _make_feed_context(user_did, feed_name, request_id)
         return FeedSkeletonResponse(

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1,5 +1,6 @@
 """Tests for the XRPC feed generator endpoints."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1603,3 +1604,82 @@ class TestSendInteractions:
 
         rec.assert_called_once()  # raw interaction is still stored
         seen_rec.assert_not_called()  # but not denormalized
+
+
+# ---------------------------------------------------------------------------
+# Feed debug capture
+# ---------------------------------------------------------------------------
+
+class TestFeedDebugCapture:
+    """getFeedSkeleton captures debug info only for flagged users."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_auth_and_session(self):
+        with (
+            patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"),
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
+            yield
+
+    def _patch_generators(self, candidates):
+        return _patch_unranked_your_feed_generators(candidates)
+
+    def _user_doc(self, debug_feeds):
+        from ..documents import UserDocument
+
+        return UserDocument(user_did="did:plc:testuser", username=TEST_USERNAME, debug_feeds=debug_feeds)
+
+    @staticmethod
+    async def _drain(coros):
+        for coro in coros:
+            await coro
+
+    def test_writes_debug_record_when_enabled(self):
+        spawned: list = []
+        with (
+            self._patch_generators(_make_candidates("p", 3)),
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(True)),
+            patch("app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)),
+            patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_write,
+        ):
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
+            assert resp.status_code == 200
+            asyncio.run(self._drain(spawned))
+
+        mock_write.assert_awaited_once()
+        doc = mock_write.call_args[0][1]
+        assert doc.user_did == "did:plc:testuser"
+        assert doc.feed_name == FEED_RKEY
+        assert doc.final_order == ["at://p/0", "at://p/1", "at://p/2"]
+        # Generator output was captured under the active recorder scope.
+        assert any(r.generator_name == "post_similarity" for r in doc.generator_outputs)
+
+    def test_no_debug_record_when_disabled(self):
+        spawned: list = []
+        with (
+            self._patch_generators(_make_candidates("p", 3)),
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(False)),
+            patch("app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)),
+            patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_write,
+        ):
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
+            assert resp.status_code == 200
+            asyncio.run(self._drain(spawned))
+
+        mock_write.assert_not_awaited()
+
+    def test_flag_read_failure_is_non_fatal(self, caplog):
+        spawned: list = []
+        with (
+            self._patch_generators(_make_candidates("p", 2)),
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, side_effect=RuntimeError("boom")),
+            patch("app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)),
+            patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_write,
+        ):
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
+            assert resp.status_code == 200
+            asyncio.run(self._drain(spawned))
+
+        mock_write.assert_not_awaited()
+        assert "Failed to read debug flag" in caplog.text


### PR DESCRIPTION
Closes #114.

When a post shows up in a feed, we currently have no way to answer "why this item?" after the fact. The retrieve → rank → diversify pipeline discards all intermediate signal: which generator produced a candidate, its scores at each stage, how the ranker reordered it, and where diversification finally placed it. This PR captures that information per feed load so we can inspect it later, and adds a CLI to do so.

### Approach

Capture is driven by a `ContextVar` recorder (`lib/feed_debug.py`), mirroring the existing `request_cache_scope` pattern. Pipeline stages call record helpers that are no-ops unless a recorder is installed, so there is **zero cost unless a debug-enabled user triggers it**. The recorder holds the real pipeline objects (`CandidateGenerateRequest`, `CandidateResult`, `RankPredictResult`, `CandidatePost`) rather than parallel debug types, so it keeps capturing new fields as the ranking pipeline evolves; the per-item "why this item?" view is assembled at display time by the CLI.

Capture is gated behind a per-user `debug_feeds` flag on the user record (no feature-flag library yet, per the issue). The flag is read once on the feed hot path (fail-soft); when enabled, the pipeline runs under a recorder scope and the assembled document is written in a background task — handle resolution and the Firestore write stay off the serving path.

### What's included

- **Per-user opt-in flag** `debug_feeds` on `UserDocument`.
- **Debug records** stored at `users/{did}/feed_debug/{request_id}`, one per feed load, with a 7-day native TTL (`expires_at`). TTL policy registered in `scripts/gcp_setup.sh` alongside the existing `feed_cache`/`seen_posts` policies.
- **`CandidatePost` enrichment**: added `author_username` plus media metadata (`contains_images`, `contains_video`, `image_count`, `video_count`, `external_uri`). Media comes from Elasticsearch via the shared `candidate_post_from_hit`; author handles are resolved DID→handle via the existing id resolver in the background writer. These are canonical post attributes, not debug-only fields.
- **Instrumentation** of candidate generation, the `post_similarity`/`two_tower` user-feature steps, and the rank/diversify stages — no signature changes.
- **CLI** `scripts/feed_debug.py`: `feed_debug <user> --enable|--disable|--list|--show <request_id>`, with `rich`-rendered output that shows each item's journey (`retrieved by <generator> (gen score) → ranked #N (model score) → final #pos`), media, snippet, and a discarded-candidates table. `--environment dev|stage|prod` (default `dev`/emulator; `--env` alias) selects the Firestore target.

### Notes

- `rich` added to `[dev-packages]` (the CLI is a local debug tool, never imported by the server).
- Embeddings are stripped and post content is truncated before storage to keep documents well under Firestore's 1 MB limit.
- The `feed_debug` TTL policy must be applied to stage/prod by running `scripts/gcp_setup.sh` against each (the local emulator ignores TTL policies).
- Tested: recorder/build-document, document + Firestore-helper, media-field, and end-to-end xrpc capture tests; full suite green.
