### PR TITLE
Use colon-free user document IDs

### DIFF
--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -34,6 +34,18 @@ SEEN_POSTS_RETENTION_DAYS = 5
 # How long a feed-debug record lives before native Firestore TTL deletes it.
 FEED_DEBUG_RETENTION_DAYS = 7
 
+# Prefix stripped from a DID to form the user document ID. The full DID is
+# still stored in the document's ``user_did`` field; only the document *key* is
+# shortened. This keeps colons out of the key — colons in a document ID break
+# subcollection navigation in the Firestore emulator UI. All users are
+# currently did:plc; other DID methods are passed through unchanged.
+_USER_DID_PREFIX = "did:plc:"
+
+
+def user_doc_id(user_did: str) -> str:
+    """Map a DID to its Firestore user-document ID (colon-free for did:plc)."""
+    return user_did.removeprefix(_USER_DID_PREFIX)
+
 
 def init_firestore_client() -> AsyncClient:
     """Create an async Firestore client.
@@ -71,7 +83,7 @@ def init_firestore_client() -> AsyncClient:
 
 async def get_user(db: AsyncClient, user_did: str) -> UserDocument | None:
     """Fetch a user document by DID, or return ``None`` if not found."""
-    doc = await db.collection(USERS_COLLECTION).document(user_did).get()
+    doc = await db.collection(USERS_COLLECTION).document(user_doc_id(user_did)).get()
     if not doc.exists:
         return None
     data = doc.to_dict()
@@ -87,7 +99,7 @@ async def upsert_user(db: AsyncClient, user_did: str, username: str) -> UserDocu
     On subsequent visits ``last_seen_at`` is refreshed and ``username`` is
     updated if it changed.
     """
-    ref = db.collection(USERS_COLLECTION).document(user_did)
+    ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
     doc = await ref.get()
 
     now = datetime.now(timezone.utc)
@@ -142,7 +154,7 @@ async def set_user_debug_flag(db: AsyncClient, user_did: str, enabled: bool) -> 
     The user document must already exist (users are created on their first feed
     request); raises ``ValueError`` otherwise so the CLI can report it clearly.
     """
-    ref = db.collection(USERS_COLLECTION).document(user_did)
+    ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
     doc = await ref.get()
     if not doc.exists:
         raise ValueError(f"No user document for {user_did}")
@@ -158,7 +170,7 @@ async def get_feed_activity(db: AsyncClient, user_did: str, feed_name: str) -> F
     """Fetch a feed activity document, or return ``None`` if not found."""
     doc = await (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(FEED_ACTIVITY_COLLECTION)
         .document(feed_name)
         .get()
@@ -180,7 +192,7 @@ async def upsert_feed_activity(db: AsyncClient, user_did: str, feed_name: str) -
     """
     ref = (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(FEED_ACTIVITY_COLLECTION)
         .document(feed_name)
     )
@@ -244,7 +256,7 @@ async def record_seen_posts(db: AsyncClient, user_did: str, post_uris: list[str]
 
     ref = (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(SEEN_POSTS_COLLECTION)
         .document(bucket_id)
     )
@@ -268,7 +280,7 @@ async def get_recent_seen_uris(
     now = datetime.now(timezone.utc)
     query = (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(SEEN_POSTS_COLLECTION)
         .where("expires_at", ">", now)
     )
@@ -304,7 +316,7 @@ async def write_feed_debug(db: AsyncClient, doc: FeedDebugDocument) -> None:
     """
     ref = (
         db.collection(USERS_COLLECTION)
-        .document(doc.user_did)
+        .document(user_doc_id(doc.user_did))
         .collection(FEED_DEBUG_COLLECTION)
         .document(doc.request_id)
     )
@@ -317,7 +329,7 @@ async def get_recent_feed_debug(
     """Return a user's most recent feed-debug records, newest first."""
     query = (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(FEED_DEBUG_COLLECTION)
         .order_by("generated_at", direction=Query.DESCENDING)
         .limit(limit)
@@ -336,7 +348,7 @@ async def get_feed_debug(
     """Fetch a single feed-debug record, or ``None`` if not found."""
     doc = await (
         db.collection(USERS_COLLECTION)
-        .document(user_did)
+        .document(user_doc_id(user_did))
         .collection(FEED_DEBUG_COLLECTION)
         .document(request_id)
         .get()

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -28,6 +28,7 @@ from ..lib.firestore import (
     set_user_debug_flag,
     upsert_feed_activity,
     upsert_user,
+    user_doc_id,
     write_feed_debug,
 )
 
@@ -152,6 +153,28 @@ class TestInitFirestoreClient:
         init_firestore_client()
 
         MockAsyncClient.assert_called_once_with(project="demo-no-project", database="(default)")
+
+
+# ---------------------------------------------------------------------------
+# user_doc_id
+# ---------------------------------------------------------------------------
+
+
+class TestUserDocId:
+    def test_strips_did_plc_prefix(self):
+        assert user_doc_id("did:plc:testuser123") == "testuser123"
+
+    def test_passes_through_other_methods(self):
+        assert user_doc_id("did:web:example.com") == "did:web:example.com"
+
+    @pytest.mark.asyncio
+    async def test_user_doc_keyed_by_stripped_id(self):
+        db, collection_ref, doc_ref = _mock_firestore_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        await get_user(db, "did:plc:testuser123")
+
+        collection_ref.document.assert_called_with("testuser123")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Base branch:** `raindrift/feed-debug-data` (stacked — review/merge that first). Diff is scoped to the document-ID change.

User documents are keyed by the full DID (`did:plc:<id>`). Colons in a Firestore document ID break subcollection navigation in the **emulator UI** — there's no clickable link from a user doc to its subcollections (`feed_debug`, `feed_activity`, `seen_posts`), so they appear missing even though the data is there and reachable by direct URL. This makes the new feed-debug data effectively un-browsable in local dev.

### Change

User documents are now keyed by the DID with the `did:plc:` prefix stripped (e.g. `did:plc:abc123` → `abc123`), removing colons from the key. The full DID is still stored in the document's `user_did` field — only the document *key* changes. Other DID methods pass through unchanged (all current users are `did:plc`).

This is centralized in `lib/firestore.py`: a single `user_doc_id()` helper, applied at every user-document key site. Callers continue to pass full DIDs; the mapping happens at the Firestore boundary, so no other code or the CLI changes.

### Impact — clean reset, no migration

Existing user docs keyed by the full DID are abandoned; new requests create fresh docs under the stripped key. We're treating this as an intentional reset rather than migrating:

- Local dev: just regenerate (re-enable the flag, load feeds).
- Stage/prod: resets the `users` collection — `created_at` history is lost and seen-post exclusions reset (the latter self-heals; users may briefly re-see recent posts). No data of lasting value is dropped.