### PR TITLE
Fix zeroed-out popularity candidate scores

### DIFF
--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -108,7 +108,7 @@ async def popularity_search(
                 },
             ],
             "score_mode": "multiply",
-            "boost_mode": "multiply",
+            "boost_mode": "replace",
         }
     }
 

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -96,6 +96,8 @@ class TestPopularitySearch:
         script_source = script_func["script"]["source"]
         assert "Math.max(likes, 0.0)" in script_source
         assert "Math.log1p(likes)" in script_source
+        assert query["function_score"]["score_mode"] == "multiply"
+        assert query["function_score"]["boost_mode"] == "replace"
 
     @pytest.mark.asyncio
     async def test_video_only_true_includes_filter(self):


### PR DESCRIPTION
I noticed that all the scores from the "popularity" candidate generator are zero. I think it's because we're using "boost_mode": "multiply". Which means it takes the base query score and multiplies it by the function score. But the base query just filters, so its score is 0. And hence 0 * function_score outputs 0.

Fixed this by changing it to "boost_mode": "replace"

Closes #149 