### PR TITLE
Better Handling of Missing Rank Candidate Scores

### DIFF
--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -23,7 +23,7 @@ class PerspectiveLanguageNotSupportedError(Exception):
     language is not supported by one or more requested attributes.
 
     This is expected for non-English content and should be handled gracefully
-    by callers (e.g. assign a neutral score rather than logging an error).
+    by callers (e.g. mark the score missing rather than logging an error).
     """
 
     def __init__(self, language: str | None = None) -> None:
@@ -175,42 +175,42 @@ def _get_client() -> PerspectiveClient:
     return _client
 
 
-async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float]:
+async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float | None]:
     """Return PRC scores for *candidates*, keyed by ``at_uri``.
 
     Posts with content=None, where the minute quota is exhausted, or where the
-    API call fails receive a neutral score of 0.0. Every candidate with an
-    ``at_uri`` is scored — none are dropped.
+    API call fails receive a missing score of None. Every candidate with an
+    ``at_uri`` is returned — none are dropped.
     """
     if not candidates:
         return {}
 
     client = _get_client()
 
-    async def _score_one(c: CandidatePost) -> float:
+    async def _score_one(c: CandidatePost) -> float | None:
         if not c.content or not c.content.strip():
-            return 0.0
+            return None
         if not await _rate_limit_acquire():
-            logger.warning("Perspective API minute quota exhausted; using neutral score for post %s", c.at_uri)
-            return 0.0
+            logger.warning("Perspective API minute quota exhausted; using missing score for post %s", c.at_uri)
+            return None
         try:
             return await client.score(c.content)
         except PerspectiveLanguageNotSupportedError as exc:
             logger.debug(
-                "Perspective API: language not supported (%s) for post %s; using neutral score",
+                "Perspective API: language not supported (%s) for post %s; using missing score",
                 exc.language,
                 c.at_uri,
             )
-            return 0.0
+            return None
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 429:
-                logger.warning("Perspective API rate limited for post %s; using neutral score", c.at_uri)
+                logger.warning("Perspective API rate limited for post %s; using missing score", c.at_uri)
             else:
                 logger.exception("Perspective API scoring failed for post %s", c.at_uri)
-            return 0.0
+            return None
         except Exception:
             logger.exception("Perspective API scoring failed for post %s", c.at_uri)
-            return 0.0
+            return None
 
     scorable = [c for c in candidates if c.at_uri]
     scores = await asyncio.gather(*(_score_one(c) for c in scorable))

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -186,7 +186,20 @@ class TestScoreCandidates:
 
         assert result == {"at://a/1": 0.1, "at://a/2": 0.5, "at://a/3": 0.9}
 
-    def test_none_content_gets_neutral_score(self):
+    def test_zero_score_remains_valid_score(self):
+        candidates = [
+            _make_candidate("at://a/1", content="neutral post"),
+            _make_candidate("at://a/2", content="good post"),
+        ]
+        fake = _fake_client([0.0, 0.8])
+
+        with patch("app.lib.perspective._get_client", return_value=fake):
+            import asyncio
+            result = asyncio.run(score_candidates(candidates))
+
+        assert result == {"at://a/1": 0.0, "at://a/2": 0.8}
+
+    def test_none_content_gets_missing_score(self):
         candidates = [
             _make_candidate("at://a/1", content=None),
             _make_candidate("at://a/2", content="good post"),
@@ -197,9 +210,9 @@ class TestScoreCandidates:
             import asyncio
             result = asyncio.run(score_candidates(candidates))
 
-        assert result == {"at://a/1": 0.0, "at://a/2": 0.8}
+        assert result == {"at://a/1": None, "at://a/2": 0.8}
 
-    def test_api_failure_gets_neutral_score(self):
+    def test_api_failure_gets_missing_score(self):
         candidates = [
             _make_candidate("at://a/1", content="some content"),
             _make_candidate("at://a/2", content="other content"),
@@ -211,10 +224,10 @@ class TestScoreCandidates:
             import asyncio
             result = asyncio.run(score_candidates(candidates))
 
-        assert result == {"at://a/1": 0.0, "at://a/2": 0.7}
+        assert result == {"at://a/1": None, "at://a/2": 0.7}
 
-    def test_language_not_supported_gets_neutral_score(self):
-        """A LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE 400 should return 0.0 without
+    def test_language_not_supported_gets_missing_score(self):
+        """A LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE 400 should return None without
         logging at ERROR level — it's expected for non-English content."""
         import asyncio
 
@@ -228,9 +241,9 @@ class TestScoreCandidates:
         with patch("app.lib.perspective._get_client", return_value=fake):
             result = asyncio.run(score_candidates(candidates))
 
-        assert result == {"at://a/1": 0.0, "at://a/2": 0.7}
+        assert result == {"at://a/1": None, "at://a/2": 0.7}
 
-    def test_rate_limit_gets_neutral_score(self):
+    def test_rate_limit_gets_missing_score(self):
         candidates = [
             _make_candidate("at://a/1", content="some content"),
             _make_candidate("at://a/2", content="other content"),
@@ -245,9 +258,9 @@ class TestScoreCandidates:
             import asyncio
             result = asyncio.run(score_candidates(candidates))
 
-        assert result == {"at://a/1": 0.0, "at://a/2": 0.7}
+        assert result == {"at://a/1": None, "at://a/2": 0.7}
 
-    def test_minute_quota_exhausted_returns_neutral_without_api_call(self):
+    def test_minute_quota_exhausted_returns_missing_without_api_call(self):
         candidates = [_make_candidate("at://a/1", content="text")]
         fake = _fake_client([0.9])
 
@@ -259,7 +272,7 @@ class TestScoreCandidates:
             result = asyncio.run(score_candidates(candidates))
 
         fake.score.assert_not_called()
-        assert result == {"at://a/1": 0.0}
+        assert result == {"at://a/1": None}
 
     def test_all_candidates_scored_none_dropped(self):
         candidates = [_make_candidate(f"at://a/{i}", content="text") for i in range(5)]

--- a/src/app/lib/rankers/perspective.py
+++ b/src/app/lib/rankers/perspective.py
@@ -37,12 +37,14 @@ class PerspectiveRanker(Ranker):
         valid_candidates = [(c, c.at_uri) for c in candidates if c.at_uri is not None]
         scores = await score_candidates([c for c, _at_uri in valid_candidates])
 
+        def _sort_key(item: tuple[int, tuple[CandidatePost, str]]) -> tuple[bool, float, int]:
+            idx, (_candidate, at_uri) = item
+            score = scores.get(at_uri)
+            return (score is None, -(score if score is not None else 0.0), idx)
+
         ranked_candidates = sorted(
             enumerate(valid_candidates),
-            key=lambda item: (
-                -scores.get(item[1][1], 0.0),
-                item[0],
-            ),
+            key=_sort_key,
         )
 
         rankings: list[RankedCandidate] = []
@@ -51,7 +53,7 @@ class PerspectiveRanker(Ranker):
                 RankedCandidate(
                     at_uri=at_uri,
                     rank=rank_idx,
-                    rank_score=scores.get(at_uri, 0.0),
+                    rank_score=scores.get(at_uri),
                 )
             )
 

--- a/src/app/lib/rankers/perspective_test.py
+++ b/src/app/lib/rankers/perspective_test.py
@@ -78,7 +78,7 @@ class TestPerspectiveRanker:
         assert [c.at_uri for c in scored_candidates] == ["at://a/1"]
         assert [r.at_uri for r in result.result.rankings] == ["at://a/1"]
 
-    def test_predict_uses_neutral_score_for_unscored_candidates(self):
+    def test_predict_uses_missing_score_for_unscored_candidates(self):
         candidates = [
             _make_candidate("at://a/1", content="scored"),
             _make_candidate("at://a/2", content="unscored"),
@@ -86,9 +86,35 @@ class TestPerspectiveRanker:
         with patch(
             "app.lib.rankers.perspective.score_candidates",
             new_callable=AsyncMock,
-            return_value={"at://a/1": 0.5},  # at://a/2 missing -> neutral
+            return_value={"at://a/1": 0.5},  # at://a/2 missing -> None
         ):
             result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
 
         by_uri = {r.at_uri: r.rank_score for r in result.result.rankings}
-        assert by_uri == {"at://a/1": 0.5, "at://a/2": 0.0}
+        assert by_uri == {"at://a/1": 0.5, "at://a/2": None}
+
+    def test_predict_orders_real_scores_descending_with_missing_last(self):
+        candidates = [
+            _make_candidate("at://a/missing", content="missing"),
+            _make_candidate("at://a/negative", content="negative"),
+            _make_candidate("at://a/zero", content="zero"),
+            _make_candidate("at://a/positive", content="positive"),
+        ]
+        with patch(
+            "app.lib.rankers.perspective.score_candidates",
+            new_callable=AsyncMock,
+            return_value={
+                "at://a/missing": None,
+                "at://a/negative": -0.2,
+                "at://a/zero": 0.0,
+                "at://a/positive": 0.7,
+            },
+        ):
+            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+
+        assert [(r.at_uri, r.rank, r.rank_score) for r in result.result.rankings] == [
+            ("at://a/positive", 1, 0.7),
+            ("at://a/zero", 2, 0.0),
+            ("at://a/negative", 3, -0.2),
+            ("at://a/missing", 4, None),
+        ]

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -151,21 +151,21 @@ async def run_predict(
                 normalized_by_model[model_name][uri] = normalized_score
 
     metric_collector = get_metric_collector()
-    if metric_collector:
+    if metric_collector and dropped_candidate_count > 0:
         metric_collector.record(
             "rank.predict.dropped_candidates_count",
             dropped_candidate_count,
         )
 
-    weights_by_model: dict[str, float] = {
-        name: weight
-        for name, weight, _ in models_with_valid_results
-    }
     if rec is not None:
-        for model_name, scores_dict in normalized_by_model.items():
-            rec.record_model_scores(model_name, weights_by_model[model_name], scores_dict)
+        for model_name, weight, _ in resolved:
+            rec.record_model_scores(
+                model_name,
+                weight,
+                normalized_by_model.get(model_name, {}),
+            )
 
-    total_weight = sum(weights_by_model.values())
+    total_weight = sum(weight for _name, weight, _ranker in models_with_valid_results)
 
     def _combined(at_uri: str) -> float:
         return sum(

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -8,14 +8,15 @@ average using each model's configured relative weight.
 
 import asyncio
 import logging
+import statistics
 
 from ...models import RankedCandidate, RankPredictRequest, RankPredictResult
 from ..feed_debug import current_recorder
 from ..telemetry import timed
 from .base import Ranker, RankerError, RankerExecutionError, RankerResult, get_ranker
+from ..metrics import get_metric_collector
 
 logger = logging.getLogger(__name__)
-
 
 class RankModelNotFoundError(Exception):
     """Raised when a requested rank model does not exist."""
@@ -25,19 +26,23 @@ class RankModelNotFoundError(Exception):
         super().__init__(f"Rank model not found: {name}")
 
 
-def _normalize(raw: float | None, bounds: tuple[float, float]) -> float:
+def _normalize(
+    raw: float | None,
+    bounds: tuple[float, float],
+    default_score: float,
+) -> float:
     """Linearly map *raw* from *bounds* into [-1, 1], clamping the result.
 
     Missing scores (``None`` — e.g. a ranker couldn't score a candidate)
-    normalize to ``0.0`` (neutral), matching how individual rankers already
+    normalize to ``default_score`` (neutral), matching how individual rankers already
     treat unscoreable candidates. Degenerate bounds (``hi <= lo``) also
-    normalize to ``0.0`` to avoid division by zero.
+    normalize to ``default_score`` to avoid division by zero.
     """
     if raw is None:
-        return 0.0
+        return default_score
     lo, hi = bounds
     if hi <= lo:
-        return 0.0
+        return default_score
     normalized = 2.0 * (raw - lo) / (hi - lo) - 1.0
     return max(-1.0, min(1.0, normalized))
 
@@ -101,40 +106,89 @@ async def run_predict(
 
     rec = current_recorder()
 
-    normalized_by_model: dict[str, dict[str, float]] = {}
+    # loop through results once to calculate medians and get scores per candidate
+    medians_by_model: dict[str, float] = {}  # {model_name: median_score}
+    results_by_candidate: dict[str, dict[str, float]] = {}  # {uri: {model_name: score}}
+    models_with_valid_results: list[tuple[str, float, Ranker]] = []
     for (name, weight, ranker), result in zip(resolved, results):
-        bounds = ranker.score_bounds
+        # all the valid uris with their scores from this ranker model
         raw_by_uri = {
-            ranking.at_uri: ranking.rank_score
-            for ranking in result.result.rankings
-            if ranking.at_uri
+            r.at_uri: r.rank_score
+            for r in result.result.rankings
+            if r.at_uri is not None and r.rank_score is not None
         }
-        normalized = {uri: _normalize(score, bounds) for uri, score in raw_by_uri.items()}
-        normalized_by_model[name] = normalized
-        if rec is not None:
-            rec.record_model_scores(name, weight, normalized)
+        if raw_by_uri:
+            bounds = ranker.score_bounds
+            raw_median = statistics.median(raw_by_uri.values())
+            medians_by_model[name] = _normalize(raw_median, bounds, 0.0)
+            models_with_valid_results.append((name, weight, ranker))
+        for uri, score in raw_by_uri.items():
+            if uri not in results_by_candidate:
+                results_by_candidate[uri] = {name: score}
+            else:
+                results_by_candidate[uri][name] = score
 
-    total_weight = sum(weight for _name, weight, _ranker in resolved)
-    valid_candidates = [(c, c.at_uri) for c in request.candidates if c.at_uri is not None]
+    # loop through again to normalize scores and drop candidates with no valid scores in any model
+    candidate_uris = [c.at_uri for c in request.candidates if c.at_uri]
+    valid_candidate_uris = []
+    normalized_by_model: dict[str, dict[str, float]] = {}  # {model_name: {uri: normalized_score}}
+    dropped_candidate_count = 0
+    for uri in candidate_uris:
+        # if the model has no valid results in any of the rank models, exclude it
+        if uri not in results_by_candidate:
+            dropped_candidate_count += 1
+            continue
+        valid_candidate_uris.append(uri)
+        for model_name, _, ranker in models_with_valid_results:
+            bounds = ranker.score_bounds
+            score = None
+            if model_name in results_by_candidate[uri]:
+                score = results_by_candidate[uri][model_name]
+            normalized_score = _normalize(score, bounds, medians_by_model[model_name])
+            if model_name not in normalized_by_model:
+                normalized_by_model[model_name] = {uri: normalized_score}
+            else:
+                normalized_by_model[model_name][uri] = normalized_score
+
+    metric_collector = get_metric_collector()
+    if metric_collector:
+        metric_collector.record(
+            "rank.predict.dropped_candidates_count",
+            dropped_candidate_count,
+        )
+
+    weights_by_model: dict[str, float] = {
+        name: weight
+        for name, weight, _ in models_with_valid_results
+    }
+    if rec is not None:
+        for model_name, scores_dict in normalized_by_model.items():
+            rec.record_model_scores(model_name, weights_by_model[model_name], scores_dict)
+
+    total_weight = sum(weights_by_model.values())
 
     def _combined(at_uri: str) -> float:
         return sum(
             (weight / total_weight) * normalized_by_model[name].get(at_uri, 0.0)
-            for name, weight, _ranker in resolved
+            for name, weight, _ in models_with_valid_results
         )
 
-    ranked = sorted(
-        enumerate(valid_candidates),
-        key=lambda item: (-_combined(item[1][1]), item[0]),
-    )
+    candidates_with_scores_initial_order = [
+        (initial_idx, uri, _combined(uri))
+        for initial_idx, uri in enumerate(valid_candidate_uris)
+    ]
+    ranked = enumerate(sorted(
+        candidates_with_scores_initial_order,
+        key=lambda item: (-item[2], item[0]),
+    ), start=1)
 
     rankings: list[RankedCandidate] = []
-    for rank_idx, (_, (_candidate, at_uri)) in enumerate(ranked, start=1):
+    for rank_idx, (_, at_uri, score) in ranked:
         rankings.append(
             RankedCandidate(
                 at_uri=at_uri,
                 rank=rank_idx,
-                rank_score=_combined(at_uri),
+                rank_score=score,
             )
         )
 

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -29,20 +29,20 @@ class RankModelNotFoundError(Exception):
 def _normalize(
     raw: float | None,
     bounds: tuple[float, float],
-    default_score: float,
+    fallback_normalized_score: float,
 ) -> float:
     """Linearly map *raw* from *bounds* into [-1, 1], clamping the result.
 
     Missing scores (``None`` — e.g. a ranker couldn't score a candidate)
-    normalize to ``default_score`` (neutral), matching how individual rankers already
+    normalize to ``fallback_normalized_score`` (neutral), matching how individual rankers already
     treat unscoreable candidates. Degenerate bounds (``hi <= lo``) also
-    normalize to ``default_score`` to avoid division by zero.
+    normalize to ``fallback_normalized_score`` to avoid division by zero.
     """
     if raw is None:
-        return default_score
+        return fallback_normalized_score
     lo, hi = bounds
     if hi <= lo:
-        return default_score
+        return fallback_normalized_score
     normalized = 2.0 * (raw - lo) / (hi - lo) - 1.0
     return max(-1.0, min(1.0, normalized))
 
@@ -83,6 +83,9 @@ async def run_predict(
     candidate via a weighted average (weights normalized to sum to 1, so the
     combined score also stays within [-1, 1]). The final ordering is by
     combined score, descending, with ties broken by original candidate order.
+    If a candidate at_uri has no valid scores from any model, it is dropped.
+    If it has a score from at least one model but not the others, the median
+    (per-model results) is filled in for those missing scores.
     """
     if not request.candidates:
         raise RankerError("candidates list must not be empty")
@@ -109,7 +112,7 @@ async def run_predict(
     # loop through results once to calculate medians and get scores per candidate
     medians_by_model: dict[str, float] = {}  # {model_name: median_score}
     results_by_candidate: dict[str, dict[str, float]] = {}  # {uri: {model_name: score}}
-    models_with_valid_results: list[tuple[str, float, Ranker]] = []
+    models_with_valid_results: list[tuple[str, float, Ranker]] = [] # filtered version of resolved
     for (name, weight, ranker), result in zip(resolved, results):
         # all the valid uris with their scores from this ranker model
         raw_by_uri = {

--- a/src/app/lib/rankers/predict_test.py
+++ b/src/app/lib/rankers/predict_test.py
@@ -5,7 +5,13 @@ import asyncio
 import pytest
 from pydantic import ValidationError
 
-from ...models import CandidatePost, RankModelSpec, RankPredictRequest, RankPredictResult, RankedCandidate
+from ...models import (
+    CandidatePost,
+    RankedCandidate,
+    RankModelSpec,
+    RankPredictRequest,
+    RankPredictResult,
+)
 from ..feed_debug import FeedDebugRecorder, feed_debug_scope
 from . import predict as predict_module
 from .base import RankerExecutionError, RankerResult
@@ -14,10 +20,18 @@ from .base import RankerExecutionError, RankerResult
 class StubRanker:
     """A ranker that returns pre-configured raw scores keyed by `at_uri`."""
 
-    def __init__(self, name: str, bounds: tuple[float, float], scores: dict[str, float]):
+    def __init__(
+        self,
+        name: str,
+        bounds: tuple[float, float],
+        scores: dict[str, float],
+        *,
+        include_missing: bool = True,
+    ):
         self._name = name
         self._bounds = bounds
         self._scores = scores
+        self._include_missing = include_missing
 
     @property
     def name(self) -> str:
@@ -36,6 +50,7 @@ class StubRanker:
             )
             for idx, candidate in enumerate(candidates, start=1)
             if candidate.at_uri is not None
+            and (self._include_missing or candidate.at_uri in self._scores)
         ]
         return RankerResult(model=self.name, result=RankPredictResult(rankings=rankings))
 
@@ -129,14 +144,14 @@ def test_run_predict_normalizes_and_combines_with_weights(monkeypatch):
     ]
 
 
-def test_run_predict_treats_missing_scores_as_neutral(monkeypatch):
-    """A candidate a ranker didn't score normalizes to 0.0 (neutral) when combined."""
+def test_run_predict_drops_candidates_with_no_valid_scores(monkeypatch):
+    """Candidates with no valid score from any ranker are excluded."""
     candidates = [
         CandidatePost(at_uri="at://post/a", score=0.5),
         CandidatePost(at_uri="at://post/b", score=0.5),
     ]
     rankers = {
-        "x": StubRanker("x", (0.0, 1.0), {"at://post/a": 1.0}),  # "b" missing -> neutral
+        "x": StubRanker("x", (0.0, 1.0), {"at://post/a": 1.0}),
     }
     monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
 
@@ -149,7 +164,158 @@ def test_run_predict_treats_missing_scores_as_neutral(monkeypatch):
 
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
         ("at://post/a", 1, pytest.approx(1.0)),
+    ]
+
+
+def test_run_predict_uses_ranker_median_for_explicit_missing_score(monkeypatch):
+    """A valid candidate missing one ranker's score gets that ranker's median score."""
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+        CandidatePost(at_uri="at://post/c", score=0.5),
+    ]
+    rankers = {
+        "x": StubRanker("x", (0.0, 10.0), {"at://post/a": 10.0, "at://post/c": 0.0}),
+        "y": StubRanker(
+            "y",
+            (-1.0, 1.0),
+            {"at://post/a": 0.0, "at://post/b": 0.0, "at://post/c": 0.0},
+        ),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    result = asyncio.run(
+        predict_module.run_predict(
+            _request(
+                models=[
+                    RankModelSpec(name="x", weight=3.0),
+                    RankModelSpec(name="y", weight=1.0),
+                ],
+                candidates=candidates,
+            ),
+            es=object(),
+        )
+    )
+
+    assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
+        ("at://post/a", 1, pytest.approx(0.75)),
         ("at://post/b", 2, pytest.approx(0.0)),
+        ("at://post/c", 3, pytest.approx(-0.75)),
+    ]
+
+
+def test_run_predict_uses_ranker_median_for_omitted_score(monkeypatch):
+    """Median fallback also applies when a ranker omits a still-valid candidate."""
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+        CandidatePost(at_uri="at://post/c", score=0.5),
+    ]
+    rankers = {
+        "x": StubRanker(
+            "x",
+            (0.0, 10.0),
+            {"at://post/a": 10.0, "at://post/c": 0.0},
+            include_missing=False,
+        ),
+        "y": StubRanker(
+            "y",
+            (-1.0, 1.0),
+            {"at://post/a": 0.0, "at://post/b": 0.0, "at://post/c": 0.0},
+        ),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    result = asyncio.run(
+        predict_module.run_predict(
+            _request(
+                models=[
+                    RankModelSpec(name="x", weight=3.0),
+                    RankModelSpec(name="y", weight=1.0),
+                ],
+                candidates=candidates,
+            ),
+            es=object(),
+        )
+    )
+
+    assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
+        ("at://post/a", 1, pytest.approx(0.75)),
+        ("at://post/b", 2, pytest.approx(0.0)),
+        ("at://post/c", 3, pytest.approx(-0.75)),
+    ]
+
+
+def test_run_predict_ignores_ranker_with_no_valid_scores(monkeypatch):
+    """A ranker with no valid scores does not dilute weights or crash."""
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+    ]
+    rankers = {
+        "x": StubRanker("x", (0.0, 1.0), {"at://post/a": 1.0, "at://post/b": 0.0}),
+        "empty": StubRanker("empty", (0.0, 1.0), {}),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    result = asyncio.run(
+        predict_module.run_predict(
+            _request(
+                models=[
+                    RankModelSpec(name="x", weight=1.0),
+                    RankModelSpec(name="empty", weight=9.0),
+                ],
+                candidates=candidates,
+            ),
+            es=object(),
+        )
+    )
+
+    assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
+        ("at://post/a", 1, pytest.approx(1.0)),
+        ("at://post/b", 2, pytest.approx(-1.0)),
+    ]
+
+
+def test_run_predict_returns_empty_when_no_ranker_has_valid_scores(monkeypatch):
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+    ]
+    rankers = {
+        "empty": StubRanker("empty", (0.0, 1.0), {}),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    result = asyncio.run(
+        predict_module.run_predict(
+            _request(models=[RankModelSpec(name="empty", weight=1.0)], candidates=candidates),
+            es=object(),
+        )
+    )
+
+    assert result.rankings == []
+
+
+def test_run_predict_treats_zero_scores_as_valid(monkeypatch):
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+    ]
+    rankers = {
+        "x": StubRanker("x", (-1.0, 1.0), {"at://post/a": 0.0}),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    result = asyncio.run(
+        predict_module.run_predict(
+            _request(models=[RankModelSpec(name="x", weight=1.0)], candidates=candidates),
+            es=object(),
+        )
+    )
+
+    assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
+        ("at://post/a", 1, pytest.approx(0.0)),
     ]
 
 

--- a/src/app/lib/rankers/predict_test.py
+++ b/src/app/lib/rankers/predict_test.py
@@ -277,6 +277,39 @@ def test_run_predict_ignores_ranker_with_no_valid_scores(monkeypatch):
     ]
 
 
+def test_run_predict_records_empty_model_scores_for_empty_ranker(monkeypatch):
+    """Feed debug includes configured rankers that had no valid scores."""
+    candidates = [
+        CandidatePost(at_uri="at://post/a", score=0.5),
+        CandidatePost(at_uri="at://post/b", score=0.5),
+    ]
+    rankers = {
+        "x": StubRanker("x", (0.0, 1.0), {"at://post/a": 1.0, "at://post/b": 0.0}),
+        "empty": StubRanker("empty", (0.0, 1.0), {}),
+    }
+    monkeypatch.setattr(predict_module, "get_ranker", lambda name: rankers[name])
+
+    rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+    with feed_debug_scope(rec):
+        asyncio.run(
+            predict_module.run_predict(
+                _request(
+                    models=[
+                        RankModelSpec(name="x", weight=1.0),
+                        RankModelSpec(name="empty", weight=9.0),
+                    ],
+                    candidates=candidates,
+                ),
+                es=object(),
+            )
+        )
+
+    assert rec.model_scores == [
+        ("x", 1.0, {"at://post/a": pytest.approx(1.0), "at://post/b": pytest.approx(-1.0)}),
+        ("empty", 9.0, {}),
+    ]
+
+
 def test_run_predict_returns_empty_when_no_ranker_has_valid_scores(monkeypatch):
     candidates = [
         CandidatePost(at_uri="at://post/a", score=0.5),


### PR DESCRIPTION
Closes #151 

Some changes to how we handle missing scores in the ranking stage (which now does a weighted average of one or more rankers, like two_tower and perspective): 
- If a candidate has no valid score from any of the rank models, it is excluded from the results.
  - Logs the number of candidates dropped because of this. Uses the metric collector. Not sure if I did this in the correct way - I didn't see a good example to go off of so I did my best.
- If a candidate has a valid score from at least one rank model, then we fill in any missing scores with the (normalized) median score for that model's results.
- If a given rank model has no valid scores at all, for any of the results, ignore that model and just use the other ones.