### PR TITLE
Fix: post_similarity returns no results

### DIFF
--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -112,17 +112,8 @@ async def knn_search_posts(
         candidates.append(candidate_post_from_hit(hit, generator_name=generator_name))
         if len(candidates) >= num_candidates:
             break
-    
-    # drop candidates without embeddings
-    candidates_with_embeddings = [
-        candidate for candidate in candidates if candidate.minilm_l12_embedding
-    ]
-    if len(candidates_with_embeddings) < len(candidates):
-        logger.info(
-            "Dropped %d post-similarity candidates without embeddings",
-            len(candidates) - len(candidates_with_embeddings),
-        )
-    return candidates_with_embeddings
+
+    return candidates
 
 
 class PostSimilarityCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -378,7 +378,7 @@ class TestKnnSearchPosts:
         assert candidates[0].generator_name is None
 
     @pytest.mark.asyncio
-    async def test_drops_candidates_without_embeddings(self):
+    async def test_keeps_candidates_without_embeddings_for_later_hydration(self):
         es = FakeEs(responses={
             "posts_recent": {
                 "hits": {
@@ -403,8 +403,10 @@ class TestKnnSearchPosts:
             }
         })
         candidates = await knn_search_posts(es, [0.1, 0.2], num_candidates=10)
-        assert len(candidates) == 1
+        assert len(candidates) == 2
         assert candidates[0].at_uri == "at://post/1"
+        assert candidates[1].at_uri == "at://post/2"
+        assert candidates[1].minilm_l12_embedding is None
 
     @pytest.mark.asyncio
     async def test_passes_generator_name(self):

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -622,7 +622,6 @@ class TestPostSimilarityGenerator:
                                     "_source": {
                                         "at_uri": "at://result/1",
                                         "content": "recommended post",
-                                        "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.5]},
                                     },
                                 }
                             ]
@@ -636,6 +635,7 @@ class TestPostSimilarityGenerator:
         assert len(result.candidates) == 1
         assert result.candidates[0].at_uri == "at://result/1"
         assert result.candidates[0].score == 0.9
+        assert result.candidates[0].minilm_l12_embedding is None
         assert result.candidates[0].generator_name == "post_similarity"
 
     @pytest.mark.asyncio

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -284,6 +284,10 @@ async def _run_ranking_pipeline(
         candidates = await _hydrate_embeddings(es, candidates)
 
         if feed_cfg.rank_request_template is not None:
+            candidates = [c for c in candidates if c.minilm_l12_embedding]
+            if not candidates:
+                return []
+
             rank_req = feed_cfg.rank_request_template.model_copy(
                 update={"candidates": candidates, "user_did": gen_request.user_did}
             )

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1327,6 +1327,8 @@ class TestRankedFeed:
             ).json()
 
         mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args
+        assert mock_run.await_args
         assert mock_fetch.await_args.args[1] == ["at://p/0"]
         rank_req = mock_run.await_args.args[0]
         assert rank_req.candidates[0].minilm_l12_embedding == TEST_EMBEDDING
@@ -1351,6 +1353,7 @@ class TestRankedFeed:
                 params={"feed": RANKED_FEED_URI},
             ).json()
 
+        assert mock_run.await_args
         rank_req = mock_run.await_args.args[0]
         assert [c.at_uri for c in rank_req.candidates] == ["at://p/0"]
         assert [item["post"] for item in data["feed"]] == ["at://p/0"]

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -10,6 +10,7 @@ from ..main import app
 from ..feeds import FEEDS
 from ..models import CandidatePost, FeedCursor, RankedCandidate, RankPredictResult
 from ..lib.candidates.base import CandidateResult
+from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import FeedCache
 
 
@@ -36,11 +37,13 @@ CANDIDATE_ONLY_FEEDS = (
     ("network-likes", "network_likes"),
     ("popularity", "popularity"),
 )
+TEST_EMBEDDING = encode_float32_b64([1.0, 0.0, 0.0])
 
 
-def _make_candidates(prefix: str, n: int, generator_name: str = "test") -> list[CandidatePost]:
+def _make_candidates(prefix: str, n: int, generator_name: str = "test", with_embedding: bool = False) -> list[CandidatePost]:
+    embedding = TEST_EMBEDDING if with_embedding else None
     return [
-        CandidatePost(at_uri=f"at://{prefix}/{i}", content=f"post {i}", minilm_l12_embedding=None, score=None, generator_name=generator_name)
+        CandidatePost(at_uri=f"at://{prefix}/{i}", content=f"post {i}", minilm_l12_embedding=embedding, score=None, generator_name=generator_name)
         for i in range(n)
     ]
 
@@ -1290,7 +1293,7 @@ class TestRankedFeed:
 
     def test_ranking_applied_to_candidates(self):
         """When ranking succeeds, posts are returned in ranked order."""
-        candidates = _make_candidates("p", 3)
+        candidates = _make_candidates("p", 3, with_embedding=True)
         # Ranker reverses the order: p/2, p/1, p/0
         reversed_rankings = [
             RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=float(3 - r))
@@ -1308,18 +1311,41 @@ class TestRankedFeed:
         posts = [item["post"] for item in data["feed"]]
         assert posts == ["at://p/2", "at://p/1", "at://p/0"]
 
+    def test_drops_candidates_missing_embeddings_before_ranking(self):
+        """Candidates still missing embeddings after hydration are not sent to ranking."""
+        candidates = [
+            CandidatePost(at_uri="at://p/0", content=None, minilm_l12_embedding=TEST_EMBEDDING, score=None, generator_name="g"),
+            CandidatePost(at_uri="at://p/1", content=None, minilm_l12_embedding=None, score=None, generator_name="g"),
+        ]
+        rank_result = RankPredictResult(rankings=[
+            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=0.5),
+        ])
+
+        with self._patch_generators(candidates), \
+             patch("app.routers.xrpc._hydrate_embeddings", new_callable=AsyncMock, return_value=candidates), \
+             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            ).json()
+
+        rank_req = mock_run.await_args.args[0]
+        assert [c.at_uri for c in rank_req.candidates] == ["at://p/0"]
+        assert [item["post"] for item in data["feed"]] == ["at://p/0"]
+
     def test_mmr_uses_rank_score_not_generator_score(self):
         """MMR should weight by the model's rank_score, not the generator's ES score.
 
         Candidates are given generator scores that disagree with the ranker's
-        ordering.  With no embeddings, MMR picks purely by relevance score, so
+        ordering.  With identical embeddings, MMR's content penalty is tied, so
         the output order reveals which score is used.
         """
         # Generator scores: p/0 highest, p/1 middle, p/2 lowest.
         candidates = [
-            CandidatePost(at_uri="at://p/0", score=3.0, content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://p/1", score=2.0, content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://p/2", score=1.0, content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(at_uri="at://p/0", score=3.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
+            CandidatePost(at_uri="at://p/1", score=2.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
+            CandidatePost(at_uri="at://p/2", score=1.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
         ]
         # Ranker reverses the order: p/2 best, p/1 middle, p/0 worst.
         rank_result = RankPredictResult(rankings=[
@@ -1341,7 +1367,7 @@ class TestRankedFeed:
 
     def test_ranking_failure_returns_500(self):
         """When ranking raises, the feed fails with a 500."""
-        candidates = _make_candidates("p", 3)
+        candidates = _make_candidates("p", 3, with_embedding=True)
 
         with self._patch_generators(candidates), \
              patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
@@ -1384,7 +1410,7 @@ class TestBestOfFriendsFeed:
 
     def test_ranking_applied_to_candidates(self):
         """Candidates from followed_users are returned in two-tower ranked order."""
-        candidates = _make_candidates("p", 3)
+        candidates = _make_candidates("p", 3, with_embedding=True)
         reversed_rankings = [
             RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=float(3 - r))
             for r, i in enumerate([2, 1, 0])
@@ -1403,7 +1429,7 @@ class TestBestOfFriendsFeed:
 
     def test_ranking_failure_returns_500(self):
         """When the two-tower ranker raises, the feed returns HTTP 500."""
-        candidates = _make_candidates("p", 3)
+        candidates = _make_candidates("p", 3, with_embedding=True)
 
         with self._patch_generators(candidates), \
              patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1311,6 +1311,27 @@ class TestRankedFeed:
         posts = [item["post"] for item in data["feed"]]
         assert posts == ["at://p/2", "at://p/1", "at://p/0"]
 
+    def test_hydrates_lightweight_candidates_before_ranking(self):
+        """Embedding-free generated candidates are hydrated before ranking."""
+        candidates = _make_candidates("p", 1)
+        rank_result = RankPredictResult(rankings=[
+            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+        ])
+
+        with self._patch_generators(candidates), \
+             patch("app.routers.xrpc.fetch_post_embeddings", new_callable=AsyncMock, return_value=[("at://p/0", [1.0, 0.0, 0.0])]) as mock_fetch, \
+             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            ).json()
+
+        mock_fetch.assert_awaited_once()
+        assert mock_fetch.await_args.args[1] == ["at://p/0"]
+        rank_req = mock_run.await_args.args[0]
+        assert rank_req.candidates[0].minilm_l12_embedding == TEST_EMBEDDING
+        assert [item["post"] for item in data["feed"]] == ["at://p/0"]
+
     def test_drops_candidates_missing_embeddings_before_ranking(self):
         """Candidates still missing embeddings after hydration are not sent to ranking."""
         candidates = [


### PR DESCRIPTION
Closes #157 

Two changes together (mine being the second one) introduced a bug that causes us to never return any results for the post_similarity candidate generator. 

We modified a function to not return the embeddings field, to speed things up. (They get re-hydrated later). Then we modified the function to remove results without the embedding field. Whoops. 

So now knn_search_posts no longer removes candidates without embeddings. They get removed after the hydrate step in the xrpc router before the ranking stage. Note that we should change this behavior in the future if our rank model doesn't depend on the content embeddings.

Verified locally that we get no results in the current code, and that we do get results with this fix.