### PR TITLE
Pin welcome post to top of first feed page

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -46,7 +46,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="67 R",
         diversify=False,
         exclude_seen_posts=False,
-        pinned_post_uri="at://did:plc:xznjzvqyjg5u4qhdcivigxx7/app.bsky.feed.post/3mo524zow2s2z",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprixpw42r25",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
@@ -61,7 +61,7 @@ FEEDS: dict[str, FeedConfig] = {
         public=True,
         internal_rkey="a0-yf",
         internal_display_name="a0 YF",
-        pinned_post_uri="at://did:plc:xznjzvqyjg5u4qhdcivigxx7/app.bsky.feed.post/3mo52penmws2e",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprirzcv3a24",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="two_tower", weight=0.5),
@@ -85,6 +85,7 @@ FEEDS: dict[str, FeedConfig] = {
         public=True,
         internal_rkey="fd-bof",
         internal_display_name="fd BOF",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprivkqqe224",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],
             infill=None,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -46,6 +46,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="67 R",
         diversify=False,
         exclude_seen_posts=False,
+        pinned_post_uri="at://did:plc:xznjzvqyjg5u4qhdcivigxx7/app.bsky.feed.post/3mo524zow2s2z",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
@@ -60,6 +61,7 @@ FEEDS: dict[str, FeedConfig] = {
         public=True,
         internal_rkey="a0-yf",
         internal_display_name="a0 YF",
+        pinned_post_uri="at://did:plc:xznjzvqyjg5u4qhdcivigxx7/app.bsky.feed.post/3mo52penmws2e",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="two_tower", weight=0.5),

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -20,10 +20,6 @@ class TestFeedsRegistry:
         overlap = primary_rkeys & internal_rkeys
         assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"
 
-    def test_your_feed_and_random_have_pinned_post_uris(self):
-        assert FEEDS["your-feed"].pinned_post_uri is not None
-        assert FEEDS["random"].pinned_post_uri is not None
-
     def test_candidate_only_feeds_are_direct_unranked_generators(self):
         for feed_name, generator_name in CANDIDATE_ONLY_FEEDS.items():
             cfg = FEEDS[feed_name]

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -20,6 +20,10 @@ class TestFeedsRegistry:
         overlap = primary_rkeys & internal_rkeys
         assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"
 
+    def test_your_feed_and_random_have_pinned_post_uris(self):
+        assert FEEDS["your-feed"].pinned_post_uri is not None
+        assert FEEDS["random"].pinned_post_uri is not None
+
     def test_candidate_only_feeds_are_direct_unranked_generators(self):
         for feed_name, generator_name in CANDIDATE_ONLY_FEEDS.items():
             cfg = FEEDS[feed_name]

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -214,3 +214,7 @@ class FeedConfig(BaseModel):
         "denormalized onto the user record. When False, neither happens (the raw "
         "interactions are still stored).",
     )
+    pinned_post_uri: str | None = Field(
+        None,
+        description="AT URI of a post to pin at the top of the first page of this feed.",
+    )

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -50,3 +50,10 @@ class TestFeedConfig:
         cfg = _minimal_feed_cfg(internal_rkey="e2-s", internal_display_name="e2 S")
         assert cfg.internal_rkey == "e2-s"
         assert cfg.internal_display_name == "e2 S"
+
+    def test_pinned_post_uri_defaults_to_none(self):
+        assert _minimal_feed_cfg().pinned_post_uri is None
+
+    def test_pinned_post_uri_can_be_set(self):
+        uri = "at://did:plc:example/app.bsky.feed.post/abc123"
+        assert _minimal_feed_cfg(pinned_post_uri=uri).pinned_post_uri == uri

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -399,6 +399,15 @@ def _skeleton_items(uris: list[str], feed_context: str) -> list[SkeletonItem]:
     return [SkeletonItem(post=uri, feed_context=feed_context) for uri in uris]
 
 
+def _prepend_pinned(pinned_uri: str, uris: list[str], limit: int) -> list[str]:
+    """Prepend the pinned URI and cap the result at limit.
+
+    Removes the pinned URI from the generated list first to avoid duplication.
+    """
+    deduped = [u for u in uris if u != pinned_uri]
+    return [pinned_uri] + deduped[: limit - 1]
+
+
 # Fire-and-forget background tasks (Firestore session writes, …). Keeping a
 # strong reference here prevents the event loop from garbage-collecting them
 # mid-flight; the done callback removes them once they complete.
@@ -802,8 +811,11 @@ async def get_feed_skeleton(
             debug_enabled=debug_enabled,
         )
 
-        # First page to return immediately.
-        page = all_uris[:limit]
+        # First page to return immediately. Prepend the pinned post if configured.
+        if feed_cfg.pinned_post_uri:
+            page = _prepend_pinned(feed_cfg.pinned_post_uri, all_uris, limit)
+        else:
+            page = all_uris[:limit]
 
         # Store the full batch and issue a cursor only when there are more pages.
         next_cursor = None

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1269,6 +1269,11 @@ class TestRankedFeed:
              patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _clear_pinned_post(self, monkeypatch):
+        """Isolate ranking tests from the pinned post — that's tested in TestPinnedPost."""
+        monkeypatch.setattr(FEEDS["your-feed"], "pinned_post_uri", None)
+
     def _patch_generators(self, candidates):
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(
@@ -1800,3 +1805,102 @@ class TestGetFeedSkeletonProbe:
             headers={"X-Probe-Secret": self.PROBE_SECRET},
         )
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Pinned post
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedPost:
+    PINNED_URI = "at://did:plc:pinauthor/app.bsky.feed.post/pinnedpost"
+
+    def _make_random_feed_with_pin(self):
+        cfg = FEEDS["random"].model_copy(update={"pinned_post_uri": self.PINNED_URI})
+        return {"random": cfg, **{k: v for k, v in FEEDS.items() if k != "random"}}
+
+    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
+    @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
+    @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
+    def test_pinned_post_is_first_on_first_page(self, *mocks):
+        """Pinned post appears as the first item when no cursor is sent."""
+        from app.routers import xrpc as xrpc_mod
+
+        candidates = _make_candidates("did:plc:a", 5, "random_posts")
+        random_gen = AsyncMock()
+        random_gen.generate.return_value = CandidateResult(
+            generator_name="random_posts", candidates=candidates
+        )
+
+        def fake_get_generator(name):
+            return random_gen if name == "random_posts" else None
+
+        patched_feeds = self._make_random_feed_with_pin()
+        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
+             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["feed"][0]["post"] == self.PINNED_URI
+
+    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
+    @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
+    @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
+    def test_pinned_post_not_duplicated_if_in_candidates(self, *mocks):
+        """If the pinned URI is already in generated candidates, it appears only once."""
+        from app.routers import xrpc as xrpc_mod
+
+        candidates = [
+            CandidatePost(at_uri=self.PINNED_URI, content="pinned", score=None, generator_name="random_posts"),
+            *_make_candidates("did:plc:a", 4, "random_posts"),
+        ]
+        random_gen = AsyncMock()
+        random_gen.generate.return_value = CandidateResult(
+            generator_name="random_posts", candidates=candidates
+        )
+
+        def fake_get_generator(name):
+            return random_gen if name == "random_posts" else None
+
+        patched_feeds = self._make_random_feed_with_pin()
+        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
+             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10},
+            )
+
+        assert resp.status_code == 200
+        post_uris = [item["post"] for item in resp.json()["feed"]]
+        assert post_uris.count(self.PINNED_URI) == 1
+        assert post_uris[0] == self.PINNED_URI
+
+    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
+    @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
+    @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
+    def test_pinned_post_not_on_subsequent_pages(self, *mocks):
+        """Pinned post does not appear when a cursor is sent (subsequent pages)."""
+        from app.routers import xrpc as xrpc_mod
+
+        patched_feeds = self._make_random_feed_with_pin()
+        cache = InMemoryFeedCache()
+        cached_uris = [f"at://did:plc:a/{i}" for i in range(20)]
+        cache._store["testcacheid"] = cached_uris
+        app.state.feed_cache = cache
+
+        cursor = FeedCursor(id="testcacheid", offset=10).encode()
+        with patch.object(xrpc_mod, "FEEDS", patched_feeds):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10, "cursor": cursor},
+            )
+
+        assert resp.status_code == 200
+        post_uris = [item["post"] for item in resp.json()["feed"]]
+        assert self.PINNED_URI not in post_uris

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1427,6 +1427,11 @@ class TestBestOfFriendsFeed:
              patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _clear_pinned_post(self, monkeypatch):
+        """Isolate ranking tests from the pinned post — that's tested in TestPinnedPost."""
+        monkeypatch.setattr(FEEDS["best-of-friends"], "pinned_post_uri", None)
+
     def _patch_generators(self, candidates):
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(


### PR DESCRIPTION
Closes #77

Each stage/prod feeds now show a pinned welcome post as its first item, so new users understand what the feed is when they open it.

## This PR

- Add `pinned_post_uri: str | None` field to `FeedConfig`
- Set pinned post URIs for `your-feed` and `random` in `feeds.py`
- In `xrpc.py`, prepend the pinned URI to the first page only (cursor=None path); the post is never stored in the cache so it doesn't repeat on scroll

## Tests
<img width="724" height="247" alt="Screenshot 2026-07-03 at 3 27 34 PM" src="https://github.com/user-attachments/assets/38a68c54-ffad-4b1f-a32d-75c7ee0e562b" />
<img width="725" height="250" alt="Screenshot 2026-07-03 at 3 27 20 PM" src="https://github.com/user-attachments/assets/b834a214-1f28-467f-b66a-2e47fe59208f" />
<img width="724" height="287" alt="Screenshot 2026-07-03 at 3 27 47 PM" src="https://github.com/user-attachments/assets/675ba235-912d-4fcf-9037-477cb18c5378" />
