### PR TITLE
Add scheduled feed probes for continuous latency monitoring

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -208,6 +208,7 @@ deploy_api_service() {
     local inference_api_key_secret="inference-api-key-stage"
     local firestore_api_key_secret="firestore-api-key-stage"
     local feed_context_secret="feed-context-secret-stage"
+    local probe_secret="probe-secret-stage"
     local perspective_api_key_secret="perspective-api-key-stage"
     local firestore_database="greenearth-stage"
     if [ "$ENVIRONMENT" = "prod" ]; then
@@ -215,6 +216,7 @@ deploy_api_service() {
         inference_api_key_secret="inference-api-key-prod"
         firestore_api_key_secret="firestore-api-key-prod"
         feed_context_secret="feed-context-secret-prod"
+        probe_secret="probe-secret-prod"
         perspective_api_key_secret="perspective-api-key-prod"
         firestore_database="greenearth-prod"
     fi
@@ -248,6 +250,7 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-secrets=GE_INFERENCE_API_KEY=$inference_api_key_secret:latest"
     deploy_cmd="$deploy_cmd --set-secrets=GE_FIRESTORE_API_KEY=$firestore_api_key_secret:latest"
     deploy_cmd="$deploy_cmd --set-secrets=GE_FEED_CONTEXT_SECRET=$feed_context_secret:latest"
+    deploy_cmd="$deploy_cmd --set-secrets=GE_PROBE_SECRET=$probe_secret:latest"
     deploy_cmd="$deploy_cmd --set-secrets=GE_PERSPECTIVE_API_KEY=$perspective_api_key_secret:latest"
 
     # Resource and scaling configuration

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -240,6 +240,7 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-env-vars=GE_ELASTICSEARCH_VERIFY_SSL=false"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_FIRESTORE_PROJECT=$PROJECT_ID"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_FIRESTORE_DATABASE=$firestore_database"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_PROBE_USER_DID=did:plc:wrmpulygwvuhjn2c3jbalgqj"
 
     if [ -n "$GE_INFERENCE_BASE_URL" ]; then
         deploy_cmd="$deploy_cmd --set-env-vars=GE_INFERENCE_BASE_URL=$GE_INFERENCE_BASE_URL"

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -543,6 +543,57 @@ setup_bsky_secret() {
     fi
 }
 
+setup_feed_probe_cloud_scheduler() {
+    log_info "Setting up Cloud Scheduler feed probes for $ENVIRONMENT..."
+
+    # Resolve the Cloud Run service URL for this environment.
+    # Feed probes are direct unauthenticated HTTP GETs — no Cloud Run Job needed.
+    local service_url
+    service_url=$(gcloud run services describe "greenearth-api-$ENVIRONMENT" \
+        --region="$REGION" \
+        --project="$PROJECT_ID" \
+        --format="value(status.url)" 2>/dev/null)
+
+    if [ -z "$service_url" ]; then
+        log_warn "Could not resolve service URL for greenearth-api-$ENVIRONMENT — skipping feed probe scheduler setup"
+        log_warn "Deploy the API first, then re-run gcp_setup.sh"
+        return 0
+    fi
+
+    local generator_did="did:plc:wrmpulygwvuhjn2c3jbalgqj"
+    local schedule="* * * * *"
+    # All three public feeds (public=True in feeds.py)
+    local public_feeds=("random" "your-feed" "best-of-friends")
+
+    for feed_rkey in "${public_feeds[@]}"; do
+        local job_name="feed-probe-${feed_rkey}-${ENVIRONMENT}"
+        local uri="${service_url}/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://${generator_did}/app.bsky.feed.generator/${feed_rkey}&limit=5"
+        local description="Per-minute feed probe for ${feed_rkey} (${ENVIRONMENT}) — latency signal in Cloud Monitoring"
+
+        log_info "Configuring feed probe: $job_name"
+
+        if ! gcloud scheduler jobs describe "$job_name" --location="$REGION" --project="$PROJECT_ID" > /dev/null 2>&1; then
+            gcloud scheduler jobs create http "$job_name" \
+                --location="$REGION" \
+                --project="$PROJECT_ID" \
+                --schedule="$schedule" \
+                --uri="$uri" \
+                --http-method=GET \
+                --description="$description"
+            log_info "Cloud Scheduler feed probe created: $job_name"
+        else
+            gcloud scheduler jobs update http "$job_name" \
+                --location="$REGION" \
+                --project="$PROJECT_ID" \
+                --schedule="$schedule" \
+                --uri="$uri" \
+                --http-method=GET \
+                --description="$description"
+            log_info "Cloud Scheduler feed probe updated: $job_name"
+        fi
+    done
+}
+
 check_vpc_connector() {
     log_info "Checking for VPC connector..."
 
@@ -621,6 +672,7 @@ main() {
     setup_bsky_secret
     setup_perspective_secret
     check_vpc_connector
+    setup_feed_probe_cloud_scheduler
 
     echo ""
     log_info "✓ GCP setup complete!"
@@ -630,6 +682,7 @@ main() {
     log_info "  2. Ensure inference domain mapping is set up (inference-stage/inference)"
     log_info "     via ../engagement-prediction/inference_service/gcp_setup.sh"
     log_info "  3. Run ./scripts/deploy.sh to deploy the API to Cloud Run"
+    log_info "  4. Feed probe schedulers: 3 jobs fire every minute to produce latency signal in Cloud Monitoring"
     echo ""
 }
 

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -162,6 +162,14 @@ get_feed_context_secret() {
     fi
 }
 
+get_probe_secret() {
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        echo "probe-secret-prod"
+    else
+        echo "probe-secret-stage"
+    fi
+}
+
 get_perspective_api_key_secret() {
     if [ "$ENVIRONMENT" = "prod" ]; then
         echo "perspective-api-key-prod"
@@ -335,6 +343,29 @@ ensure_feed_context_secret() {
         --member="serviceAccount:$sa_email" \
         --role="roles/secretmanager.secretAccessor" \
         --condition=None > /dev/null 2>&1 || log_info "Service account already has access to $key_secret"
+}
+
+ensure_probe_secret() {
+    local sa_email="api-runner-$ENVIRONMENT@$PROJECT_ID.iam.gserviceaccount.com"
+    local probe_secret
+    probe_secret="$(get_probe_secret)"
+
+    log_info "Ensuring probe secret exists: $probe_secret"
+
+    if ! gcloud secrets describe "$probe_secret" --project="$PROJECT_ID" > /dev/null 2>&1; then
+        local value
+        value=$(openssl rand -hex 32)
+        echo -n "$value" | gcloud secrets create "$probe_secret" --data-file=- --project="$PROJECT_ID"
+        log_info "Probe secret created: $probe_secret"
+    else
+        log_info "Probe secret already exists: $probe_secret (preserving value)"
+    fi
+
+    gcloud secrets add-iam-policy-binding "$probe_secret" \
+        --member="serviceAccount:$sa_email" \
+        --role="roles/secretmanager.secretAccessor" \
+        --project="$PROJECT_ID" \
+        --condition=None > /dev/null 2>&1 || log_info "Service account already has access to $probe_secret"
 }
 
 create_service_account() {
@@ -560,6 +591,17 @@ setup_feed_probe_cloud_scheduler() {
         return 0
     fi
 
+    local probe_secret_name
+    probe_secret_name="$(get_probe_secret)"
+    local probe_secret_value
+    probe_secret_value=$(gcloud secrets versions access latest \
+        --secret="$probe_secret_name" --project="$PROJECT_ID" 2>/dev/null)
+
+    if [ -z "$probe_secret_value" ]; then
+        log_warn "Could not read probe secret $probe_secret_name — run ensure_probe_secret first"
+        return 0
+    fi
+
     local generator_did="did:plc:wrmpulygwvuhjn2c3jbalgqj"
     local schedule="* * * * *"
     # All three public feeds (public=True in feeds.py)
@@ -579,6 +621,7 @@ setup_feed_probe_cloud_scheduler() {
                 --schedule="$schedule" \
                 --uri="$uri" \
                 --http-method=GET \
+                --headers="X-Probe-Secret=$probe_secret_value" \
                 --description="$description"
             log_info "Cloud Scheduler feed probe created: $job_name"
         else
@@ -588,6 +631,7 @@ setup_feed_probe_cloud_scheduler() {
                 --schedule="$schedule" \
                 --uri="$uri" \
                 --http-method=GET \
+                --headers="X-Probe-Secret=$probe_secret_value" \
                 --description="$description"
             log_info "Cloud Scheduler feed probe updated: $job_name"
         fi
@@ -658,6 +702,7 @@ main() {
     ensure_firestore_api_key_secret
     ensure_inference_api_key_secret_access
     ensure_feed_context_secret
+    ensure_probe_secret
 
     # Fetch ES API key from K8s unless disabled or already provided
     if [ "$FETCH_ES_KEY" = true ] && [ -z "$GE_ELASTICSEARCH_API_KEY" ]; then

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -631,7 +631,7 @@ setup_feed_probe_cloud_scheduler() {
                 --schedule="$schedule" \
                 --uri="$uri" \
                 --http-method=GET \
-                --headers="X-Probe-Secret=$probe_secret_value" \
+                --update-headers="X-Probe-Secret=$probe_secret_value" \
                 --description="$description"
             log_info "Cloud Scheduler feed probe updated: $job_name"
         fi

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -609,7 +609,7 @@ setup_feed_probe_cloud_scheduler() {
 
     for feed_rkey in "${public_feeds[@]}"; do
         local job_name="feed-probe-${feed_rkey}-${ENVIRONMENT}"
-        local uri="${service_url}/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://${generator_did}/app.bsky.feed.generator/${feed_rkey}&limit=5"
+        local uri="${service_url}/xrpc/app.bsky.feed.getFeedSkeleton?feed=at://${generator_did}/app.bsky.feed.generator/${feed_rkey}&limit=30"
         local description="Per-minute feed probe for ${feed_rkey} (${ENVIRONMENT}) — latency signal in Cloud Monitoring"
 
         log_info "Configuring feed probe: $job_name"

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -116,7 +116,8 @@ setup_gcp_project() {
         apikeys.googleapis.com \
         secretmanager.googleapis.com \
         vpcaccess.googleapis.com \
-        compute.googleapis.com
+        compute.googleapis.com \
+        cloudscheduler.googleapis.com
 
     log_info "GCP APIs enabled successfully"
 }

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -679,7 +679,8 @@ async def get_feed_skeleton(
         logger.error("Firestore client not initialized")
         raise HTTPException(status_code=500, detail="Firestore unavailable")
 
-    _spawn_background(_record_session(request, user_did, feed_name, db))
+    if user_did != "did:plc:probe":
+        _spawn_background(_record_session(request, user_did, feed_name, db))
 
     # Per-user opt-in: capture pipeline debugging info for this feed load. This
     # costs one extra Firestore read per request; fail-soft so a hiccup degrades

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -652,20 +652,25 @@ async def get_feed_skeleton(
 
     feed_cfg = FEEDS[feed_name]
 
-    # Authenticate the requesting user via the AT Protocol inter-service JWT.
-    # A valid DID is required for this feed endpoint.
-    user_did = await verify_auth_header(request, service_did=_get_service_did())
+    # Cloud Scheduler probe bypass: if GE_PROBE_SECRET is set and the request
+    # carries the matching X-Probe-Secret header, skip AT Protocol auth and
+    # use a synthetic DID so the full pipeline runs and emits latency metrics.
+    _probe_secret = os.environ.get("GE_PROBE_SECRET")
+    if _probe_secret and request.headers.get("X-Probe-Secret") == _probe_secret:
+        user_did = "did:plc:probe"
+    else:
+        user_did = await verify_auth_header(request, service_did=_get_service_did())
 
-    if not user_did:
-        if request.headers.get("Authorization"):
-            logger.warning("Auth header present but verification failed for feed %s", feed_name)
-        else:
-            logger.warning("No auth header present for feed %s", feed_name)
-        raise HTTPException(
-            status_code=401,
-            detail="Authentication required",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        if not user_did:
+            if request.headers.get("Authorization"):
+                logger.warning("Auth header present but verification failed for feed %s", feed_name)
+            else:
+                logger.warning("No auth header present for feed %s", feed_name)
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
 
     # Record authenticated users in Firestore for backend analytics. Runs in
     # the background since this isn't essential for serving.

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -12,6 +12,7 @@ See: https://docs.bsky.app/docs/starter-templates/custom-feeds
 """
 
 import asyncio
+import hmac
 import logging
 import os
 import time
@@ -656,7 +657,9 @@ async def get_feed_skeleton(
     # carries the matching X-Probe-Secret header, skip AT Protocol auth and
     # use a synthetic DID so the full pipeline runs and emits latency metrics.
     _probe_secret = os.environ.get("GE_PROBE_SECRET")
-    if _probe_secret and request.headers.get("X-Probe-Secret") == _probe_secret:
+    if _probe_secret and hmac.compare_digest(
+        request.headers.get("X-Probe-Secret", ""), _probe_secret
+    ):
         user_did = "did:plc:probe"
     else:
         user_did = await verify_auth_header(request, service_did=_get_service_did())

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -660,7 +660,7 @@ async def get_feed_skeleton(
     if _probe_secret and hmac.compare_digest(
         request.headers.get("X-Probe-Secret", ""), _probe_secret
     ):
-        user_did = os.environ.get("GE_PROBE_USER_DID", "did:plc:wrmpulygwvuhjn2c3jbalgqj")
+        user_did = os.environ.get("GE_PROBE_USER_DID", "did:plc:s4tl2ajfsnstzuxtegl7r33g")
     else:
         user_did = await verify_auth_header(request, service_did=_get_service_did())
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -655,12 +655,12 @@ async def get_feed_skeleton(
 
     # Cloud Scheduler probe bypass: if GE_PROBE_SECRET is set and the request
     # carries the matching X-Probe-Secret header, skip AT Protocol auth and
-    # use a synthetic DID so the full pipeline runs and emits latency metrics.
+    # use the configured probe DID so the full pipeline runs and emits latency metrics.
     _probe_secret = os.environ.get("GE_PROBE_SECRET")
     if _probe_secret and hmac.compare_digest(
         request.headers.get("X-Probe-Secret", ""), _probe_secret
     ):
-        user_did = "did:plc:probe"
+        user_did = os.environ.get("GE_PROBE_USER_DID", "did:plc:wrmpulygwvuhjn2c3jbalgqj")
     else:
         user_did = await verify_auth_header(request, service_did=_get_service_did())
 
@@ -682,8 +682,7 @@ async def get_feed_skeleton(
         logger.error("Firestore client not initialized")
         raise HTTPException(status_code=500, detail="Firestore unavailable")
 
-    if user_did != "did:plc:probe":
-        _spawn_background(_record_session(request, user_did, feed_name, db))
+    _spawn_background(_record_session(request, user_did, feed_name, db))
 
     # Per-user opt-in: capture pipeline debugging info for this feed load. This
     # costs one extra Firestore read per request; fail-soft so a hiccup degrades

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1733,4 +1733,70 @@ class TestFeedDebugCapture:
             asyncio.run(self._drain(spawned))
 
         mock_write.assert_not_awaited()
-        assert "Failed to read debug flag" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Probe bypass (Cloud Scheduler)
+# ---------------------------------------------------------------------------
+
+class TestGetFeedSkeletonProbe:
+    """Cloud Scheduler hits the endpoint without AT Protocol auth.
+
+    When GE_PROBE_SECRET is set and the request carries the matching
+    X-Probe-Secret header, auth is bypassed and a synthetic DID is used.
+    """
+
+    PROBE_SECRET = "test-probe-secret-xyz"
+
+    @pytest.fixture(autouse=True)
+    def _set_probe_secret(self, monkeypatch):
+        monkeypatch.setenv("GE_PROBE_SECRET", self.PROBE_SECRET)
+
+    @pytest.fixture(autouse=True)
+    def _no_at_proto_auth(self):
+        """Simulate requests with no AT Protocol Bearer token."""
+        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_firestore(self):
+        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
+             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+            yield
+
+    def test_correct_probe_secret_returns_200(self):
+        """Matching X-Probe-Secret bypasses 401 and returns a feed."""
+        with _patch_unranked_your_feed_generators(_make_candidates("p", 3)):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI},
+                headers={"X-Probe-Secret": self.PROBE_SECRET},
+            )
+        assert resp.status_code == 200
+
+    def test_wrong_probe_secret_returns_401(self):
+        """Wrong X-Probe-Secret still 401s (no bypass)."""
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI},
+            headers={"X-Probe-Secret": "wrong-secret"},
+        )
+        assert resp.status_code == 401
+
+    def test_missing_probe_header_returns_401(self):
+        """No header at all still 401s."""
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI},
+        )
+        assert resp.status_code == 401
+
+    def test_probe_secret_env_unset_ignores_header(self, monkeypatch):
+        """When GE_PROBE_SECRET is not configured, any header value is ignored."""
+        monkeypatch.delenv("GE_PROBE_SECRET", raising=False)
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI},
+            headers={"X-Probe-Secret": self.PROBE_SECRET},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Adds Cloud Scheduler jobs that probe all three public feeds (`random`, `your-feed`, `best-of-friends`) every minute, so `feed.render.duration_ms` gets a continuous signal in Cloud Monitoring instead of sparse dots.
- AT Protocol JWTs expire in ~20 minutes and cannot be pre-issued for a scheduler, so a `probe-secret-{stage,prod}` is generated in Secret Manager and validated via `X-Probe-Secret` header in `getFeedSkeleton` to bypass AT Protocol auth for probe requests.
- Probe DID is `greenearth-social.bsky.social` (`did:plc:wrmpulygwvuhjn2c3jbalgqj`), the project's operational account. This allows user-specific generators (`followed_users`, `post_similarity`) to run without errors. `seen_posts` accumulation is intentionally not bypassed, because the account is operational so there is no UX impact, and adding a bypass would introduce unnecessary complexity.

## Results (stage)
Now the rendering duration is constantly monitored and can be seen in the dashboard :)
<img width="1157" height="698" alt="image" src="https://github.com/user-attachments/assets/a653eedf-a66c-4b15-a9a3-0109d9b5ca89" />