### PR TITLE
Remove thread_parent_post filters across all candidate generators

### DIFF
--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -39,7 +39,7 @@ async def followed_users_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = [{"exists": {"field": "thread_parent_post"}}]
+    must_not: list[dict] = []
     if exclude_uris:
         must_not.append({"terms": {"at_uri": exclude_uris}})
 

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -121,7 +121,6 @@ class TestFollowedUsersSearch:
                 "filter": [
                     {"terms": {"author_did": ["did:plc:follow1", "did:plc:follow2"]}},
                 ],
-                "must_not": [{"exists": {"field": "thread_parent_post"}}],
             }
         }
 
@@ -160,7 +159,6 @@ class TestFollowedUsersSearch:
 
         query = es.calls[0]["query"]
         assert query["bool"]["must_not"] == [
-            {"exists": {"field": "thread_parent_post"}},
             {"terms": {"at_uri": ["at://post/1", "at://post/2"]}},
         ]
 
@@ -171,9 +169,7 @@ class TestFollowedUsersSearch:
 
         await followed_users_search(es, "did:plc:user1", num_candidates=10)
 
-        assert es.calls[0]["query"]["bool"]["must_not"] == [
-            {"exists": {"field": "thread_parent_post"}},
-        ]
+        assert "must_not" not in es.calls[0]["query"]["bool"]
 
     @pytest.mark.asyncio
     async def test_returns_empty_and_skips_es_when_no_followed_users(self, monkeypatch):

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -113,7 +113,7 @@ async def fetch_posts_by_uris(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = [{"exists": {"field": "thread_parent_post"}}]
+    must_not: list[dict] = []
     if exclude_uris:
         must_not.append({"terms": {"at_uri": exclude_uris}})
 

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -203,7 +203,6 @@ class TestFetchPostsByUris:
         assert {"term": {"contains_video": True}} in query["bool"]["filter"]
         assert {"terms": {"at_uri": ["at://post/a"]}} in query["bool"]["filter"]
         assert query["bool"]["must_not"] == [
-            {"exists": {"field": "thread_parent_post"}},
             {"terms": {"at_uri": ["at://post/seen"]}},
         ]
 

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -67,7 +67,7 @@ async def popularity_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = [{"exists": {"field": "thread_parent_post"}}]
+    must_not: list[dict] = []
     if exclude_uris:
         must_not.append({"terms": {"at_uri": exclude_uris}})
 

--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -12,12 +12,12 @@ import logging
 
 from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
-from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings, POSTS_KNN_INDEX, unwrap_es_response
+from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings, POSTS_KNN_INDEX
 from ..feed_debug import current_recorder
 from ..embeddings import (
     MINILM_L12_EMBEDDING_FIELD,
 )
-from .utils import CANDIDATE_SOURCE_FIELDS, candidate_post_from_hit
+from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
@@ -37,16 +37,6 @@ def average_vectors(vectors: list[list[float]]) -> list[float]:
     return [x / n for x in avg]
 
 
-# How many extra hits to fetch from ES per requested candidate. The kNN
-# neighborhood of an averaged-likes vector is empirically ~75% replies and
-# ~5-10% videos, so we need significant margin to still hit num_candidates
-# after Python-side filtering. Capped so we don't blow out latency on large
-# requests.
-OVERFETCH_MULTIPLIER = 5
-MIN_OVERFETCH = 60
-MAX_OVERFETCH = 500
-
-
 async def knn_search_posts(
     es,
     query_vector: list[float],
@@ -57,32 +47,30 @@ async def knn_search_posts(
 ) -> list[CandidatePost]:
     """Run a kNN search against the ``posts_recent`` index and return candidate posts.
 
-    Reply exclusion (``thread_parent_post exists``) and the rare
-    ``video_only`` filter are applied **in Python** rather than via the ES
-    ``knn.filter`` parameter. Empirically, putting those filters in the
-    kNN clause forces ES into brute-force scoring (>1 s per shard, several
-    seconds total), even when ~55% of docs survive the filter. Profiling
-    shows the per-shard ``vector_operations_count`` jumps from a few
-    thousand to >100k when this happens.
-
-    Cheap, bitmap-friendly filters (``exclude_uris`` as a ``terms``
-    must_not) stay in ES because they don't trigger the fallback and
-    they save bandwidth.
+    Filters are passed inside the kNN clause so ES applies them during HNSW
+    traversal. The ``posts_recent`` index contains only top-level posts (no
+    replies), so no reply-exclusion filter is needed.
     """
-    fetch_size = max(
-        MIN_OVERFETCH,
-        min(MAX_OVERFETCH, num_candidates * OVERFETCH_MULTIPLIER),
-    )
+    filters: list[dict] = []
+    if video_only:
+        filters.append({"term": {"contains_video": True}})
+
+    must_not: list[dict] = []
+    if exclude_uris:
+        must_not.append({"terms": {"at_uri": exclude_uris}})
 
     knn_clause: dict = {
         "field": MINILM_L12_EMBEDDING_FIELD,
         "query_vector": query_vector,
-        "k": fetch_size,
-        "num_candidates": min(1500, fetch_size * 3),
+        "k": num_candidates,
+        "num_candidates": max(100, num_candidates * 10),
     }
-    if exclude_uris:
+    if filters or must_not:
         knn_clause["filter"] = {
-            "bool": {"must_not": [{"terms": {"at_uri": exclude_uris}}]}
+            "bool": {
+                **({"filter": filters} if filters else {}),
+                **({"must_not": must_not} if must_not else {}),
+            }
         }
 
     async with timed(
@@ -90,30 +78,16 @@ async def knn_search_posts(
         "knn_search_posts",
         index=POSTS_KNN_INDEX,
         num_candidates=num_candidates,
-        fetch_size=fetch_size,
     ):
         resp = await es.search(
             index=POSTS_KNN_INDEX,
             knn=knn_clause,
-            size=fetch_size,
+            size=num_candidates,
             _source=CANDIDATE_SOURCE_FIELDS,
             request_timeout=60,
         )
 
-    data = unwrap_es_response(resp)
-    candidates: list[CandidatePost] = []
-    for hit in data.get("hits", {}).get("hits", []):
-        src = hit.get("_source") or {}
-        # Skip replies — exclude documents where thread_parent_post is set.
-        if src.get("thread_parent_post"):
-            continue
-        if video_only and not src.get("contains_video"):
-            continue
-        candidates.append(candidate_post_from_hit(hit, generator_name=generator_name))
-        if len(candidates) >= num_candidates:
-            break
-
-    return candidates
+    return candidate_posts_from_es_response(resp, generator_name=generator_name)
 
 
 class PostSimilarityCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -432,19 +432,33 @@ class TestKnnSearchPosts:
         assert candidates[0].generator_name == "post_similarity"
 
     @pytest.mark.asyncio
-    async def test_no_reply_filter_in_es_query(self):
-        """Reply exclusion is intentionally NOT sent to ES — it would force
-        a brute-force fallback (~10x slower). We filter replies in Python."""
+    async def test_no_filters_when_no_args(self):
+        """No filter clause sent to ES when there is nothing to filter on."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(es, [0.1, 0.2], num_candidates=5)
         knn = es.calls[0]["knn"]
         assert es.calls[0]["query"] is None
-        # No filter at all when there are no exclude_uris.
+        assert "filter" not in knn
+
+    @pytest.mark.asyncio
+    async def test_video_only_true_sends_es_filter(self):
+        """video_only is applied on the ES side inside knn.filter."""
+        es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
+        await knn_search_posts(es, [0.1, 0.2], num_candidates=5, video_only=True)
+        knn = es.calls[0]["knn"]
+        assert {"term": {"contains_video": True}} in knn["filter"]["bool"]["filter"]
+
+    @pytest.mark.asyncio
+    async def test_video_only_false_omits_filter(self):
+        """When video_only is False and no exclude_uris, no filter is sent."""
+        es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
+        await knn_search_posts(es, [0.1, 0.2], num_candidates=5, video_only=False)
+        knn = es.calls[0]["knn"]
         assert "filter" not in knn
 
     @pytest.mark.asyncio
     async def test_exclude_uris_is_an_es_filter(self):
-        """exclude_uris is bitmap-friendly and small, so it stays in ES."""
+        """exclude_uris is bitmap-friendly and stays in ES knn.filter."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
             es, [0.1, 0.2], num_candidates=5, exclude_uris=["at://a", "at://b"]
@@ -453,116 +467,13 @@ class TestKnnSearchPosts:
         assert {"terms": {"at_uri": ["at://a", "at://b"]}} in knn["filter"]["bool"]["must_not"]
 
     @pytest.mark.asyncio
-    async def test_replies_are_filtered_out_in_python(self):
-        """Hits with thread_parent_post set are dropped from the returned set."""
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.95,
-                            "_source": {
-                                "at_uri": "at://post/1",
-                                "content": "original",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
-                            },
-                        },
-                        {
-                            "_score": 0.94,
-                            "_source": {
-                                "at_uri": "at://post/2",
-                                "content": "reply",
-                                "thread_parent_post": "at://parent/x",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
-                            },
-                        },
-                        {
-                            "_score": 0.93,
-                            "_source": {
-                                "at_uri": "at://post/3",
-                                "content": "another original",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.0, 1.0]},
-                            },
-                        },
-                    ]
-                }
-            }
-        })
-        candidates = await knn_search_posts(es, [0.1, 0.2], num_candidates=10)
-        assert [c.at_uri for c in candidates] == ["at://post/1", "at://post/3"]
-
-    @pytest.mark.asyncio
-    async def test_video_only_filters_in_python(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.9,
-                            "_source": {
-                                "at_uri": "at://a",
-                                "content": "some content",
-                                "contains_video": True,
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://b",
-                                "content": "some content",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_score": 0.7,
-                            "_source": {
-                                "at_uri": "at://c",
-                                "content": "some content",
-                                "contains_video": True,
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                    ]
-                }
-            }
-        })
-        candidates = await knn_search_posts(es, [0.1, 0.2], num_candidates=10, video_only=True)
-        assert [c.at_uri for c in candidates] == ["at://a", "at://c"]
-
-    @pytest.mark.asyncio
-    async def test_overfetches_to_compensate_for_python_filter(self):
-        """We ask ES for several times num_candidates so Python-side
-        reply/video filtering still leaves enough results."""
+    async def test_uses_num_candidates_directly_for_k(self):
+        """No overfetch: k == num_candidates since replies are gone from the index."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(es, [0.1, 0.2], num_candidates=10)
         call = es.calls[0]
-        # OVERFETCH_MULTIPLIER * num_candidates with a floor of MIN_OVERFETCH.
-        assert call["size"] >= 50
-        assert call["knn"]["k"] == call["size"]
-
-    @pytest.mark.asyncio
-    async def test_caps_returned_candidates_at_num_candidates(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0 - i / 100,
-                            "_source": {
-                                "at_uri": f"at://p/{i}",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                                "content": "some content",
-                            }
-                        }
-                        for i in range(20)
-                    ]
-                }
-            }
-        })
-        candidates = await knn_search_posts(es, [0.1, 0.2], num_candidates=5)
-        assert len(candidates) == 5
-        assert [c.at_uri for c in candidates] == [f"at://p/{i}" for i in range(5)]
+        assert call["size"] == 10
+        assert call["knn"]["k"] == 10
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -22,7 +22,7 @@ async def random_posts_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = [{"exists": {"field": "thread_parent_post"}}]
+    must_not: list[dict] = []
     if exclude_uris:
         must_not.append({"terms": {"at_uri": exclude_uris}})
 

--- a/src/app/lib/candidates/utils.py
+++ b/src/app/lib/candidates/utils.py
@@ -14,7 +14,6 @@ CANDIDATE_SOURCE_FIELDS = [
     "at_uri",
     "author_did",
     "content",
-    "thread_parent_post",   # used for Python-side reply filtering
     "contains_video",       # used for video_only filtering
     "contains_images",      # media metadata (feed debugging)
     "image_count",          # media metadata (feed debugging)


### PR DESCRIPTION
Closes #148

The posts and posts_recent Elasticsearch indices were split so replies now live in a separate index. Top-level-post-only indices no longer contain documents where `thread_parent_post` is set, making two classes of workarounds obsolete.

# This PR

- **`post_similarity.py`**: Reverts the Python-side overfetch+filter workaround (commit `9947521`). Removes the `OVERFETCH_MULTIPLIER`/`MIN_OVERFETCH`/`MAX_OVERFETCH` constants, the 5× overfetch, and the Python-side reply and video filtering loop. Restores `video_only` as an ES-side `knn.filter.bool.filter` clause. `k` is now set directly to `num_candidates` since no reply overhead exists.
- **`followed_users.py`, `network_likes.py`, `popularity.py`, `random_posts.py`**: Removes `must_not: exists: thread_parent_post` from all four generators querying the `posts` index.
- **`utils.py`**: Removes `thread_parent_post` from `CANDIDATE_SOURCE_FIELDS` — the field is no longer needed since no generator filters on it in Python.
- All tests updated to reflect the new ES-side filtering behavior.

# Testing

- `pytest src/app/lib/candidates/ -v` — 73 passed, 0 failed
- Verified new tests confirm: `video_only` goes into `knn.filter.bool.filter`, `exclude_uris` stays in `knn.filter.bool.must_not`, no filter clause when neither arg is set, `k == num_candidates` (no overfetch)