### PR TITLE
Move exclude_uris filtering from ES must_not back to Python

### DIFF
--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -39,10 +39,6 @@ async def followed_users_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = []
-    if exclude_uris:
-        must_not.append({"terms": {"at_uri": exclude_uris}})
-
     try:
         async with timed(logger, "bsky_get_follows", user_did=user_did):
             followed_dids: list[str] = await get_followed_user_dids(
@@ -67,9 +63,10 @@ async def followed_users_search(
                 *filters,
                 {"terms": {"author_did": followed_dids}},
             ],
-            **("must_not" and {"must_not": must_not} if must_not else {}),
         }
     }
+
+    fetch_size = num_candidates + len(exclude_uris or [])
 
     async with timed(
         logger,
@@ -80,11 +77,16 @@ async def followed_users_search(
         resp = await es.search(
             index="posts",
             query=query,
-            size=num_candidates,
+            size=fetch_size,
             sort=[{"created_at": "desc"}],
             _source=CANDIDATE_SOURCE_FIELDS,
         )
-    return candidate_posts_from_es_response(resp, generator_name=generator_name)
+
+    candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
+    if exclude_uris:
+        exclude_set = set(exclude_uris)
+        candidates = [c for c in candidates if c.at_uri not in exclude_set]
+    return candidates[:num_candidates]
 
 
 class FollowedUsersCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -112,7 +112,7 @@ class TestFollowedUsersSearch:
         assert len(es.calls) == 1
         call = es.calls[0]
         assert call["index"] == "posts"
-        assert call["size"] == 20
+        assert call["size"] == 20  # num_candidates=20, no exclude_uris
         assert call["sort"] == [{"created_at": "desc"}]
 
         query = call["query"]
@@ -146,30 +146,49 @@ class TestFollowedUsersSearch:
         assert {"term": {"contains_video": True}} not in filters
 
     @pytest.mark.asyncio
-    async def test_exclude_uris_adds_must_not_terms(self, monkeypatch):
+    async def test_exclude_uris_overfetches_and_filters_in_python(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs()
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_score": 1.0,
+                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 0.9,
+                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 0.8,
+                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
+                        },
+                    ]
+                }
+            }
+        })
 
-        await followed_users_search(
+        candidates = await followed_users_search(
             es,
             "did:plc:user1",
-            num_candidates=10,
-            exclude_uris=["at://post/1", "at://post/2"],
+            num_candidates=2,
+            exclude_uris=["at://post/excluded"],
         )
 
-        query = es.calls[0]["query"]
-        assert query["bool"]["must_not"] == [
-            {"terms": {"at_uri": ["at://post/1", "at://post/2"]}},
-        ]
+        assert "must_not" not in es.calls[0]["query"]["bool"]
+        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert [c.at_uri for c in candidates] == ["at://post/1", "at://post/2"]
 
     @pytest.mark.asyncio
-    async def test_no_exclude_uris_omits_must_not(self, monkeypatch):
+    async def test_no_exclude_uris_omits_must_not_and_no_overfetch(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs()
 
         await followed_users_search(es, "did:plc:user1", num_candidates=10)
 
         assert "must_not" not in es.calls[0]["query"]["bool"]
+        assert es.calls[0]["size"] == 10
 
     @pytest.mark.asyncio
     async def test_returns_empty_and_skips_es_when_no_followed_users(self, monkeypatch):

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -113,17 +113,12 @@ async def fetch_posts_by_uris(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = []
-    if exclude_uris:
-        must_not.append({"terms": {"at_uri": exclude_uris}})
-
     posts_query = {
         "bool": {
             "filter": [
                 *filters,
                 {"terms": {"at_uri": at_uris}},
             ],
-            "must_not": must_not,
         }
     }
 
@@ -134,9 +129,10 @@ async def fetch_posts_by_uris(
         _source=CANDIDATE_SOURCE_FIELDS,
     )
 
+    exclude_set = set(exclude_uris) if exclude_uris else set()
     candidates_by_uri: dict[str, CandidatePost] = {}
     for candidate in candidate_posts_from_es_response(resp, generator_name=generator_name):
-        if candidate.at_uri:
+        if candidate.at_uri and candidate.at_uri not in exclude_set:
             candidates_by_uri[candidate.at_uri] = candidate
 
     return [

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -189,22 +189,26 @@ class TestFetchPostsByUris:
         assert candidates[0].minilm_l12_embedding is not None
 
     @pytest.mark.asyncio
-    async def test_applies_video_and_exclude_filters(self):
-        es = FakeEs()
+    async def test_applies_video_filter_in_es_and_exclude_filter_in_python(self):
+        es = FakeEs(
+            posts_by_uri={
+                "at://post/a": post_hit("at://post/a"),
+                "at://post/seen": post_hit("at://post/seen"),
+            },
+        )
 
-        await fetch_posts_by_uris(
+        candidates = await fetch_posts_by_uris(
             es,
-            ["at://post/a"],
+            ["at://post/a", "at://post/seen"],
             video_only=True,
             exclude_uris=["at://post/seen"],
         )
 
         query = es.calls[0]["query"]
         assert {"term": {"contains_video": True}} in query["bool"]["filter"]
-        assert {"terms": {"at_uri": ["at://post/a"]}} in query["bool"]["filter"]
-        assert query["bool"]["must_not"] == [
-            {"terms": {"at_uri": ["at://post/seen"]}},
-        ]
+        assert {"terms": {"at_uri": ["at://post/a", "at://post/seen"]}} in query["bool"]["filter"]
+        assert "must_not" not in query["bool"]
+        assert [c.at_uri for c in candidates] == ["at://post/a"]
 
     @pytest.mark.asyncio
     async def test_empty_uri_list_skips_es(self):

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -67,16 +67,11 @@ async def popularity_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = []
-    if exclude_uris:
-        must_not.append({"terms": {"at_uri": exclude_uris}})
-
     query = {
         "function_score": {
             "query": {
                 "bool": {
                     "filter": filters,
-                    **("must_not" and {"must_not": must_not} if must_not else {}),
                 }
             },
             "functions": [
@@ -112,14 +107,21 @@ async def popularity_search(
         }
     }
 
+    fetch_size = num_candidates + len(exclude_uris or [])
+
     async with timed(logger, "es_popularity", num_candidates=num_candidates):
         resp = await es.search(
             index="posts",
             query=query,
-            size=num_candidates,
+            size=fetch_size,
             _source=CANDIDATE_SOURCE_FIELDS,
         )
-    return candidate_posts_from_es_response(resp, generator_name=generator_name)
+
+    candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
+    if exclude_uris:
+        exclude_set = set(exclude_uris)
+        candidates = [c for c in candidates if c.at_uri not in exclude_set]
+    return candidates[:num_candidates]
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -116,6 +116,46 @@ class TestPopularitySearch:
         assert any("range" in f for f in filters)
 
     @pytest.mark.asyncio
+    async def test_exclude_uris_overfetches_and_filters_in_python(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_score": 10.0,
+                            "_source": {"at_uri": "at://popular/1", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 9.0,
+                            "_source": {"at_uri": "at://popular/excluded", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 8.0,
+                            "_source": {"at_uri": "at://popular/2", "content": "x", "embeddings": {}},
+                        },
+                    ]
+                }
+            }
+        })
+
+        candidates = await popularity_search(
+            es,
+            num_candidates=2,
+            exclude_uris=["at://popular/excluded"],
+        )
+
+        inner_bool = es.calls[0]["query"]["function_score"]["query"]["bool"]
+        assert "must_not" not in inner_bool
+        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert [c.at_uri for c in candidates] == ["at://popular/1", "at://popular/2"]
+
+    @pytest.mark.asyncio
+    async def test_no_exclude_uris_no_overfetch(self):
+        es = FakeEs()
+        await popularity_search(es, num_candidates=10)
+        assert es.calls[0]["size"] == 10
+
+    @pytest.mark.asyncio
     async def test_returns_empty_when_no_results(self):
         es = FakeEs()
         candidates = await popularity_search(es, num_candidates=10)

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -22,16 +22,11 @@ async def random_posts_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    must_not: list[dict] = []
-    if exclude_uris:
-        must_not.append({"terms": {"at_uri": exclude_uris}})
-
     query = {
         "function_score": {
             "query": {
                 "bool": {
                     "filter": filters,
-                    **("must_not" and {"must_not": must_not} if must_not else {}),
                 }
             },
             "random_score": {},
@@ -39,13 +34,20 @@ async def random_posts_search(
         }
     }
 
+    fetch_size = num_candidates + len(exclude_uris or [])
+
     resp = await es.search(
         index="posts",
         query=query,
-        size=num_candidates,
+        size=fetch_size,
         _source=CANDIDATE_SOURCE_FIELDS,
     )
-    return candidate_posts_from_es_response(resp, generator_name=generator_name)
+
+    candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
+    if exclude_uris:
+        exclude_set = set(exclude_uris)
+        candidates = [c for c in candidates if c.at_uri not in exclude_set]
+    return candidates[:num_candidates]
 
 
 class RandomPostsCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -98,6 +98,46 @@ class TestRandomPostsSearch:
         assert {"term": {"contains_video": True}} not in filters
 
     @pytest.mark.asyncio
+    async def test_exclude_uris_overfetches_and_filters_in_python(self):
+        es = FakeEs(responses={
+            "posts": {
+                "hits": {
+                    "hits": [
+                        {
+                            "_score": 1.0,
+                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 0.9,
+                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
+                        },
+                        {
+                            "_score": 0.8,
+                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
+                        },
+                    ]
+                }
+            }
+        })
+
+        candidates = await random_posts_search(
+            es,
+            num_candidates=2,
+            exclude_uris=["at://post/excluded"],
+        )
+
+        inner_bool = es.calls[0]["query"]["function_score"]["query"]["bool"]
+        assert "must_not" not in inner_bool
+        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert [c.at_uri for c in candidates] == ["at://post/1", "at://post/2"]
+
+    @pytest.mark.asyncio
+    async def test_no_exclude_uris_no_overfetch(self):
+        es = FakeEs()
+        await random_posts_search(es, num_candidates=10)
+        assert es.calls[0]["size"] == 10
+
+    @pytest.mark.asyncio
     async def test_returns_empty_when_no_results(self):
         es = FakeEs()
         candidates = await random_posts_search(es, num_candidates=10)


### PR DESCRIPTION
Closes #172

Profiling (issue #148, PR #167) shows `followed_users_search` is the dominant source of slow ES queries. The bottleneck is the `ConstantScore(-at_uri:...)` scorer generated by `must_not: [terms: {at_uri: exclude_uris}]` — ES rebuilds this inverted scorer on every segment across 36–56 shards. Moving filtering back to Python eliminates this overhead entirely.

# This PR

- **`followed_users_search`, `random_posts_search`, `popularity_search`**: Remove `must_not` clause from ES query; overfetch by `len(exclude_uris)` (`size = num_candidates + len(exclude_uris or [])`); filter excluded URIs in Python post-response; cap at `num_candidates`
- **`fetch_posts_by_uris` (network_likes)**: Remove `must_not` clause; no overfetch needed since `size=len(at_uris)` already covers all possible hits; filter excluded URIs in Python when building `candidates_by_uri`
- Update all four test files to assert no `must_not` in ES queries, correct overfetch sizes, and correct Python-side filtering behavior

# Testing

- All 46 unit tests across the four modified test files pass (`pytest src/app/lib/candidates/{followed_users,random_posts,popularity,network_likes}_test.py`)