### PR TITLE
Diversify and Feed Debug Output Nits

### DIFF
--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -117,6 +117,11 @@ def _fmt_score(score: float | None) -> str:
     return f"{score:.4f}" if score is not None else "—"
 
 
+def _diversification_relevance_contribution(div) -> float:
+    """Displayed relevance term so: score = rel - author_penalty - content_penalty."""
+    return div.score + div.author_penalty + div.content_penalty
+
+
 def _model_specs_str(doc: FeedDebugDocument) -> str:
     """Configured rank models with weights, e.g. 'two_tower(1), perspective(1)'.
 
@@ -326,7 +331,7 @@ def _item_panel(
     if div is not None:
         diversify_line = Text()
         diversify_line.append("diversify    rel ", style="dim")
-        diversify_line.append(f"{div.relevance:.3f}", style="white")
+        diversify_line.append(f"{_diversification_relevance_contribution(div):.3f}", style="white")
         diversify_line.append("   −author ", style="dim")
         diversify_line.append(f"{div.author_penalty:.3f}", style="magenta")
         diversify_line.append("   −content ", style="dim")

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -50,10 +50,16 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
 
     while remaining:
         if not selected:
-            best = max(remaining, key=lambda i: norm_scores[i])
+            best = max(remaining, key=lambda i: (1 - BETA) * norm_scores[i])
             if diag is not None:
                 diag.append(
-                    (candidates[best].at_uri or "", norm_scores[best], norm_scores[best], 0.0, 0.0)
+                    (
+                        candidates[best].at_uri or "",
+                        norm_scores[best],
+                        (1 - BETA) * norm_scores[best],
+                        0.0,
+                        0.0,
+                    )
                 )
         else:
             best = max(

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -3,8 +3,16 @@
 import pytest
 
 from ..models import CandidatePost
-from .diversify import AUTHOR_WEIGHT, _cosine_similarity, _raw_similarity, _similarity, mmr_rerank
+from .diversify import (
+    AUTHOR_WEIGHT,
+    BETA,
+    _cosine_similarity,
+    _raw_similarity,
+    _similarity,
+    mmr_rerank,
+)
 from .embeddings import encode_float32_b64
+from .feed_debug import FeedDebugRecorder, feed_debug_scope
 
 
 def _post(uri: str, score: float, author_did: str | None = None) -> CandidatePost:
@@ -89,6 +97,24 @@ def test_equal_scores_diversity_drives_selection():
     result = mmr_rerank([a1, a2, b1])
     uris = [c.at_uri for c in result]
     assert uris.index("at://bob/1") < uris.index("at://alice/2")
+
+
+def test_first_debug_score_uses_weighted_relevance():
+    """The first pick has no diversity penalty, but its MMR score is still beta-weighted."""
+    a = _post("at://a/1", score=1.0, author_did="did:plc:a")
+    b = _post("at://b/1", score=0.5, author_did="did:plc:b")
+    rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+
+    with feed_debug_scope(rec):
+        result = mmr_rerank([a, b])
+
+    assert result[0] is a
+    at_uri, relevance, score, author_penalty, content_penalty = rec.diversification[0]
+    assert at_uri == "at://a/1"
+    assert relevance == pytest.approx(1.0)
+    assert score == pytest.approx((1 - BETA) * relevance)
+    assert author_penalty == pytest.approx(0.0)
+    assert content_penalty == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -3,16 +3,8 @@
 import pytest
 
 from ..models import CandidatePost
-from .diversify import (
-    AUTHOR_WEIGHT,
-    BETA,
-    _cosine_similarity,
-    _raw_similarity,
-    _similarity,
-    mmr_rerank,
-)
+from .diversify import AUTHOR_WEIGHT, _cosine_similarity, _raw_similarity, _similarity, mmr_rerank
 from .embeddings import encode_float32_b64
-from .feed_debug import FeedDebugRecorder, feed_debug_scope
 
 
 def _post(uri: str, score: float, author_did: str | None = None) -> CandidatePost:
@@ -97,24 +89,6 @@ def test_equal_scores_diversity_drives_selection():
     result = mmr_rerank([a1, a2, b1])
     uris = [c.at_uri for c in result]
     assert uris.index("at://bob/1") < uris.index("at://alice/2")
-
-
-def test_first_debug_score_uses_weighted_relevance():
-    """The first pick has no diversity penalty, but its MMR score is still beta-weighted."""
-    a = _post("at://a/1", score=1.0, author_did="did:plc:a")
-    b = _post("at://b/1", score=0.5, author_did="did:plc:b")
-    rec = FeedDebugRecorder(feed_name="f", regenerated=False)
-
-    with feed_debug_scope(rec):
-        result = mmr_rerank([a, b])
-
-    assert result[0] is a
-    at_uri, relevance, score, author_penalty, content_penalty = rec.diversification[0]
-    assert at_uri == "at://a/1"
-    assert relevance == pytest.approx(1.0)
-    assert score == pytest.approx((1 - BETA) * relevance)
-    assert author_penalty == pytest.approx(0.0)
-    assert content_penalty == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from .candidates.base import CandidateResult
-from .diversify import mmr_rerank
+from .diversify import BETA, mmr_rerank
 from .embeddings import encode_float32_b64
 from .feed_debug import (
     CONTENT_SNIPPET_MAX,
@@ -225,8 +225,12 @@ class TestDiversificationCapture:
             mmr_rerank([a, b])
 
         assert [e[0] for e in rec.diversification] == ["at://a", "at://b"]
-        # First pick: selected on relevance alone, no penalty.
-        assert rec.diversification[0] == ("at://a", 1.0, 1.0, 0.0, 0.0)
+        # First pick: selected on weighted relevance alone, no penalty.
+        _, rel, score, author_pen, content_pen = rec.diversification[0]
+        assert rel == pytest.approx(1.0)
+        assert score == pytest.approx((1 - BETA) * 1.0)
+        assert author_pen == pytest.approx(0.0)
+        assert content_pen == pytest.approx(0.0)
         # Second pick: author_penalty = BETA * AUTHOR_WEIGHT * 1 = 0.5 * 0.75.
         _, rel, score, author_pen, content_pen = rec.diversification[1]
         assert rel == pytest.approx(0.5)


### PR DESCRIPTION
Closes #177 

- In the MMR diversify pass, the most relevant post gets a normalized score of 1.0. Whereas every subsequent post gets a score of (1-B) * norm_score - B * similarity, where B is currently set to 0.5. So it makes more sense to set the first post to 1-B to keep it consistent with the other posts.
- In the feed_debug output, there is a relevance score, the author penalty, the content penalty, and the final score. Again the (1-B) term isn't currently included in the relevance score, and so you don't have the nice relationship where score = relevance - penalty1 - penalty2. If we include the (1-B) then the equation holds. Just a little easier to understand the numbers.

### Testing
- Added unit tests
- Deployed to stage and confirmed correct numbers