### PR TITLE
Move feed candidate generators and ranking lookups to posts_recent

### DIFF
--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -33,7 +33,7 @@ async def followed_users_search(
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
 ) -> list[CandidatePost]:
-    """Fetch posts from users followed by user_did from the ``posts`` index."""
+    """Fetch posts from users followed by user_did from the ``posts_recent`` index."""
 
     filters: list[dict] = []
     if video_only:
@@ -75,7 +75,7 @@ async def followed_users_search(
         num_candidates=num_candidates,
     ):
         resp = await es.search(
-            index="posts",
+            index="posts_recent",
             query=query,
             size=fetch_size,
             sort=[{"created_at": "desc"}],

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -60,7 +60,7 @@ class TestFollowedUsersSearch:
             fake_get_followed_user_dids,
         )
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -111,7 +111,7 @@ class TestFollowedUsersSearch:
 
         assert len(es.calls) == 1
         call = es.calls[0]
-        assert call["index"] == "posts"
+        assert call["index"] == "posts_recent"
         assert call["size"] == 20  # num_candidates=20, no exclude_uris
         assert call["sort"] == [{"created_at": "desc"}]
 
@@ -149,7 +149,7 @@ class TestFollowedUsersSearch:
     async def test_exclude_uris_overfetches_and_filters_in_python(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -225,7 +225,7 @@ class TestFollowedUsersSearch:
     async def test_generator_name_defaults_to_none(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -255,7 +255,7 @@ class TestFollowedUsersCandidateGenerator:
     async def test_generate(self, generator, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -111,7 +111,7 @@ async def popularity_search(
 
     async with timed(logger, "es_popularity", num_candidates=num_candidates):
         resp = await es.search(
-            index="posts",
+            index="posts_recent",
             query=query,
             size=fetch_size,
             _source=CANDIDATE_SOURCE_FIELDS,

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -39,7 +39,7 @@ class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -82,7 +82,7 @@ class TestPopularitySearch:
 
         assert len(es.calls) == 1
         call = es.calls[0]
-        assert call["index"] == "posts"
+        assert call["index"] == "posts_recent"
         assert call["size"] == 20
 
         query = call["query"]
@@ -118,7 +118,7 @@ class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_exclude_uris_overfetches_and_filters_in_python(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -164,7 +164,7 @@ class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_handles_missing_embeddings(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -185,7 +185,7 @@ class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_generator_name_defaults_to_none(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -216,7 +216,7 @@ class TestPopularityCandidateGenerator:
     @pytest.mark.asyncio
     async def test_generate(self, generator):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -16,7 +16,7 @@ async def random_posts_search(
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
 ) -> list[CandidatePost]:
-    """Fetch random posts from the ``posts`` index."""
+    """Fetch random posts from the ``posts_recent`` index."""
 
     filters: list[dict] = []
     if video_only:
@@ -37,7 +37,7 @@ async def random_posts_search(
     fetch_size = num_candidates + len(exclude_uris or [])
 
     resp = await es.search(
-        index="posts",
+        index="posts_recent",
         query=query,
         size=fetch_size,
         _source=CANDIDATE_SOURCE_FIELDS,

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -31,7 +31,7 @@ class TestRandomPostsSearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -75,7 +75,7 @@ class TestRandomPostsSearch:
 
         assert len(es.calls) == 1
         call = es.calls[0]
-        assert call["index"] == "posts"
+        assert call["index"] == "posts_recent"
         assert call["size"] == 20
 
         query = call["query"]
@@ -100,7 +100,7 @@ class TestRandomPostsSearch:
     @pytest.mark.asyncio
     async def test_exclude_uris_overfetches_and_filters_in_python(self):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {
@@ -152,7 +152,7 @@ class TestRandomPostsCandidateGenerator:
     @pytest.mark.asyncio
     async def test_generate(self, generator):
         es = FakeEs(responses={
-            "posts": {
+            "posts_recent": {
                 "hits": {
                     "hits": [
                         {

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -107,6 +107,7 @@ async def fetch_recent_liked_post_uris(
 async def fetch_post_embeddings(
     es,
     at_uris: list[str],
+    index: str = "posts",
 ) -> list[tuple[str, list[float]]]:
     """Fetch MiniLM L12 embeddings for a list of post AT URIs.
 
@@ -124,7 +125,7 @@ async def fetch_post_embeddings(
             query = {"terms": {"at_uri": at_uris}}
 
             resp = await es.search(
-                index="posts",
+                index=index,
                 query=query,
                 size=len(at_uris),
                 _source=[
@@ -159,13 +160,14 @@ async def fetch_post_embeddings(
     cache = get_request_cache()
     if cache is None:
         return await _fetch()
-    key = ("fetch_post_embeddings", tuple(at_uris))
+    key = ("fetch_post_embeddings", index, tuple(at_uris))
     return await cache.get_or_compute(key, _fetch)
 
 
 async def fetch_post_embeddings_and_authors(
     es,
     at_uris: list[str],
+    index: str = "posts",
 ) -> list[tuple[str, list[float], str]]:
     """Fetch MiniLM L12 embeddings for a list of post AT URIs, as well as their author DIDs.
 
@@ -184,7 +186,7 @@ async def fetch_post_embeddings_and_authors(
             query = {"terms": {"at_uri": at_uris}}
 
             resp = await es.search(
-                index="posts",
+                index=index,
                 query=query,
                 size=len(at_uris),
                 _source=[
@@ -225,5 +227,5 @@ async def fetch_post_embeddings_and_authors(
     cache = get_request_cache()
     if cache is None:
         return await _fetch()
-    key = ("fetch_post_embeddings_and_authors", tuple(at_uris))
+    key = ("fetch_post_embeddings_and_authors", index, tuple(at_uris))
     return await cache.get_or_compute(key, _fetch)

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -125,7 +125,7 @@ class TwoTowerRanker(Ranker):
                     missing_uris.append(uri)
 
                 if missing_uris:
-                    fetched = await fetch_post_embeddings_and_authors(es, missing_uris)
+                    fetched = await fetch_post_embeddings_and_authors(es, missing_uris, index="posts_recent")
                     uris_embs_authors.extend(fetched)
 
                 if not uris_embs_authors:

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -44,7 +44,7 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
         fake_fetch_recent_liked_post_uris,
     )
 
-    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index=None):
         if at_uris == ["at://liked/1"]:
             return [("at://liked/1", [0.5, 0.5], "did:plc:liked")]
         return [
@@ -102,7 +102,7 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return []
 
-    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index=None):
         seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
         return [("at://post/a", [2.0, 0.0], "did:plc:a")]
 
@@ -161,7 +161,7 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return ["at://liked/1"]
 
-    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index=None):
         seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
         if at_uris == ["at://liked/1"]:
             return []
@@ -224,7 +224,7 @@ def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missi
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return []
 
-    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index=None):
         return []
 
     async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
@@ -279,7 +279,7 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
     async def fake_fetch_recent_liked_post_uris(es, user_did):
         return ["at://liked/1"]
 
-    async def fake_fetch_post_embeddings_and_authors(es, at_uris):
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index=None):
         if at_uris == ["at://liked/1"]:
             return [("at://liked/1", [0.5, 0.5], "did:plc:liked")]
         return [("at://post/a", [1.0, 0.0], "did:plc:a")]

--- a/src/app/routers/candidates_test.py
+++ b/src/app/routers/candidates_test.py
@@ -52,7 +52,8 @@ def fake_app_es():
                             ]
                         }
                     }
-                # function_score (popularity) or kNN (post_similarity)
+            if index == "posts_recent":
+                # function_score (popularity, random_posts)
                 if isinstance(query, dict) and "function_score" in query:
                     return {
                         "hits": {
@@ -76,7 +77,6 @@ def fake_app_es():
                             ]
                         }
                     }
-            if index == "posts_recent":
                 # kNN search result (post_similarity)
                 return {
                     "hits": {

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -219,7 +219,7 @@ async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[Candi
 
     try:
         async with timed(logger, "hydrate_embeddings", n_missing=len(missing)):
-            pairs = await fetch_post_embeddings(es, missing)
+            pairs = await fetch_post_embeddings(es, missing, index="posts_recent")
     except Exception:
         # If the refetch fails, MMR falls back to author-only similarity
         # and the two-tower ranker has its own refetch path. Don't fail


### PR DESCRIPTION
Closes #169

Step 1 (extend `posts_recent` alias to 2 weeks) was completed in ingex PR #389. This PR implements Steps 2 and 3 from the issue.

# This PR

- Migrate `popularity_search`, `followed_users_search`, and `random_posts_search` to query `posts_recent` instead of `posts`, reducing shard scatter from 36–56 to 14
- Add `index` parameter (defaulting to `"posts"`) to `fetch_post_embeddings` and `fetch_post_embeddings_and_authors` in `elasticsearch.py`
- Update ranking call sites (`two_tower.py`, `xrpc.py`) to pass `index="posts_recent"`; seed-fetching paths (`post_similarity.py`, `inference.py`) retain the default `posts`
- Update cache keys to include `index` so calls to different indices are not incorrectly deduplicated
- Update candidate generator unit tests to reflect `posts_recent`

# Testing

- All 34 candidate generator unit tests pass
- Confirm via ES Profile API that candidate generator queries now hit 14 shards instead of 36–56
- Confirm `fetch_liked_posts_from_es` (network_likes) remains on `posts`
- Confirm seed-fetching paths (`post_similarity.py`, `inference.py`) remain on `posts`
- Confirm Skylight endpoints remain on `posts`