### PR TITLE
Heavy Ranker in API

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -72,7 +72,7 @@ FEEDS: dict[str, FeedConfig] = {
         ),
         rank_request_template=RankPredictRequest.model_construct(
             models=[
-                RankModelSpec(name="two_tower", weight=1.0),
+                RankModelSpec(name="heavy_ranker", weight=1.0),
                 RankModelSpec(name="perspective", weight=1.0),
             ],
         ),
@@ -92,7 +92,7 @@ FEEDS: dict[str, FeedConfig] = {
         ),
         rank_request_template=RankPredictRequest.model_construct(
             models=[
-                RankModelSpec(name="two_tower", weight=1.0),
+                RankModelSpec(name="heavy_ranker", weight=1.0),
                 RankModelSpec(name="perspective", weight=1.0),
             ],
         ),

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -29,3 +29,11 @@ class TestFeedsRegistry:
             assert cfg.gen_request_template.infill is None
             assert cfg.rank_request_template is None
             assert cfg.diversify is False
+
+    def test_personalized_feeds_use_heavy_ranker_and_perspective(self):
+        for feed_name in ("your-feed", "best-of-friends"):
+            cfg = FEEDS[feed_name]
+            assert cfg.rank_request_template is not None
+            assert [
+                spec.name for spec in cfg.rank_request_template.models
+            ] == ["heavy_ranker", "perspective"]

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -10,7 +10,7 @@ from ..candidates.post_similarity import (
     fetch_recent_liked_post_uris,
 )
 from ..candidates.utils import candidate_post_from_hit
-from ..elasticsearch import fetch_post_embeddings_and_authors
+from ..elasticsearch import fetch_post_embeddings_and_authors, fetch_recent_liked_post_uris_and_times
 from ..embeddings import MINILM_L12_EMBEDDING_FIELD, MINILM_L12_EMBEDDING_KEY
 
 # ---------------------------------------------------------------------------
@@ -92,6 +92,69 @@ class TestFetchRecentLikedPostUris:
         })
         uris = await fetch_recent_liked_post_uris(es, "did:plc:user1")
         assert uris == ["at://post/1", "at://post/3"]
+
+
+class TestFetchRecentLikedPostUrisAndTimes:
+    @pytest.mark.asyncio
+    async def test_returns_subject_uris_and_times(self):
+        es = FakeEs(responses={
+            "likes": {
+                "hits": {
+                    "hits": [
+                        {"_source": {"subject_uri": "at://post/1", "created_at": "2026-01-01T00:00:00+00:00"}},
+                        {"_source": {"subject_uri": "at://post/2", "created_at": "2026-01-02T00:00:00+00:00"}},
+                    ]
+                }
+            }
+        })
+        uris, times = await fetch_recent_liked_post_uris_and_times(es, "did:plc:user1", limit=10)
+
+        assert uris == ["at://post/1", "at://post/2"]
+        assert times == ["2026-01-01T00:00:00+00:00", "2026-01-02T00:00:00+00:00"]
+
+        call = es.calls[0]
+        assert call["index"] == "likes"
+        assert call["query"] == {
+            "bool": {
+                "filter": [
+                    {"terms": {"author_did": ["did:plc:user1"]}},
+                    {"exists": {"field": "created_at"}},
+                ],
+            }
+        }
+        assert call["sort"] == [{"created_at": "desc"}]
+        assert call["_source"] == ["subject_uri", "created_at"]
+
+    @pytest.mark.asyncio
+    async def test_skips_hits_missing_subject_uri_or_time_to_keep_lists_aligned(self):
+        es = FakeEs(responses={
+            "likes": {
+                "hits": {
+                    "hits": [
+                        {"_source": {"subject_uri": "at://post/1", "created_at": "2026-01-01T00:00:00+00:00"}},
+                        {"_source": {"created_at": "2026-01-02T00:00:00+00:00"}},
+                        {"_source": {"subject_uri": "at://post/3"}},
+                        {"_source": {"subject_uri": "at://post/4", "created_at": "2026-01-04T00:00:00+00:00"}},
+                    ]
+                }
+            }
+        })
+
+        uris, times = await fetch_recent_liked_post_uris_and_times(es, ["did:plc:user1", "did:plc:user2"])
+
+        assert uris == ["at://post/1", "at://post/4"]
+        assert times == ["2026-01-01T00:00:00+00:00", "2026-01-04T00:00:00+00:00"]
+        assert len(uris) == len(times)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_search_for_empty_users(self):
+        es = FakeEs()
+
+        uris, times = await fetch_recent_liked_post_uris_and_times(es, [])
+
+        assert uris == []
+        assert times == []
+        assert es.calls == []
 
 
 class TestFetchPostEmbeddings:

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -115,7 +115,9 @@ async def fetch_recent_liked_post_uris_and_times(
 
     Queries the ``likes`` index for documents where ``author_did`` matches
     *user_did*, sorted by ``created_at`` descending, and extracts the
-    ``subject_uri`` and ```` field from each hit.
+    ``subject_uri`` and ``created_at`` field from each hit.
+
+    Excludes posts without ``created_at`` time.
 
     When a request cache is active the result is memorized so repeat
     calls within the same request (e.g. post_similarity and the two-tower
@@ -133,7 +135,10 @@ async def fetch_recent_liked_post_uris_and_times(
         ):
             query = {
                 "bool": {
-                    "filter": [{"terms": {"author_did": user_dids}}],
+                    "filter": [
+                        {"terms": {"author_did": user_dids}},
+                        {"exists": {"field": "created_at"}},
+                    ],
                 }
             }
 
@@ -150,10 +155,9 @@ async def fetch_recent_liked_post_uris_and_times(
             times: list[AwareDatetime] = []
             for hit in data.get("hits", {}).get("hits", []):
                 uri = (hit.get("_source") or {}).get("subject_uri")
-                if uri:
-                    uris.append(uri)
                 time = (hit.get("_source") or {}).get("created_at")
-                if time:
+                if uri and time:
+                    uris.append(uri)
                     times.append(time)
             return uris, times
 

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -5,6 +5,7 @@ routers and candidate generators.
 """
 
 import logging
+from pydantic import AwareDatetime
 
 from elastic_transport import ObjectApiResponse
 from fastapi import HTTPException
@@ -104,6 +105,65 @@ async def fetch_recent_liked_post_uris(
     return await cache.get_or_compute(key, _fetch)
 
 
+async def fetch_recent_liked_post_uris_and_times(
+    es,
+    user_dids: str | list[str],
+    limit: int = DEFAULT_LIKED_POSTS_LIMIT,
+) -> tuple[list[str], list[AwareDatetime]]:
+    """Return the AT URIs of posts the user most recently liked,
+    along with the timestamp of that like.
+
+    Queries the ``likes`` index for documents where ``author_did`` matches
+    *user_did*, sorted by ``created_at`` descending, and extracts the
+    ``subject_uri`` and ```` field from each hit.
+
+    When a request cache is active the result is memoized so repeat
+    calls within the same request (e.g. post_similarity and the two-tower
+    ranker) share a single ES round-trip.
+    """
+    if isinstance(user_dids, str):
+        user_dids = [user_dids]
+
+    if not user_dids:
+        return [], []
+
+    async def _fetch() -> tuple[list[str], list[AwareDatetime]]:
+        async with timed(
+            logger, "es_recent_likes_and_times", n_users=len(user_dids), limit=limit
+        ):
+            query = {
+                "bool": {
+                    "filter": [{"terms": {"author_did": user_dids}}],
+                }
+            }
+
+            resp = await es.search(
+                index="likes",
+                query=query,
+                size=limit,
+                sort=[{"created_at": "desc"}],
+                _source=["subject_uri", "created_at"],
+            )
+
+            data = unwrap_es_response(resp)
+            uris: list[str] = []
+            times: list[AwareDatetime] = []
+            for hit in data.get("hits", {}).get("hits", []):
+                uri = (hit.get("_source") or {}).get("subject_uri")
+                if uri:
+                    uris.append(uri)
+                time = (hit.get("_source") or {}).get("created_at")
+                if time:
+                    times.append(time)
+            return uris, times
+
+    cache = get_request_cache()
+    if cache is None:
+        return await _fetch()
+    key = ("fetch_recent_liked_post_uris_and_times", tuple(sorted(user_dids)), limit)
+    return await cache.get_or_compute(key, _fetch)
+
+
 async def fetch_post_embeddings(
     es,
     at_uris: list[str],
@@ -165,6 +225,73 @@ async def fetch_post_embeddings(
 
 
 async def fetch_post_embeddings_and_authors(
+    es,
+    at_uris: list[str],
+    index: str = "posts",
+) -> list[tuple[str, list[float], str]]:
+    """Fetch MiniLM L12 embeddings for a list of post AT URIs, as well as their author DIDs.
+
+    Returns ``(at_uri, embedding, author_did)`` triples in the same order as ``at_uris``.
+    Posts without embeddings or embedding source text are silently skipped.
+    Posts without author DIDs are kept, with an empty string ("") author_did.
+
+    When a request cache is active the result is memoized so repeat
+    calls within the same request share a single ES round-trip.
+    """
+    if not at_uris:
+        return []
+
+    async def _fetch() -> list[tuple[str, list[float], str]]:
+        async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
+            query = {"terms": {"at_uri": at_uris}}
+
+            resp = await es.search(
+                index=index,
+                query=query,
+                size=len(at_uris),
+                _source=[
+                    "at_uri",
+                    MINILM_L12_EMBEDDING_FIELD,
+                    "author_did",
+                    *POST_EMBEDDING_SOURCE_FIELDS,
+                ],
+            )
+
+            data = unwrap_es_response(resp)
+            embeddings_by_uri: dict[str, list[float]] = {}
+            author_dids_by_uri: dict[str, str] = {}
+            for hit in data.get("hits", {}).get("hits", []):
+                src = hit.get("_source") or {}
+                at_uri = src.get("at_uri")
+                if not at_uri:
+                    continue
+                if not post_has_embedding_source(src):
+                    continue
+                emb = src.get("embeddings")
+                if isinstance(emb, dict):
+                    vec = emb.get(MINILM_L12_EMBEDDING_KEY)
+                    if vec:
+                        embeddings_by_uri[at_uri] = vec
+                author_did = src.get("author_did")
+                if isinstance(author_did, str):
+                    author_dids_by_uri[at_uri] = author_did
+
+            ordered_embeddings: list[tuple[str, list[float], str]] = []
+            for at_uri in at_uris:
+                vec = embeddings_by_uri.get(at_uri)
+                author_did = author_dids_by_uri.get(at_uri, "")
+                if vec:
+                    ordered_embeddings.append((at_uri, vec, author_did))
+            return ordered_embeddings
+
+    cache = get_request_cache()
+    if cache is None:
+        return await _fetch()
+    key = ("fetch_post_embeddings_and_authors", index, tuple(at_uris))
+    return await cache.get_or_compute(key, _fetch)
+
+
+async def fetch_post_embeddings_authors(
     es,
     at_uris: list[str],
     index: str = "posts",

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -117,7 +117,7 @@ async def fetch_recent_liked_post_uris_and_times(
     *user_did*, sorted by ``created_at`` descending, and extracts the
     ``subject_uri`` and ```` field from each hit.
 
-    When a request cache is active the result is memoized so repeat
+    When a request cache is active the result is memorized so repeat
     calls within the same request (e.g. post_similarity and the two-tower
     ranker) share a single ES round-trip.
     """
@@ -225,73 +225,6 @@ async def fetch_post_embeddings(
 
 
 async def fetch_post_embeddings_and_authors(
-    es,
-    at_uris: list[str],
-    index: str = "posts",
-) -> list[tuple[str, list[float], str]]:
-    """Fetch MiniLM L12 embeddings for a list of post AT URIs, as well as their author DIDs.
-
-    Returns ``(at_uri, embedding, author_did)`` triples in the same order as ``at_uris``.
-    Posts without embeddings or embedding source text are silently skipped.
-    Posts without author DIDs are kept, with an empty string ("") author_did.
-
-    When a request cache is active the result is memoized so repeat
-    calls within the same request share a single ES round-trip.
-    """
-    if not at_uris:
-        return []
-
-    async def _fetch() -> list[tuple[str, list[float], str]]:
-        async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
-            query = {"terms": {"at_uri": at_uris}}
-
-            resp = await es.search(
-                index=index,
-                query=query,
-                size=len(at_uris),
-                _source=[
-                    "at_uri",
-                    MINILM_L12_EMBEDDING_FIELD,
-                    "author_did",
-                    *POST_EMBEDDING_SOURCE_FIELDS,
-                ],
-            )
-
-            data = unwrap_es_response(resp)
-            embeddings_by_uri: dict[str, list[float]] = {}
-            author_dids_by_uri: dict[str, str] = {}
-            for hit in data.get("hits", {}).get("hits", []):
-                src = hit.get("_source") or {}
-                at_uri = src.get("at_uri")
-                if not at_uri:
-                    continue
-                if not post_has_embedding_source(src):
-                    continue
-                emb = src.get("embeddings")
-                if isinstance(emb, dict):
-                    vec = emb.get(MINILM_L12_EMBEDDING_KEY)
-                    if vec:
-                        embeddings_by_uri[at_uri] = vec
-                author_did = src.get("author_did")
-                if isinstance(author_did, str):
-                    author_dids_by_uri[at_uri] = author_did
-
-            ordered_embeddings: list[tuple[str, list[float], str]] = []
-            for at_uri in at_uris:
-                vec = embeddings_by_uri.get(at_uri)
-                author_did = author_dids_by_uri.get(at_uri, "")
-                if vec:
-                    ordered_embeddings.append((at_uri, vec, author_did))
-            return ordered_embeddings
-
-    cache = get_request_cache()
-    if cache is None:
-        return await _fetch()
-    key = ("fetch_post_embeddings_and_authors", index, tuple(at_uris))
-    return await cache.get_or_compute(key, _fetch)
-
-
-async def fetch_post_embeddings_authors(
     es,
     at_uris: list[str],
     index: str = "posts",

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -5,7 +5,6 @@ routers and candidate generators.
 """
 
 import logging
-from pydantic import AwareDatetime
 
 from elastic_transport import ObjectApiResponse
 from fastapi import HTTPException
@@ -109,7 +108,7 @@ async def fetch_recent_liked_post_uris_and_times(
     es,
     user_dids: str | list[str],
     limit: int = DEFAULT_LIKED_POSTS_LIMIT,
-) -> tuple[list[str], list[AwareDatetime]]:
+) -> tuple[list[str], list[str]]:
     """Return the AT URIs of posts the user most recently liked,
     along with the timestamp of that like.
 
@@ -129,7 +128,7 @@ async def fetch_recent_liked_post_uris_and_times(
     if not user_dids:
         return [], []
 
-    async def _fetch() -> tuple[list[str], list[AwareDatetime]]:
+    async def _fetch() -> tuple[list[str], list[str]]:
         async with timed(
             logger, "es_recent_likes_and_times", n_users=len(user_dids), limit=limit
         ):
@@ -152,7 +151,7 @@ async def fetch_recent_liked_post_uris_and_times(
 
             data = unwrap_es_response(resp)
             uris: list[str] = []
-            times: list[AwareDatetime] = []
+            times: list[str] = []
             for hit in data.get("hits", {}).get("hits", []):
                 uri = (hit.get("_source") or {}).get("subject_uri")
                 time = (hit.get("_source") or {}).get("created_at")

--- a/src/app/lib/inference.py
+++ b/src/app/lib/inference.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 import os
 import time
-from pydantic import AwareDatetime
 
 from .elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings_and_authors
 from .feed_debug import current_recorder
@@ -159,7 +158,7 @@ async def predict_user_tower_single(
 async def predict_heavy_ranker_single_user(
     history_embeddings: list[list[float]],
     history_author_dids: list[str],
-    history_liked_at_times: list[AwareDatetime],
+    history_liked_at_times: list[str],
     candidate_post_embeddings: list[list[float]],
     candidate_author_dids: list[str],
     *,

--- a/src/app/lib/inference.py
+++ b/src/app/lib/inference.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import time
+from pydantic import AwareDatetime
 
 from .elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings_and_authors
 from .feed_debug import current_recorder
@@ -80,7 +81,7 @@ def _decode_inference_json(source_name: str, resp) -> object:
 def _extract_inference_outputs(
     source_name: str,
     payload: object,
-) -> list[list[float]]:
+) -> list:
     if not isinstance(payload, dict):
         raise InferenceResponseFormatError(
             f"{source_name} inference response was not an object",
@@ -153,6 +154,45 @@ async def predict_user_tower_single(
         raise_inference_response_error("user-tower", resp.status_code, resp.text)
     payload = _decode_inference_json("user-tower", resp)
     return _extract_inference_outputs("user-tower", payload)
+
+
+async def predict_heavy_ranker_single_user(
+    history_embeddings: list[list[float]],
+    history_author_dids: list[str],
+    history_liked_at_times: list[AwareDatetime],
+    candidate_post_embeddings: list[list[float]],
+    candidate_author_dids: list[str],
+    *,
+    base_url: str,
+    api_key: str,
+) -> list[float]:
+    url = f"{base_url}/models/ranker/predict"
+    headers = build_inference_headers(api_key)
+    payload = {
+        "history_embeddings": history_embeddings,
+        "history_author_dids": history_author_dids,
+        "history_liked_at_times": history_liked_at_times,
+        "candidate_post_embeddings": candidate_post_embeddings,
+        "candidate_author_dids": candidate_author_dids,
+    }
+
+    client = get_http_client()
+    async with timed(
+        logger,
+        "ranker_predict_http",
+        n_history=len(history_embeddings),
+        n_candidates=len(candidate_post_embeddings)
+    ):
+        resp = await client.post(url, json=payload, headers=headers)
+    if resp.is_error:
+        logger.error(
+            "ranker predict failed status=%s body=%s",
+            resp.status_code,
+            resp.text,
+        )
+        raise_inference_response_error("ranker", resp.status_code, resp.text)
+    payload = _decode_inference_json("ranker", resp)
+    return _extract_inference_outputs("ranker", payload)
 
 
 async def compute_user_embedding(

--- a/src/app/lib/inference_test.py
+++ b/src/app/lib/inference_test.py
@@ -70,6 +70,85 @@ def test_extract_inference_outputs_raises_for_malformed_payload():
         inference_module._extract_inference_outputs("user-tower", {})
 
 
+def test_extract_inference_outputs_accepts_ranker_score_list():
+    assert inference_module._extract_inference_outputs(
+        "ranker",
+        {"outputs": [0.1, -0.2]},
+    ) == [0.1, -0.2]
+
+
+@pytest.mark.asyncio
+async def test_predict_heavy_ranker_single_user_posts_ranker_payload(monkeypatch):
+    class FakeResponse:
+        is_error = False
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {"outputs": [0.7, -0.1]}
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def post(self, url, json, headers):
+            self.calls.append({"url": url, "json": json, "headers": headers})
+            return FakeResponse()
+
+    client = FakeClient()
+    monkeypatch.setattr(inference_module, "get_http_client", lambda: client)
+
+    result = await inference_module.predict_heavy_ranker_single_user(
+        history_embeddings=[[1.0, 0.0]],
+        history_author_dids=["did:plc:history"],
+        history_liked_at_times=["2026-01-01T00:00:00+00:00"],
+        candidate_post_embeddings=[[0.0, 1.0], [1.0, 1.0]],
+        candidate_author_dids=["did:plc:candidate-a", "did:plc:candidate-b"],
+        base_url="https://inference.example",
+        api_key="secret",
+    )
+
+    assert result == [0.7, -0.1]
+    assert client.calls == [
+        {
+            "url": "https://inference.example/models/ranker/predict",
+            "headers": {"X-API-Key": "secret"},
+            "json": {
+                "history_embeddings": [[1.0, 0.0]],
+                "history_author_dids": ["did:plc:history"],
+                "history_liked_at_times": ["2026-01-01T00:00:00+00:00"],
+                "candidate_post_embeddings": [[0.0, 1.0], [1.0, 1.0]],
+                "candidate_author_dids": ["did:plc:candidate-a", "did:plc:candidate-b"],
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_predict_heavy_ranker_single_user_raises_for_http_error(monkeypatch):
+    class FakeResponse:
+        is_error = True
+        status_code = 503
+        text = "ranker unavailable"
+
+    class FakeClient:
+        async def post(self, url, json, headers):
+            return FakeResponse()
+
+    monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+    with pytest.raises(RuntimeError, match="ranker inference failed status=503"):
+        await inference_module.predict_heavy_ranker_single_user(
+            history_embeddings=[],
+            history_author_dids=[],
+            history_liked_at_times=[],
+            candidate_post_embeddings=[[0.0, 1.0]],
+            candidate_author_dids=["did:plc:candidate"],
+            base_url="https://inference.example",
+            api_key="secret",
+        )
+
+
 @pytest.mark.asyncio
 async def test_cached_post_tower_uuid_reuses_successful_lookup(monkeypatch):
     calls = 0

--- a/src/app/lib/rankers/__init__.py
+++ b/src/app/lib/rankers/__init__.py
@@ -21,6 +21,7 @@ from .predict import (
 from .candidate_score import CandidateScoreRanker
 from .perspective import PerspectiveRanker
 from .two_tower import TwoTowerRanker
+from .heavy_ranker import HeavyRanker
 
 _candidate_score = CandidateScoreRanker()
 register_ranker(_candidate_score)
@@ -31,10 +32,14 @@ register_ranker(_two_tower)
 _perspective = PerspectiveRanker()
 register_ranker(_perspective)
 
+_heavy_ranker = HeavyRanker()
+register_ranker(_heavy_ranker)
+
 __all__ = [
     "CandidateScoreRanker",
     "PerspectiveRanker",
     "TwoTowerRanker",
+    "HeavyRanker",
     "Ranker",
     "RankerError",
     "RankerExecutionError",

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -1,0 +1,178 @@
+"""Heavy ranker model.
+"""
+
+import asyncio
+import logging
+from pydantic import AwareDatetime
+
+from ...models import RankedCandidate, CandidatePost, RankPredictResult
+from .base import Ranker, RankerResult
+from ..elasticsearch import (
+    fetch_post_embeddings_and_authors,
+    fetch_recent_liked_post_uris_and_times,
+)
+from ..embeddings import decode_float32_b64
+from ..telemetry import timed
+from ..inference import (
+    get_inference_settings,
+    predict_heavy_ranker_single_user,
+)
+from ..feed_debug import current_recorder
+from .utils import get_rank_predict_results_from_candidates_and_scores
+
+logger = logging.getLogger(__name__)
+HEAVY_RANKER_MODEL_NAME = "heavy_ranker"
+
+
+class HeavyRanker(Ranker):
+    """Rank candidate posts relative to a user using an ML model."""
+
+    @property
+    def name(self) -> str:
+        return HEAVY_RANKER_MODEL_NAME
+
+    @property
+    def score_bounds(self) -> tuple[float, float]:
+        return (-1.0, 1.0)
+
+    async def predict(
+        self,
+        es,
+        user_did: str,
+        candidates: list[CandidatePost]
+    ) -> RankerResult:
+        inference_base_url, inference_api_key = (
+            get_inference_settings()
+        )
+
+        valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
+        candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
+
+
+        async def _get_user_features() -> tuple[list[list[float]], list[str], list[AwareDatetime]]:
+            async with timed(logger, "ranker_get_user_features", user_did=user_did):
+                user_history_vectors: list[list[float]] = []
+                history_author_dids: list[str] = []
+                user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
+
+                rec = current_recorder()
+
+                if not user_history_liked_uris:
+                    logger.info("No likes found for user %s", user_did)
+                    if rec is not None:
+                        rec.record_user_features(HEAVY_RANKER_MODEL_NAME, [], 0)
+                else:
+                    user_history_embedding_pairs: list[tuple[str, list[float], str]] = await fetch_post_embeddings_and_authors(
+                        es, user_history_liked_uris,
+                    )
+                    if rec is not None:
+                        rec.record_user_features(
+                            HEAVY_RANKER_MODEL_NAME, user_history_liked_uris, len(user_history_embedding_pairs)
+                        )
+                    if not user_history_embedding_pairs:
+                        logger.info(
+                            "No embeddings found for %d liked posts of user %s",
+                            len(user_history_liked_uris),
+                            user_did,
+                        )
+                    else:
+                        user_history_vectors = [embedding for _, embedding, _ in user_history_embedding_pairs]
+                        history_author_dids = [author_did for _, _, author_did in user_history_embedding_pairs]
+
+                return user_history_vectors, history_author_dids, history_liked_at_times
+        # end _get_user_features()
+
+
+        async def _get_candidate_features() -> (
+            tuple[list[CandidatePost], list[list[float]], list[str]] | None
+        ):
+            async with timed(
+                logger, "ranker_get_candidate_features", n_candidates=len(candidates_by_uri)
+            ):
+                # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+                uris_embs_authors: list[tuple[str, list[float], str]] = []
+                missing_uris: list[str] = []
+                for uri, candidate in candidates_by_uri.items():
+                    if candidate.minilm_l12_embedding and candidate.author_did:
+                        try:
+                            vec = decode_float32_b64(candidate.minilm_l12_embedding)
+                            uris_embs_authors.append((uri, vec, candidate.author_did))
+                            continue
+                        except Exception:
+                            pass
+                    missing_uris.append(uri)
+
+                if missing_uris:
+                    fetched = await fetch_post_embeddings_and_authors(es, missing_uris, index="posts_recent")
+                    uris_embs_authors.extend(fetched)
+
+                if not uris_embs_authors:
+                    return None
+
+                ranked_candidates_input = [
+                    candidates_by_uri[at_uri]
+                    for at_uri, _, _ in uris_embs_authors
+                    if at_uri in candidates_by_uri
+                ]
+                input_post_embeddings = [
+                    embedding for _, embedding, _ in uris_embs_authors
+                ]
+                author_dids = [
+                    author_did for _, _, author_did in uris_embs_authors
+                ]
+                return ranked_candidates_input, input_post_embeddings, author_dids
+        # end _get_candidate_features()
+
+
+        user_features, candidate_features = await asyncio.gather(
+            _get_user_features(),
+            _get_candidate_features(),
+        )
+
+        history_embeddings, history_author_dids, history_liked_at_times = user_features
+
+        def _return_empty_ranker_result(msg: str):
+            logger.info(msg)
+            rankings = [
+                RankedCandidate(
+                    at_uri=candidate.at_uri,
+                    rank=rank_idx,
+                    rank_score=None,
+                )
+                for rank_idx, candidate in enumerate(valid_candidates, start=1)
+                if candidate.at_uri is not None
+            ]
+            return RankerResult(model=self.name, result=RankPredictResult(rankings=rankings))
+
+        if candidate_features is None:
+            return _return_empty_ranker_result(
+                "No valid features found for any of %d candidate posts of user %s"
+            )
+        candidate_posts, candidate_post_embeddings, candidate_author_dids = candidate_features
+
+        ranker_outputs = await predict_heavy_ranker_single_user(
+            history_embeddings,
+            history_author_dids,
+            history_liked_at_times,
+            candidate_post_embeddings,
+            candidate_author_dids,
+            base_url=inference_base_url,
+            api_key=inference_api_key
+        )
+
+        if not ranker_outputs:
+            return _return_empty_ranker_result(
+                f"No ranker outputs for any of {len(candidates_by_uri)} candidate posts of user {user_did}"
+            )
+        if len(ranker_outputs) != len(candidate_posts):
+            return _return_empty_ranker_result(
+                f"Heavy ranker returned {len(ranker_outputs)} results but {len(candidate_posts)} were requested."
+            )
+
+        result = get_rank_predict_results_from_candidates_and_scores(
+            candidate_posts,
+            ranker_outputs,
+            valid_candidates
+        )
+        
+        return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-from pydantic import AwareDatetime
 
 from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerResult
@@ -45,11 +44,11 @@ class HeavyRanker(Ranker):
             get_inference_settings()
         )
 
-        async def _get_user_features() -> tuple[list[list[float]], list[str], list[AwareDatetime]]:
+        async def _get_user_features() -> tuple[list[list[float]], list[str], list[str]]:
             async with timed(logger, "ranker_get_user_features", user_did=user_did):
                 user_history_vectors: list[list[float]] = []
                 history_author_dids: list[str] = []
-                filtered_history_liked_at_times: list[AwareDatetime] = []
+                filtered_history_liked_at_times: list[str] = []
                 user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
 
                 rec = current_recorder()

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -45,14 +45,11 @@ class HeavyRanker(Ranker):
             get_inference_settings()
         )
 
-        valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
-        candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
-
-
         async def _get_user_features() -> tuple[list[list[float]], list[str], list[AwareDatetime]]:
             async with timed(logger, "ranker_get_user_features", user_did=user_did):
                 user_history_vectors: list[list[float]] = []
                 history_author_dids: list[str] = []
+                filtered_history_liked_at_times: list[AwareDatetime] = []
                 user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
 
                 rec = current_recorder()
@@ -78,8 +75,14 @@ class HeavyRanker(Ranker):
                     else:
                         user_history_vectors = [embedding for _, embedding, _ in user_history_embedding_pairs]
                         history_author_dids = [author_did for _, _, author_did in user_history_embedding_pairs]
+                        filtered_history_uris = [uri for uri, _, _ in user_history_embedding_pairs]
+                        filtered_history_liked_at_times = [
+                            liked_at_time 
+                            for uri, liked_at_time in zip(user_history_liked_uris, history_liked_at_times)
+                            if uri in filtered_history_uris
+                        ]
 
-                return user_history_vectors, history_author_dids, history_liked_at_times
+                return user_history_vectors, history_author_dids, filtered_history_liked_at_times
         # end _get_user_features()
 
 
@@ -109,7 +112,7 @@ class HeavyRanker(Ranker):
                 if not uris_embs_authors:
                     return None
 
-                ranked_candidates_input = [
+                candidates_with_embeddings = [
                     candidates_by_uri[at_uri]
                     for at_uri, _, _ in uris_embs_authors
                     if at_uri in candidates_by_uri
@@ -120,9 +123,11 @@ class HeavyRanker(Ranker):
                 author_dids = [
                     author_did for _, _, author_did in uris_embs_authors
                 ]
-                return ranked_candidates_input, input_post_embeddings, author_dids
+                return candidates_with_embeddings, input_post_embeddings, author_dids
         # end _get_candidate_features()
 
+
+        candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
 
         user_features, candidate_features = await asyncio.gather(
             _get_user_features(),
@@ -139,14 +144,14 @@ class HeavyRanker(Ranker):
                     rank=rank_idx,
                     rank_score=None,
                 )
-                for rank_idx, candidate in enumerate(valid_candidates, start=1)
+                for rank_idx, candidate in enumerate(candidates_by_uri.values(), start=1)
                 if candidate.at_uri is not None
             ]
             return RankerResult(model=self.name, result=RankPredictResult(rankings=rankings))
 
         if candidate_features is None:
             return _return_empty_ranker_result(
-                "No valid features found for any of %d candidate posts of user %s"
+                f"No valid features found for any of {len(candidates_by_uri)} candidate posts of user {user_did}"
             )
         candidate_posts, candidate_post_embeddings, candidate_author_dids = candidate_features
 
@@ -172,7 +177,7 @@ class HeavyRanker(Ranker):
         result = get_rank_predict_results_from_candidates_and_scores(
             candidate_posts,
             ranker_outputs,
-            valid_candidates
+            candidates_by_uri.values()
         )
         
         return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -77,7 +77,7 @@ class HeavyRanker(Ranker):
                         history_author_dids = [author_did for _, _, author_did in user_history_embedding_pairs]
                         filtered_history_uris = [uri for uri, _, _ in user_history_embedding_pairs]
                         filtered_history_liked_at_times = [
-                            liked_at_time 
+                            liked_at_time
                             for uri, liked_at_time in zip(user_history_liked_uris, history_liked_at_times)
                             if uri in filtered_history_uris
                         ]
@@ -179,5 +179,5 @@ class HeavyRanker(Ranker):
             ranker_outputs,
             candidates_by_uri.values()
         )
-        
+
         return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/heavy_ranker_test.py
+++ b/src/app/lib/rankers/heavy_ranker_test.py
@@ -1,0 +1,372 @@
+"""Tests for the heavy ranker."""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from ...models import CandidatePost
+from ..embeddings import encode_float32_b64
+from . import heavy_ranker as heavy_ranker_module
+from .heavy_ranker import HeavyRanker
+
+
+def _time(hour: int) -> datetime:
+    return datetime(2026, 1, 1, hour, tzinfo=timezone.utc)
+
+
+def test_predict_requires_inference_env_vars(monkeypatch):
+    monkeypatch.delenv("GE_INFERENCE_BASE_URL", raising=False)
+    monkeypatch.delenv("GE_INFERENCE_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="GE_INFERENCE_BASE_URL"):
+        asyncio.run(
+            HeavyRanker().predict(
+                es=None,
+                user_did="did:plc:user1",
+                candidates=[CandidatePost(at_uri="at://post/1")],
+            )
+        )
+
+
+def test_predict_filters_history_times_to_embeddable_likes_and_ranks_candidates(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    liked_times = [_time(1), _time(2), _time(3)]
+    seen = {}
+
+    async def fake_fetch_recent_liked_post_uris_and_times(es, user_did):
+        assert user_did == "did:plc:user1"
+        return ["at://liked/a", "at://liked/b", "at://liked/c"], liked_times
+
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index="posts"):
+        seen.setdefault("fetch_calls", []).append((list(at_uris), index))
+        if at_uris == ["at://liked/a", "at://liked/b", "at://liked/c"]:
+            return [
+                ("at://liked/a", [1.0, 0.0], "did:plc:liked-a"),
+                ("at://liked/c", [0.0, 1.0], "did:plc:liked-c"),
+            ]
+        if at_uris == ["at://post/a", "at://post/b", "at://post/missing"]:
+            return [
+                ("at://post/b", [0.0, 1.0], "did:plc:b"),
+                ("at://post/a", [1.0, 0.0], "did:plc:a"),
+            ]
+        raise AssertionError(f"unexpected at_uris: {at_uris}")
+
+    async def fake_predict_heavy_ranker_single_user(
+        history_embeddings,
+        history_author_dids,
+        history_liked_at_times,
+        candidate_post_embeddings,
+        candidate_author_dids,
+        *,
+        base_url,
+        api_key,
+    ):
+        seen["ranker_call"] = {
+            "history_embeddings": history_embeddings,
+            "history_author_dids": history_author_dids,
+            "history_liked_at_times": history_liked_at_times,
+            "candidate_post_embeddings": candidate_post_embeddings,
+            "candidate_author_dids": candidate_author_dids,
+            "base_url": base_url,
+            "api_key": api_key,
+        }
+        return [0.2, 0.9]
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fake_fetch_recent_liked_post_uris_and_times,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_authors",
+        fake_fetch_post_embeddings_and_authors,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+
+    result = asyncio.run(
+        HeavyRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(at_uri="at://post/a"),
+                CandidatePost(at_uri="at://post/b"),
+                CandidatePost(at_uri="at://post/missing"),
+            ],
+        )
+    )
+
+    assert seen["fetch_calls"] == [
+        (["at://liked/a", "at://liked/b", "at://liked/c"], "posts"),
+        (["at://post/a", "at://post/b", "at://post/missing"], "posts_recent"),
+    ]
+    assert seen["ranker_call"] == {
+        "history_embeddings": [[1.0, 0.0], [0.0, 1.0]],
+        "history_author_dids": ["did:plc:liked-a", "did:plc:liked-c"],
+        "history_liked_at_times": [_time(1), _time(3)],
+        "candidate_post_embeddings": [[0.0, 1.0], [1.0, 0.0]],
+        "candidate_author_dids": ["did:plc:b", "did:plc:a"],
+        "base_url": "https://example.com",
+        "api_key": "secret",
+    }
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": 0.9},
+        {"at_uri": "at://post/b", "rank": 2, "rank_score": 0.2},
+        {"at_uri": "at://post/missing", "rank": 3, "rank_score": None},
+    ]
+
+
+def test_predict_uses_embedded_candidate_features_and_fetches_missing_candidates(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    seen = {}
+
+    async def fake_fetch_recent_liked_post_uris_and_times(es, user_did):
+        return [], []
+
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index="posts"):
+        seen["fetched_candidate_uris"] = list(at_uris)
+        seen["fetched_candidate_index"] = index
+        return [("at://post/fetched", [0.0, 1.0], "did:plc:fetched")]
+
+    async def fake_predict_heavy_ranker_single_user(
+        history_embeddings,
+        history_author_dids,
+        history_liked_at_times,
+        candidate_post_embeddings,
+        candidate_author_dids,
+        *,
+        base_url,
+        api_key,
+    ):
+        seen["ranker_call"] = {
+            "history_embeddings": history_embeddings,
+            "history_author_dids": history_author_dids,
+            "history_liked_at_times": history_liked_at_times,
+            "candidate_post_embeddings": candidate_post_embeddings,
+            "candidate_author_dids": candidate_author_dids,
+        }
+        return [0.4, 0.7]
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fake_fetch_recent_liked_post_uris_and_times,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_authors",
+        fake_fetch_post_embeddings_and_authors,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+
+    result = asyncio.run(
+        HeavyRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(
+                    at_uri="at://post/embedded",
+                    minilm_l12_embedding=encode_float32_b64([1.0, 0.0]),
+                    author_did="did:plc:embedded",
+                ),
+                CandidatePost(at_uri="at://post/fetched"),
+            ],
+        )
+    )
+
+    assert seen["fetched_candidate_uris"] == ["at://post/fetched"]
+    assert seen["fetched_candidate_index"] == "posts_recent"
+    assert seen["ranker_call"] == {
+        "history_embeddings": [],
+        "history_author_dids": [],
+        "history_liked_at_times": [],
+        "candidate_post_embeddings": [[1.0, 0.0], [0.0, 1.0]],
+        "candidate_author_dids": ["did:plc:embedded", "did:plc:fetched"],
+    }
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/fetched", "rank": 1, "rank_score": 0.7},
+        {"at_uri": "at://post/embedded", "rank": 2, "rank_score": 0.4},
+    ]
+
+
+def test_predict_calls_ranker_with_empty_history_when_likes_have_no_embeddings(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    seen = {}
+
+    async def fake_fetch_recent_liked_post_uris_and_times(es, user_did):
+        return ["at://liked/a"], [_time(1)]
+
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index="posts"):
+        if at_uris == ["at://liked/a"]:
+            return []
+        return [("at://post/a", [1.0, 0.0], "did:plc:a")]
+
+    async def fake_predict_heavy_ranker_single_user(
+        history_embeddings,
+        history_author_dids,
+        history_liked_at_times,
+        candidate_post_embeddings,
+        candidate_author_dids,
+        *,
+        base_url,
+        api_key,
+    ):
+        seen["history_embeddings"] = history_embeddings
+        seen["history_author_dids"] = history_author_dids
+        seen["history_liked_at_times"] = history_liked_at_times
+        return [0.5]
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fake_fetch_recent_liked_post_uris_and_times,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_authors",
+        fake_fetch_post_embeddings_and_authors,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+
+    result = asyncio.run(
+        HeavyRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[CandidatePost(at_uri="at://post/a")],
+        )
+    )
+
+    assert seen == {
+        "history_embeddings": [],
+        "history_author_dids": [],
+        "history_liked_at_times": [],
+    }
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": 0.5},
+    ]
+
+
+def test_predict_returns_unscored_candidates_when_candidate_features_are_missing(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+
+    async def fake_fetch_recent_liked_post_uris_and_times(es, user_did):
+        return [], []
+
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index="posts"):
+        return []
+
+    async def fake_predict_heavy_ranker_single_user(*args, **kwargs):
+        raise AssertionError("ranker should not be called without candidate features")
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fake_fetch_recent_liked_post_uris_and_times,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_authors",
+        fake_fetch_post_embeddings_and_authors,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+
+    result = asyncio.run(
+        HeavyRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(at_uri="at://post/a"),
+                CandidatePost(at_uri="at://post/b"),
+            ],
+        )
+    )
+
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": None},
+        {"at_uri": "at://post/b", "rank": 2, "rank_score": None},
+    ]
+
+
+def test_predict_returns_unscored_candidates_when_output_count_mismatches(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+
+    async def fake_fetch_recent_liked_post_uris_and_times(es, user_did):
+        return [], []
+
+    async def fake_fetch_post_embeddings_and_authors(es, at_uris, index="posts"):
+        return [
+            ("at://post/a", [1.0, 0.0], "did:plc:a"),
+            ("at://post/b", [0.0, 1.0], "did:plc:b"),
+        ]
+
+    async def fake_predict_heavy_ranker_single_user(*args, **kwargs):
+        return [0.5]
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fake_fetch_recent_liked_post_uris_and_times,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_authors",
+        fake_fetch_post_embeddings_and_authors,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+
+    result = asyncio.run(
+        HeavyRanker().predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(at_uri="at://post/a"),
+                CandidatePost(at_uri="at://post/b"),
+            ],
+        )
+    )
+
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/a", "rank": 1, "rank_score": None},
+        {"at_uri": "at://post/b", "rank": 2, "rank_score": None},
+    ]

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -20,6 +20,7 @@ from ..inference import (
     raise_inference_response_error,
     compute_user_embedding,
 )
+from .utils import get_rank_predict_results_from_candidates_and_scores
 
 
 logger = logging.getLogger(__name__)
@@ -196,41 +197,9 @@ class TwoTowerRanker(Ranker):
                 )
             final_scores.append(sum([ u*p for u,p in zip(post_embedding, output_user_embedding)]))
 
-        # Rank by the final scores, breaking ties by original order in candidates list
-        candidates_with_scores = zip(ranked_candidates_input, final_scores)
-        ranked_candidates = sorted(
-            enumerate(candidates_with_scores), # (index, (candidate, score))
-            key=lambda item: (
-                -(item[1][1] if item[1][1] is not None else float("-inf")),
-                item[0],
-            ),
-        )
-
-        # Get in correct output format
-        rankings: list[RankedCandidate] = []
-        for rank_idx, (_, (candidate, score)) in enumerate(ranked_candidates, start=1):
-            assert candidate.at_uri is not None
-            rankings.append(
-                RankedCandidate(
-                    at_uri=candidate.at_uri,
-                    rank=rank_idx,
-                    rank_score=score,
-                )
-            )
-
-        ranked_uris = {ranking.at_uri for ranking in rankings}
-        for candidate in valid_candidates:
-            if candidate.at_uri is None or candidate.at_uri in ranked_uris:
-                continue
-            rankings.append(
-                RankedCandidate(
-                    at_uri=candidate.at_uri,
-                    rank=len(rankings) + 1,
-                    rank_score=None,
-                )
-            )
-
-        result = RankPredictResult(
-            rankings=rankings,
+        result = get_rank_predict_results_from_candidates_and_scores(
+            ranked_candidates_input,
+            final_scores,
+            valid_candidates
         )
         return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/utils.py
+++ b/src/app/lib/rankers/utils.py
@@ -1,0 +1,44 @@
+"""Utils for rankers"""
+
+from ...models import RankedCandidate, RankPredictResult
+
+
+def get_rank_predict_results_from_candidates_and_scores(
+    candidate_posts,
+    scores,
+    valid_candidates
+) -> RankPredictResult:
+    # Rank by the final scores, breaking ties by original order in candidates list
+    candidates_with_scores = zip(candidate_posts, scores)
+    ranked_candidates = sorted(
+        enumerate(candidates_with_scores), # (index, (candidate, score))
+        key=lambda item: (
+            -(item[1][1] if item[1][1] is not None else float("-inf")),
+            item[0],
+        ),
+    )
+
+    # Get in correct output format
+    rankings: list[RankedCandidate] = []
+    for rank_idx, (_, (candidate, score)) in enumerate(ranked_candidates, start=1):
+        assert candidate.at_uri is not None
+        rankings.append(
+            RankedCandidate(
+                at_uri=candidate.at_uri,
+                rank=rank_idx,
+                rank_score=score,
+            )
+        )
+
+    ranked_uris = {ranking.at_uri for ranking in rankings}
+    for candidate in valid_candidates:
+        if candidate.at_uri is None or candidate.at_uri in ranked_uris:
+            continue
+        rankings.append(
+            RankedCandidate(
+                at_uri=candidate.at_uri,
+                rank=len(rankings) + 1,
+                rank_score=None,
+            )
+        )
+    return RankPredictResult(rankings=rankings)

--- a/src/app/routers/rank_test.py
+++ b/src/app/routers/rank_test.py
@@ -51,6 +51,7 @@ def test_list_models(app):
             "candidate_score",
             "two_tower",
             "perspective",
+            "heavy_ranker",
         ]
     }
 


### PR DESCRIPTION
Closes #160 

## This PR
This is the next step for getting the heavy ranker working after [#18](https://github.com/greenearth-social/inference-service/pull/18) which added the heavy ranker into inference service.

- Heavy ranker gets the user and post features concurrently. Then it hits the inference service rank endpoint with the single user's full like history and ALL of the candidate posts. Note that we could consider batching this - we'd just have to split the candidate posts into batches and duplicate the user history for each batch. But I figured we could observe the performance before making this optimization. Note we'd also have to move the score normalization logic from inference service to the API because we normalize across all the candidates for a user request.

- Registers the ranker and switches Your Feed and Best of Friends to use the heavy ranker instead of two tower ranker.
- Adds an elasticsearch function that queries liked post uri's AND the associated timestamp.
- Extracts shared final ranking logic from two tower and reuses it for two tower and heavy ranker.

## Testing
- Ran API locally and successfully ran rank endpoint with new ranker
- Deployed to stage, feeds work and show ranker scores
- Added test coverage, pytest runs successfully