### PR TITLE
Tag all request-path metrics with their originating endpoint

### DIFF
--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -97,8 +97,20 @@ class MetricCollector:
 
         Instruments are lazily created based on the name suffix (see module
         docstring).  Attributes become GCP metric labels.
+
+        When recorded on a request path, the metric is automatically tagged
+        with an ``endpoint`` label naming the originating API endpoint (e.g.
+        ``get_feed_skeleton`` vs ``candidates_generate``). This is read from a
+        ContextVar set by the endpoint middleware, so every callsite gets it
+        for free. An explicitly passed ``endpoint`` attribute wins.
         """
-        attrs = dict(attributes) if attributes else None
+        from .request_context import get_endpoint
+
+        labels: dict[str, str] = dict(attributes)
+        endpoint = get_endpoint()
+        if endpoint is not None:
+            labels.setdefault("endpoint", endpoint)
+        attrs = labels or None
         if name.endswith("_count"):
             self._get_counter(name).add(int(value), attrs)
         elif name.endswith("_rate"):

--- a/src/app/lib/metrics_test.py
+++ b/src/app/lib/metrics_test.py
@@ -108,6 +108,50 @@ def test_attributes_attached_to_histogram():
                     assert attrs.get("feed_name") == "nature"
 
 
+def _attrs_for(reader, name: str) -> dict:
+    data = _get_metrics_data(reader)
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    return dict(metric.data.data_points[0].attributes or {})
+    raise AssertionError(f"{name} not found in exported metrics")
+
+
+def test_endpoint_label_added_from_context():
+    from .request_context import reset_endpoint, set_endpoint
+
+    collector, reader = _make_collector()
+    token = set_endpoint("get_feed_skeleton")
+    try:
+        collector.record("feed.render.duration_ms", 50.0, feed_name="nature")
+    finally:
+        reset_endpoint(token)
+
+    attrs = _attrs_for(reader, "feed.render.duration_ms")
+    assert attrs.get("endpoint") == "get_feed_skeleton"
+    assert attrs.get("feed_name") == "nature"
+
+
+def test_no_endpoint_label_outside_request_context():
+    collector, reader = _make_collector()
+    collector.record("feed.render.duration_ms", 50.0)
+    assert "endpoint" not in _attrs_for(reader, "feed.render.duration_ms")
+
+
+def test_explicit_endpoint_attribute_wins():
+    from .request_context import reset_endpoint, set_endpoint
+
+    collector, reader = _make_collector()
+    token = set_endpoint("get_feed_skeleton")
+    try:
+        collector.record("something.latency", 1.0, endpoint="explicit")
+    finally:
+        reset_endpoint(token)
+
+    assert _attrs_for(reader, "something.latency").get("endpoint") == "explicit"
+
+
 # ---------------------------------------------------------------------------
 # Lazy instrument reuse
 # ---------------------------------------------------------------------------

--- a/src/app/lib/request_context.py
+++ b/src/app/lib/request_context.py
@@ -21,6 +21,14 @@ from contextvars import ContextVar, Token
 
 _request_id: ContextVar[str | None] = ContextVar("ge_request_id", default=None)
 
+# The name of the API endpoint handling the current request (the matched
+# route's name, e.g. ``get_feed_skeleton`` or ``candidates_generate``). Set by
+# the endpoint middleware in :mod:`app.main` so that metrics recorded anywhere
+# on the request path can be tagged with their originating endpoint without
+# threading it through every callsite. Propagates through ``asyncio`` the same
+# way as ``rid``, so background tasks spawned from a request inherit it.
+_endpoint: ContextVar[str | None] = ContextVar("ge_endpoint", default=None)
+
 
 def get_request_id() -> str | None:
     return _request_id.get()
@@ -32,3 +40,15 @@ def set_request_id(rid: str) -> Token:
 
 def reset_request_id(token: Token) -> None:
     _request_id.reset(token)
+
+
+def get_endpoint() -> str | None:
+    return _endpoint.get()
+
+
+def set_endpoint(endpoint: str) -> Token:
+    return _endpoint.set(endpoint)
+
+
+def reset_endpoint(token: Token) -> None:
+    _endpoint.reset(token)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -38,9 +38,15 @@ from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
 from .lib.metrics import MetricCollector, set_metric_collector
 from .lib.profiling import install_profiling
-from .lib.request_context import reset_request_id, set_request_id
+from .lib.request_context import (
+    reset_endpoint,
+    reset_request_id,
+    set_endpoint,
+    set_request_id,
+)
 
 from elasticsearch import AsyncElasticsearch
+from starlette.routing import Match
 
 
 @asynccontextmanager
@@ -213,21 +219,45 @@ app = FastAPI(
 install_profiling(app)
 
 
+def _resolve_endpoint(request: Request) -> str | None:
+    """Return the name of the route that will handle *request*.
+
+    Matching is done up front (before ``call_next``) so the endpoint is
+    available as a ContextVar throughout request handling, including in
+    background tasks spawned from the handler. Returns ``None`` for requests
+    that don't fully match a named route (e.g. 404s), so we never tag metrics
+    with an arbitrary, high-cardinality label.
+    """
+    for route in request.app.routes:
+        match, _ = route.matches(request.scope)
+        if match is Match.FULL:
+            return getattr(route, "name", None)
+    return None
+
+
 @app.middleware("http")
 async def request_id_mw(request: Request, call_next):
-    """Stamp a server-generated request ID on every request.
+    """Stamp a server-generated request ID and the endpoint on every request.
 
     The ID is set as a ContextVar so log lines emitted on the request
     path (via ``timed()`` or otherwise) can include it. We deliberately
     ignore any inbound ``x-request-id`` header to avoid log forging or
     correlation poisoning from untrusted callers.
+
+    The matched endpoint name is likewise stored in a ContextVar so metrics
+    recorded anywhere on the request path are tagged with the endpoint that
+    generated them (see ``MetricCollector.record``).
     """
     rid = uuid.uuid4().hex[:12]
-    token = set_request_id(rid)
+    rid_token = set_request_id(rid)
+    endpoint = _resolve_endpoint(request)
+    endpoint_token = set_endpoint(endpoint) if endpoint is not None else None
     try:
         response = await call_next(request)
     finally:
-        reset_request_id(token)
+        reset_request_id(rid_token)
+        if endpoint_token is not None:
+            reset_endpoint(endpoint_token)
     response.headers["x-request-id"] = rid
     return response
 

--- a/src/app/main_test.py
+++ b/src/app/main_test.py
@@ -1,0 +1,32 @@
+"""Tests for app-level middleware in main.py."""
+
+from fastapi import Request
+
+from .main import _resolve_endpoint, app
+
+
+def _request_for(path: str, method: str = "GET") -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+        "app": app,
+    }
+    return Request(scope)
+
+
+def test_resolve_endpoint_returns_route_name():
+    assert (
+        _resolve_endpoint(_request_for("/xrpc/app.bsky.feed.getFeedSkeleton"))
+        == "get_feed_skeleton"
+    )
+    assert (
+        _resolve_endpoint(_request_for("/candidates/generate", method="POST"))
+        == "candidates_generate"
+    )
+    assert _resolve_endpoint(_request_for("/health")) == "healthcheck"
+
+
+def test_resolve_endpoint_none_for_unknown_path():
+    assert _resolve_endpoint(_request_for("/no/such/route")) is None


### PR DESCRIPTION
Closes #192 

Metrics recorded during request handling had no way to distinguish which API endpoint produced them — a `feed.render.duration_ms` from `getFeedSkeleton` looked identical to one from `candidates/generate`, making per-endpoint breakdowns in GCP impossible without threading an endpoint name through every `record()` callsite.

This adds an `endpoint` label automatically. The HTTP middleware resolves the matched route name up front and stores it in an `_endpoint` ContextVar (alongside the existing request-id ContextVar), and `MetricCollector.record` reads it so every metric on the request path is tagged for free, including metrics from background tasks spawned by the handler.

### Notes
- Route matching happens before `call_next` so the value is available throughout request handling. Requests that don't fully match a named route (e.g. 404s) get no label, avoiding a high-cardinality `endpoint` value.
- An explicitly passed `endpoint` attribute always wins over the ContextVar.

