### PR TITLE
Increase candidate generator timeout to 15s for MVP

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -241,6 +241,7 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-env-vars=GE_FIRESTORE_PROJECT=$PROJECT_ID"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_FIRESTORE_DATABASE=$firestore_database"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_PROBE_USER_DID=did:plc:s4tl2ajfsnstzuxtegl7r33g"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_CANDIDATE_GENERATOR_TIMEOUT_SEC=15"
 
     if [ -n "$GE_INFERENCE_BASE_URL" ]; then
         deploy_cmd="$deploy_cmd --set-env-vars=GE_INFERENCE_BASE_URL=$GE_INFERENCE_BASE_URL"

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -9,6 +9,7 @@ REST API and the XRPC feed-skeleton endpoint.
 import asyncio
 import logging
 import math
+import os
 
 from ...models import (
     CandidateGenerateRequest,
@@ -21,6 +22,13 @@ from ..feed_debug import current_recorder
 from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
+
+try:
+    _GENERATOR_TIMEOUT_SEC: float = float(
+        os.environ.get("GE_CANDIDATE_GENERATOR_TIMEOUT_SEC", "15")
+    )
+except ValueError:
+    _GENERATOR_TIMEOUT_SEC = 15.0
 
 
 # ---------------------------------------------------------------------------
@@ -123,13 +131,25 @@ async def run_generate(
     ) -> CandidateResult | None:
         try:
             async with timed(logger, "candidates.generate.duration_ms", record_metric=True, metric_attrs={"generator_name": spec.name}, count=count):
-                return await gen.generate(
-                    es=es,
-                    user_did=request.user_did,
-                    num_candidates=count,
-                    video_only=request.video_only,
-                    exclude_uris=request.exclude_uris or None,
+                return await asyncio.wait_for(
+                    gen.generate(
+                        es=es,
+                        user_did=request.user_did,
+                        num_candidates=count,
+                        video_only=request.video_only,
+                        exclude_uris=request.exclude_uris or None,
+                    ),
+                    timeout=_GENERATOR_TIMEOUT_SEC,
                 )
+        except asyncio.TimeoutError as exc:
+            logger.warning(
+                "Candidate generator '%s' timed out after %.1fs",
+                spec.name,
+                _GENERATOR_TIMEOUT_SEC,
+            )
+            if swallow_errors:
+                return None
+            raise GeneratorError(spec.name, exc) from exc
         except Exception as exc:
             logger.exception("Candidate generator '%s' failed", spec.name)
             if swallow_errors:
@@ -161,13 +181,26 @@ async def run_generate(
 
         try:
             # Ask for extra to compensate for likely dedup losses
-            infill_result = await infill_gen.generate(
-                es=es,
-                user_did=request.user_did,
-                num_candidates=shortfall * 2,
-                video_only=request.video_only,
-                exclude_uris=request.exclude_uris or None,
+            infill_result = await asyncio.wait_for(
+                infill_gen.generate(
+                    es=es,
+                    user_did=request.user_did,
+                    num_candidates=shortfall * 2,
+                    video_only=request.video_only,
+                    exclude_uris=request.exclude_uris or None,
+                ),
+                timeout=_GENERATOR_TIMEOUT_SEC,
             )
+        except asyncio.TimeoutError as exc:
+            logger.warning(
+                "Infill generator '%s' timed out after %.1fs",
+                request.infill,
+                _GENERATOR_TIMEOUT_SEC,
+            )
+            if swallow_errors:
+                infill_result = CandidateResult(generator_name=request.infill, candidates=[])
+            else:
+                raise GeneratorError(request.infill, exc, is_infill=True) from exc
         except Exception as exc:
             logger.exception("Infill generator '%s' failed", request.infill)
             if swallow_errors:


### PR DESCRIPTION
Closes #208

Candidate generator calls were failing frequently at the 5s default timeout. Temporarily increasing to 15s to improve feed quality and gather better feedback during the MVP phase; we'll tighten this back down once we move to serving degraded feeds.

# This PR

- Add `GE_CANDIDATE_GENERATOR_TIMEOUT_SEC` env var support to `run_generate` (default 15s) with `asyncio.wait_for` wrapping for both primary and infill generators
- Set `GE_CANDIDATE_GENERATOR_TIMEOUT_SEC=15` explicitly in `scripts/deploy.sh`

# Testing

- Verify `GE_CANDIDATE_GENERATOR_TIMEOUT_SEC` env var is picked up at import time
- Deploy to stage and confirm candidate generation succeeds where it was previously timing out