### PR TITLE
Log ES query body on ConnectionTimeout

### DIFF
--- a/src/app/lib/es_client.py
+++ b/src/app/lib/es_client.py
@@ -17,6 +17,8 @@ import logging
 import os
 import time
 
+from elastic_transport import ConnectionTimeout
+
 from .request_context import get_request_id
 
 logger = logging.getLogger(__name__)
@@ -44,13 +46,36 @@ class SlowQueryLoggingES:
 
     async def search(self, *args, **kwargs):
         start = time.monotonic()
+        timed_out = False
         try:
             return await self._wrapped.search(*args, **kwargs)
-        finally:
+        except ConnectionTimeout:
+            timed_out = True
             elapsed_ms = (time.monotonic() - start) * 1000
-            threshold = _slow_threshold_ms()
-            if elapsed_ms >= threshold:
-                _log_slow_search(elapsed_ms, args, kwargs)
+            _log_timeout_search(elapsed_ms, args, kwargs)
+            raise
+        finally:
+            if not timed_out:
+                elapsed_ms = (time.monotonic() - start) * 1000
+                if elapsed_ms >= _slow_threshold_ms():
+                    _log_slow_search(elapsed_ms, args, kwargs)
+
+
+def _log_timeout_search(elapsed_ms: float, args: tuple, kwargs: dict) -> None:
+    """Emit a WARNING when the ES query raised ConnectionTimeout."""
+    rid = get_request_id() or "-"
+    body = {k: v for k, v in kwargs.items() if k not in ("index", "request_timeout")}
+    try:
+        body_str = json.dumps(body, default=str)
+    except Exception:
+        body_str = repr(body)
+    logger.warning(
+        "es_query_timeout rid=%s elapsed_ms=%.1f index=%s body=%s",
+        rid,
+        elapsed_ms,
+        kwargs.get("index"),
+        body_str,
+    )
 
 
 def _log_slow_search(elapsed_ms: float, args: tuple, kwargs: dict) -> None:

--- a/src/app/lib/es_client_test.py
+++ b/src/app/lib/es_client_test.py
@@ -5,6 +5,7 @@ import json
 import logging
 
 import pytest
+from elastic_transport import ConnectionTimeout
 
 from . import es_client as es_client_module
 from .es_client import SlowQueryLoggingES
@@ -117,6 +118,71 @@ def test_other_attributes_delegate_to_wrapped():
     es = SlowQueryLoggingES(fake)
     asyncio.run(es.close())
     assert fake.closed is True
+
+
+def test_connection_timeout_logs_timeout_message(caplog, monkeypatch):
+    monkeypatch.setenv("GE_SLOW_ES_THRESHOLD_MS", "1000000")
+
+    class TimeoutEs:
+        async def search(self, **kwargs):
+            raise ConnectionTimeout("timed out")
+
+    es = SlowQueryLoggingES(TimeoutEs())
+
+    with caplog.at_level(logging.WARNING, logger=es_client_module.logger.name):
+        with pytest.raises(ConnectionTimeout):
+            asyncio.run(es.search(index="posts", query={"match_all": {}}))
+
+    matching = [r for r in caplog.records if "es_query_timeout" in r.message]
+    assert len(matching) == 1
+    assert "index=posts" in matching[0].message
+
+
+def test_connection_timeout_does_not_log_slow_query(caplog, monkeypatch):
+    monkeypatch.setenv("GE_SLOW_ES_THRESHOLD_MS", "0")
+
+    class TimeoutEs:
+        async def search(self, **kwargs):
+            raise ConnectionTimeout("timed out")
+
+    es = SlowQueryLoggingES(TimeoutEs())
+
+    with caplog.at_level(logging.WARNING, logger=es_client_module.logger.name):
+        with pytest.raises(ConnectionTimeout):
+            asyncio.run(es.search(index="posts", query={"match_all": {}}))
+
+    assert not any("slow_es_query" in r.message for r in caplog.records)
+
+
+def test_connection_timeout_is_reraised():
+    class TimeoutEs:
+        async def search(self, **kwargs):
+            raise ConnectionTimeout("timed out")
+
+    es = SlowQueryLoggingES(TimeoutEs())
+
+    with pytest.raises(ConnectionTimeout):
+        asyncio.run(es.search(index="posts", query={"match_all": {}}))
+
+
+def test_connection_timeout_log_includes_request_id(caplog, monkeypatch):
+    class TimeoutEs:
+        async def search(self, **kwargs):
+            raise ConnectionTimeout("timed out")
+
+    es = SlowQueryLoggingES(TimeoutEs())
+
+    token = set_request_id("tid99")
+    try:
+        with caplog.at_level(logging.WARNING, logger=es_client_module.logger.name):
+            with pytest.raises(ConnectionTimeout):
+                asyncio.run(es.search(index="posts", query={"match_all": {}}))
+    finally:
+        reset_request_id(token)
+
+    matching = [r for r in caplog.records if "es_query_timeout" in r.message]
+    assert matching
+    assert "rid=tid99" in matching[0].message
 
 
 def test_threshold_is_re_read_per_call(caplog, monkeypatch):


### PR DESCRIPTION
Closes #207

The ES wrapper had no specific handling for query timeouts — when `ConnectionTimeout` was raised, the slow-query `finally` block would fire but gave no indication the query actually timed out and could double-log if elapsed also exceeded the slow threshold.

# This PR

- Catches `elastic_transport.ConnectionTimeout` explicitly in `SlowQueryLoggingES.search()` and logs the full query body (index, request body, request ID, elapsed ms) with an `es_query_timeout` prefix so timed-out queries can be replayed verbatim
- Skips the slow-query log when a timeout occurred to avoid double-logging
- Re-raises `ConnectionTimeout` so callers are unaffected
- Adds 4 new tests covering: timeout log content, no double slow-query log, exception re-raise, and request ID inclusion in timeout log

# Testing

- `pytest src/app/lib/es_client_test.py -v` — 12 passed
- `pytest src/ -q` — 505 passed