### PR TITLE
Fail fast on pipeline errors behind GE_FAIL_FAST flag

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -250,6 +250,7 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-env-vars=GE_PROBE_USER_DID=did:plc:s4tl2ajfsnstzuxtegl7r33g"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_CANDIDATE_GENERATOR_TIMEOUT_SEC=15"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_POSTHOG_HOST=$GE_POSTHOG_HOST"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_FAIL_FAST=true"
 
     if [ -n "$GE_INFERENCE_BASE_URL" ]; then
         deploy_cmd="$deploy_cmd --set-env-vars=GE_INFERENCE_BASE_URL=$GE_INFERENCE_BASE_URL"

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -8,6 +8,7 @@ from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 from ..bsky import get_followed_user_dids, FollowedUsersLookupError
+from ..config import fail_fast
 from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,8 @@ async def followed_users_search(
             user_did,
             exc,
         )
+        if fail_fast():
+            raise
         return []
 
     if not followed_dids:

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -18,6 +18,7 @@ from ...models import (
     GeneratorSpec,
 )
 from .base import CandidateGenerator, CandidateResult, get_generator
+from ..config import fail_fast
 from ..feed_debug import current_recorder
 from ..metrics import get_metric_collector
 from ..telemetry import timed
@@ -98,8 +99,6 @@ class GeneratorError(Exception):
 async def run_generate(
     request: CandidateGenerateRequest,
     es,
-    *,
-    swallow_errors: bool = False,
 ) -> CandidateGenerateResult:
     """Execute a candidate-generation pipeline described by *request*.
 
@@ -109,12 +108,13 @@ async def run_generate(
         The generation configuration.
     es:
         An ``AsyncElasticsearch`` client.
-    swallow_errors:
-        If ``True``, generator failures are logged but do not raise.
-        Missing generators still raise ``GeneratorNotFoundError``.
-        This is useful for feed-skeleton endpoints that should return
-        partial results rather than 5xx.
+
+    Generator failures are swallowed (empty candidates) or re-raised according
+    to ``fail_fast()`` / ``GE_FAIL_FAST``. All call sites use that env var
+    rather than a per-call override, consistent with ``score_candidates`` and
+    ``_hydrate_embeddings``.
     """
+    _swallow = not fail_fast()
     counts = allocate_counts(request.generators, request.num_candidates)
 
     # Resolve generators up front so missing-name errors raise deterministically
@@ -165,7 +165,7 @@ async def run_generate(
                     outcome="timeout",
                     is_infill="false",
                 )
-            if swallow_errors:
+            if _swallow:
                 return CandidateResult(generator_name=spec.name, candidates=[])
             raise GeneratorError(spec.name, exc) from exc
         except Exception as exc:
@@ -178,7 +178,7 @@ async def run_generate(
                     outcome="error",
                     is_infill="false",
                 )
-            if swallow_errors:
+            if _swallow:
                 return CandidateResult(generator_name=spec.name, candidates=[])
             raise GeneratorError(spec.name, exc) from exc
 
@@ -244,7 +244,7 @@ async def run_generate(
                     outcome="timeout",
                     is_infill="true",
                 )
-            if swallow_errors:
+            if _swallow:
                 infill_result = CandidateResult(generator_name=request.infill, candidates=[])
             else:
                 raise GeneratorError(request.infill, exc, is_infill=True) from exc
@@ -258,7 +258,7 @@ async def run_generate(
                     outcome="error",
                     is_infill="true",
                 )
-            if swallow_errors:
+            if _swallow:
                 infill_result = CandidateResult(generator_name=request.infill, candidates=[])
             else:
                 raise GeneratorError(request.infill, exc, is_infill=True) from exc

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -154,7 +154,7 @@ class TestGeneratorTimeout:
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
-        result = await run_generate(_make_request("post_similarity"), es=None, swallow_errors=True)
+        result = await run_generate(_make_request("post_similarity"), es=None)
 
         assert result.candidates == []
         failure_calls = [c for c in mc.calls if c[0] == "candidates.generate.failure_count"]
@@ -173,7 +173,7 @@ class TestGeneratorTimeout:
         _stub_generators(monkeypatch, {"post_similarity": _HangingGenerator("post_similarity")})
 
         with caplog.at_level(logging.WARNING):
-            await run_generate(_make_request("post_similarity"), es=None, swallow_errors=True)
+            await run_generate(_make_request("post_similarity"), es=None)
 
         timeout_warnings = [
             r for r in caplog.records
@@ -188,12 +188,13 @@ class TestGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_timeout_no_swallow_raises_generator_error_promptly(self, monkeypatch):
+        monkeypatch.setenv("GE_FAIL_FAST", "true")
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
         _stub_generators(monkeypatch, {"post_similarity": _HangingGenerator("post_similarity")})
 
         with pytest.raises(GeneratorError) as exc_info:
             await asyncio.wait_for(
-                run_generate(_make_request("post_similarity"), es=None, swallow_errors=False),
+                run_generate(_make_request("post_similarity"), es=None),
                 timeout=1.0,
             )
 
@@ -201,13 +202,14 @@ class TestGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_timeout_no_swallow_records_metric_before_raising(self, monkeypatch):
+        monkeypatch.setenv("GE_FAIL_FAST", "true")
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
         _stub_generators(monkeypatch, {"post_similarity": _HangingGenerator("post_similarity")})
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
         with pytest.raises(GeneratorError):
-            await run_generate(_make_request("post_similarity"), es=None, swallow_errors=False)
+            await run_generate(_make_request("post_similarity"), es=None)
 
         failure_calls = [c for c in mc.calls if c[0] == "candidates.generate.failure_count"]
         assert len(failure_calls) == 1
@@ -222,7 +224,7 @@ class TestGeneratorTimeout:
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
-        result = await run_generate(_make_request("network_likes"), es=None, swallow_errors=True)
+        result = await run_generate(_make_request("network_likes"), es=None)
 
         assert result.candidates == []
         failure_calls = [c for c in mc.calls if c[0] == "candidates.generate.failure_count"]
@@ -244,7 +246,6 @@ class TestGeneratorTimeout:
             result = await run_generate(
                 _make_request("popular", num_candidates=1, infill="popular"),
                 es=None,
-                swallow_errors=True,
             )
 
         assert [c.at_uri for c in result.candidates] == ["at://infill/1"]
@@ -262,7 +263,7 @@ class TestGeneratorTimeout:
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
-        await run_generate(_make_request("popular"), es=None, swallow_errors=True)
+        await run_generate(_make_request("popular"), es=None)
 
         success_calls = [c for c in mc.calls if c[0] == "candidates.generate.success_count"]
         assert len(success_calls) == 1
@@ -289,7 +290,6 @@ class TestInfillGeneratorTimeout:
         result = await run_generate(
             _make_request("random", num_candidates=5, infill="popular"),
             es=None,
-            swallow_errors=True,
         )
 
         assert result.candidates == []
@@ -304,6 +304,7 @@ class TestInfillGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_infill_timeout_no_swallow_raises_generator_error_with_is_infill(self, monkeypatch):
+        monkeypatch.setenv("GE_FAIL_FAST", "true")
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
         _stub_generators(monkeypatch, {
             "random": _EmptyGenerator("random"),
@@ -314,7 +315,6 @@ class TestInfillGeneratorTimeout:
             await run_generate(
                 _make_request("random", num_candidates=5, infill="popular"),
                 es=None,
-                swallow_errors=False,
             )
 
         assert exc_info.value.name == "popular"
@@ -322,6 +322,7 @@ class TestInfillGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_infill_timeout_no_swallow_records_metric(self, monkeypatch):
+        monkeypatch.setenv("GE_FAIL_FAST", "true")
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
         _stub_generators(monkeypatch, {
             "random": _EmptyGenerator("random"),
@@ -334,7 +335,6 @@ class TestInfillGeneratorTimeout:
             await run_generate(
                 _make_request("random", num_candidates=5, infill="popular"),
                 es=None,
-                swallow_errors=False,
             )
 
         failure_calls = [c for c in mc.calls if c[0] == "candidates.generate.failure_count"]
@@ -355,7 +355,6 @@ class TestInfillGeneratorTimeout:
         result = await run_generate(
             _make_request("random", num_candidates=5, infill="popular"),
             es=None,
-            swallow_errors=True,
         )
 
         assert result.candidates == []
@@ -380,7 +379,6 @@ class TestInfillGeneratorTimeout:
         await run_generate(
             _make_request("random", num_candidates=5, infill="popular"),
             es=None,
-            swallow_errors=True,
         )
 
         success_calls = [c for c in mc.calls if c[0] == "candidates.generate.success_count"]
@@ -419,7 +417,6 @@ class TestInfillGeneratorTimeout:
                 exclude_uris=["at://seen/1"],
             ),
             es=None,
-            swallow_errors=True,
         )
 
         assert infill.calls[0]["exclude_uris"] == [

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ...models import CandidatePost
 from ..bsky import FollowedUsersLookupError, get_followed_user_dids
+from ..config import fail_fast
 from ..elasticsearch import unwrap_es_response
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
@@ -164,6 +165,8 @@ async def network_likes_search(
             user_did,
             exc,
         )
+        if fail_fast():
+            raise
         return []
 
     if not followed_dids:

--- a/src/app/lib/config.py
+++ b/src/app/lib/config.py
@@ -1,0 +1,12 @@
+"""Runtime configuration flags derived from environment variables."""
+
+import os
+
+
+def fail_fast() -> bool:
+    """When True, pipeline component failures raise instead of being swallowed.
+
+    Controlled by the GE_FAIL_FAST env var (default: false).
+    Set to "true" in Cloud Run deployments to disable degraded-feed serving.
+    """
+    return os.environ.get("GE_FAIL_FAST", "false").lower() in ("true", "1", "yes")

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -276,18 +276,6 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
                 c.at_uri,
             )
             return None
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 429:
-                logger.warning("Perspective API rate limited for post %s; using missing score", c.at_uri)
-                return None
-            logger.exception("Perspective API scoring failed for post %s", c.at_uri)
-            if fail_fast():
-                raise
-            return None
-        except (httpx.ConnectError, httpx.TimeoutException):
-            logger.exception("Perspective API connection/timeout error for post %s", c.at_uri)
-            if fail_fast():
-                raise
         except aiohttp.ClientResponseError as exc:
             if exc.status == 429:
                 logger.warning(

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -10,6 +10,7 @@ import time
 import httpx
 
 from ..models import CandidatePost
+from .config import fail_fast
 from .http_client import get_http_client
 from .telemetry import timed
 
@@ -205,8 +206,15 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 429:
                 logger.warning("Perspective API rate limited for post %s; using missing score", c.at_uri)
-            else:
-                logger.exception("Perspective API scoring failed for post %s", c.at_uri)
+                return None
+            logger.exception("Perspective API scoring failed for post %s", c.at_uri)
+            if fail_fast():
+                raise
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException):
+            logger.exception("Perspective API connection/timeout error for post %s", c.at_uri)
+            if fail_fast():
+                raise
             return None
         except Exception:
             logger.exception("Perspective API scoring failed for post %s", c.at_uri)

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -59,6 +59,14 @@ router = APIRouter(tags=["xrpc"])
 # Configuration
 # ---------------------------------------------------------------------------
 
+def _fail_fast() -> bool:
+    """When True, any pipeline component failure raises instead of being swallowed.
+
+    Controlled by the GE_FAIL_FAST env var (default: false).
+    Set to "true" to disable degraded-feed serving and fail on any component error.
+    """
+    return os.environ.get("GE_FAIL_FAST", "false").lower() in ("true", "1", "yes")
+
 
 def _get_service_did() -> str:
     """Return the DID of this feed generator service.
@@ -222,10 +230,9 @@ async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[Candi
         async with timed(logger, "hydrate_embeddings", n_missing=len(missing)):
             pairs = await fetch_post_embeddings(es, missing, index="posts_recent")
     except Exception:
-        # If the refetch fails, MMR falls back to author-only similarity
-        # and the two-tower ranker has its own refetch path. Don't fail
-        # the request over a hydration hiccup.
-        logger.exception("Embedding hydration failed; continuing without")
+        logger.exception("Embedding hydration failed")
+        if _fail_fast():
+            raise
         return candidates
 
     encoded: dict[str, str] = {}
@@ -274,7 +281,7 @@ async def _run_ranking_pipeline(
             num_candidates=gen_request.num_candidates,
             n_generators=len(gen_request.generators),
         ):
-            result = await run_generate(gen_request, es, swallow_errors=True)
+            result = await run_generate(gen_request, es, swallow_errors=not _fail_fast())
         candidates = result.candidates
 
         if not candidates:

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -273,7 +273,7 @@ async def _run_ranking_pipeline(
             num_candidates=gen_request.num_candidates,
             n_generators=len(gen_request.generators),
         ):
-            result = await run_generate(gen_request, es, swallow_errors=not fail_fast())
+            result = await run_generate(gen_request, es)
         candidates = result.candidates
 
         if not candidates:

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -46,6 +46,7 @@ from ..lib.firestore import (
     write_feed_debug,
 )
 from ..lib.posthog_client import get_posthog_client, track_interaction, track_session
+from ..lib.config import fail_fast
 from ..lib.request_cache import request_cache_scope
 from ..lib.telemetry import timed
 from ..feeds import FEEDS
@@ -58,15 +59,6 @@ router = APIRouter(tags=["xrpc"])
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-
-def _fail_fast() -> bool:
-    """When True, any pipeline component failure raises instead of being swallowed.
-
-    Controlled by the GE_FAIL_FAST env var (default: false).
-    Set to "true" to disable degraded-feed serving and fail on any component error.
-    """
-    return os.environ.get("GE_FAIL_FAST", "false").lower() in ("true", "1", "yes")
-
 
 def _get_service_did() -> str:
     """Return the DID of this feed generator service.
@@ -231,7 +223,7 @@ async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[Candi
             pairs = await fetch_post_embeddings(es, missing, index="posts_recent")
     except Exception:
         logger.exception("Embedding hydration failed")
-        if _fail_fast():
+        if fail_fast():
             raise
         return candidates
 
@@ -281,7 +273,7 @@ async def _run_ranking_pipeline(
             num_candidates=gen_request.num_candidates,
             n_generators=len(gen_request.generators),
         ):
-            result = await run_generate(gen_request, es, swallow_errors=not _fail_fast())
+            result = await run_generate(gen_request, es, swallow_errors=not fail_fast())
         candidates = result.candidates
 
         if not candidates:

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -145,6 +145,20 @@ def fake_app_es():
     app.state.firestore = AsyncMock()
     app.state.feed_cache = InMemoryFeedCache()
     yield
+
+
+@pytest.fixture(autouse=True)
+def passthrough_hydrate_embeddings():
+    """Return no embedding pairs so candidates pass through unchanged.
+
+    Patching at fetch_post_embeddings level (not _hydrate_embeddings) lets
+    tests that want to verify hydration behaviour override just this patch.
+    """
+    with patch(
+        "app.routers.xrpc.fetch_post_embeddings",
+        new=AsyncMock(return_value=[]),
+    ):
+        yield
     try:
         delattr(app.state, "es")
     except Exception:
@@ -535,8 +549,35 @@ class TestGetFeedSkeleton:
 
     # --- primary generator failure ---
 
-    def test_primary_failure_falls_back_to_infill(self):
-        """If primary raises, we still get infill results."""
+    def test_primary_failure_returns_500_when_fail_fast(self, monkeypatch):
+        """With GE_FAIL_FAST=true (default), a generator error surfaces as 500."""
+        monkeypatch.setenv("GE_FAIL_FAST", "true")
+
+        primary_gen = AsyncMock()
+        primary_gen.generate.side_effect = RuntimeError("ES down")
+
+        followed_users_gen = AsyncMock()
+        followed_users_gen.generate.return_value = CandidateResult(
+            generator_name="followed_users", candidates=[]
+        )
+
+        def fake_get(name):
+            return {
+                "two_tower": primary_gen,
+                "followed_users": followed_users_gen,
+            }.get(name)
+
+        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get):
+            resp = TestClient(app, raise_server_exceptions=False).get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI, "limit": 5},
+            )
+
+        assert resp.status_code == 500
+
+    def test_primary_failure_falls_back_to_infill_when_not_fail_fast(self, monkeypatch):
+        """With GE_FAIL_FAST=false, a failing primary generator yields infill results."""
+        monkeypatch.setenv("GE_FAIL_FAST", "false")
         infill = _make_candidates("infill", 3, "popularity")
 
         primary_gen = AsyncMock()


### PR DESCRIPTION
> **TL;DR**: Fail fast on feed pipeline errors, configurable via GE_FAIL_FAST env var (enabled in Cloud Run deployments).

## Fail-fast scope

**Covered (returns 500 when GE_FAIL_FAST=true)**
- Candidate generators — `generate()` failures (ES timeout, network error, etc.)
- Embedding hydration — `fetch_post_embeddings` ES call failure
- Ranker (`run_predict`) — always raises regardless of flag
- Perspective API — connection/timeout errors and non-429 HTTP errors

**Not covered (always soft-fail)**
- Perspective API 429 (rate limit) and language-not-supported — expected conditions, score treated as missing
- `_seen_exclusions` — Firestore read failure → proceeds with empty list (previously seen posts may reappear)
- `get_user` — debug flag read failure → proceeds with debug disabled
- Background tasks (`_record_session`, `_write_feed_debug`, `_record_interactions`) — fire-and-forget, no effect on response
- Feed cache — cache miss is a normal path; append/store failure returns results without a cursor
- Firestore / ID resolver initialisation checks — always 500 regardless of flag

## Toggling fail-fast

**To disable** (revert to degraded-feed serving): set `GE_FAIL_FAST=false` in `deploy.sh` and redeploy. No code change required.

| `GE_FAIL_FAST` | Behaviour |
|---|---|
| `true` | Any component failure → HTTP 500, no feed served |
| `false` (default) | Failures swallowed; feed served with whatever candidates survived |

The flag defaults to `false` so environments without the variable retain the previous behaviour.

## Implementation note

`fail_fast()` lives in `lib/config.py` so any module can import it directly without threading it as a parameter through the call stack.

Closes #204