### PR TITLE
Popularity Candidate Generator in Your Feed

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -29,8 +29,9 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="e2 S",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="two_tower", weight=0.5),
-                GeneratorSpec(name="followed_users", weight=0.5),
+                GeneratorSpec(name="two_tower", weight=0.35),
+                GeneratorSpec(name="followed_users", weight=0.35),
+                GeneratorSpec(name="popularity", weight=0.3),
             ],
             infill="popularity",
             num_candidates=30,
@@ -64,8 +65,9 @@ FEEDS: dict[str, FeedConfig] = {
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprirzcv3a24",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="two_tower", weight=0.5),
-                GeneratorSpec(name="followed_users", weight=0.5),
+                GeneratorSpec(name="two_tower", weight=0.35),
+                GeneratorSpec(name="followed_users", weight=0.35),
+                GeneratorSpec(name="popularity", weight=0.3),
             ],
             infill="popularity",
             num_candidates=30,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -24,7 +24,7 @@ from .models import (
 FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
         display_name="Unranked YF",
-        description="Development feed — post-similarity and followed-users candidate with popularity infill. No ranking.",
+        description="Development feed — same as your-feed but without ranking.",
         internal_rkey="e2-s",
         internal_display_name="e2 S",
         gen_request_template=CandidateGenerateRequest.model_construct(

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -205,6 +205,14 @@ async def run_generate(
         if infill_gen is None:
             raise GeneratorNotFoundError(request.infill, is_infill=True)
 
+        infill_exclude_uris: list[str] = []
+        for uri in request.exclude_uris or []:
+            if uri not in infill_exclude_uris:
+                infill_exclude_uris.append(uri)
+        for c in deduped:
+            if c.at_uri and c.at_uri not in infill_exclude_uris:
+                infill_exclude_uris.append(c.at_uri)
+
         try:
             # Ask for extra to compensate for likely dedup losses
             infill_result = await asyncio.wait_for(
@@ -213,7 +221,7 @@ async def run_generate(
                     user_did=request.user_did,
                     num_candidates=shortfall * 2,
                     video_only=request.video_only,
-                    exclude_uris=request.exclude_uris or None,
+                    exclude_uris=infill_exclude_uris or None,
                 ),
                 timeout=_GENERATOR_TIMEOUT_SEC,
             )

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -130,7 +130,7 @@ async def run_generate(
 
     async def _run_one(
         spec: GeneratorSpec, count: int, gen: CandidateGenerator
-    ) -> CandidateResult | None:
+    ) -> CandidateResult:
         try:
             async with timed(logger, "candidates.generate.duration_ms", record_metric=True, metric_attrs={"generator_name": spec.name}, count=count):
                 result = await asyncio.wait_for(
@@ -166,7 +166,7 @@ async def run_generate(
                     is_infill="false",
                 )
             if swallow_errors:
-                return None
+                return CandidateResult(generator_name=spec.name, candidates=[])
             raise GeneratorError(spec.name, exc) from exc
         except Exception as exc:
             logger.exception("Candidate generator '%s' failed", spec.name)
@@ -179,7 +179,7 @@ async def run_generate(
                     is_infill="false",
                 )
             if swallow_errors:
-                return None
+                return CandidateResult(generator_name=spec.name, candidates=[])
             raise GeneratorError(spec.name, exc) from exc
 
     results = await asyncio.gather(
@@ -190,8 +190,6 @@ async def run_generate(
 
     all_candidates: list[CandidatePost] = []
     for result in results:
-        if result is None:
-            continue
         if rec is not None:
             rec.record_generator_output(result)
         all_candidates.extend(result.candidates)

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from ...models import CandidateGenerateRequest, GeneratorSpec
+from ...models import CandidateGenerateRequest, CandidatePost, GeneratorSpec
 from ..candidates import generate as generate_module
 from ..candidates.base import CandidateGenerator, CandidateResult
 from ..candidates.generate import GeneratorError, run_generate
@@ -56,6 +56,29 @@ class _EmptyGenerator(CandidateGenerator):
         return CandidateResult(generator_name=self.name, candidates=[])
 
 
+class _StaticGenerator(CandidateGenerator):
+    def __init__(self, name: str, candidates: list[CandidatePost]):
+        self._name = name
+        self._candidates = candidates
+        self.calls: list[dict] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+        self.calls.append(
+            {
+                "num_candidates": num_candidates,
+                "video_only": video_only,
+                "exclude_uris": exclude_uris,
+            }
+        )
+        excluded = set(exclude_uris or [])
+        candidates = [c for c in self._candidates if c.at_uri not in excluded]
+        return CandidateResult(generator_name=self.name, candidates=candidates[:num_candidates])
+
+
 class FakeMetricCollector:
     def __init__(self):
         self.calls: list[tuple[str, float, dict]] = []
@@ -74,6 +97,7 @@ def _make_request(
     *,
     num_candidates: int = 5,
     infill: str | None = None,
+    exclude_uris: list[str] | None = None,
 ) -> CandidateGenerateRequest:
     return CandidateGenerateRequest(
         generators=[GeneratorSpec(name=generator_name, weight=1.0)],
@@ -81,7 +105,12 @@ def _make_request(
         num_candidates=num_candidates,
         video_only=False,
         infill=infill,
+        exclude_uris=exclude_uris or [],
     )
+
+
+def _candidate(uri: str, generator_name: str = "test") -> CandidatePost:
+    return CandidatePost(at_uri=uri, generator_name=generator_name)
 
 
 def _stub_generators(monkeypatch, mapping: dict) -> None:
@@ -319,3 +348,48 @@ class TestInfillGeneratorTimeout:
         infill_success = [c for c in success_calls if c[2].get("is_infill") == "true"]
         assert len(infill_success) == 1
         assert infill_success[0][2] == {"generator_name": "popular", "is_infill": "true"}
+
+    @pytest.mark.asyncio
+    async def test_infill_excludes_request_and_primary_candidate_uris(self, monkeypatch):
+        primary = _StaticGenerator(
+            "popular",
+            [
+                _candidate("at://seen/1", "popular"),
+                _candidate("at://primary/1", "popular"),
+                _candidate("at://primary/2", "popular"),
+            ],
+        )
+        infill = _StaticGenerator(
+            "popular_infill",
+            [
+                _candidate("at://seen/1", "popular_infill"),
+                _candidate("at://primary/1", "popular_infill"),
+                _candidate("at://primary/2", "popular_infill"),
+                _candidate("at://infill/1", "popular_infill"),
+                _candidate("at://infill/2", "popular_infill"),
+            ],
+        )
+        _stub_generators(monkeypatch, {"popular": primary, "popular_infill": infill})
+
+        result = await run_generate(
+            _make_request(
+                "popular",
+                num_candidates=4,
+                infill="popular_infill",
+                exclude_uris=["at://seen/1"],
+            ),
+            es=None,
+            swallow_errors=True,
+        )
+
+        assert infill.calls[0]["exclude_uris"] == [
+            "at://seen/1",
+            "at://primary/1",
+            "at://primary/2",
+        ]
+        assert [c.at_uri for c in result.candidates] == [
+            "at://primary/1",
+            "at://primary/2",
+            "at://infill/1",
+            "at://infill/2",
+        ]

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -10,6 +10,7 @@ from ...models import CandidateGenerateRequest, CandidatePost, GeneratorSpec
 from ..candidates import generate as generate_module
 from ..candidates.base import CandidateGenerator, CandidateResult
 from ..candidates.generate import GeneratorError, run_generate
+from ..feed_debug import FeedDebugRecorder, feed_debug_scope
 from ..metrics import MetricCollector, set_metric_collector
 
 
@@ -77,6 +78,23 @@ class _StaticGenerator(CandidateGenerator):
         excluded = set(exclude_uris or [])
         candidates = [c for c in self._candidates if c.at_uri not in excluded]
         return CandidateResult(generator_name=self.name, candidates=candidates[:num_candidates])
+
+
+class _FailThenReturnGenerator(CandidateGenerator):
+    def __init__(self, name: str, candidates: list[CandidatePost]):
+        self._name = name
+        self._candidates = candidates
+        self.calls = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("primary failed")
+        return CandidateResult(generator_name=self.name, candidates=self._candidates[:num_candidates])
 
 
 class FakeMetricCollector:
@@ -215,6 +233,28 @@ class TestGeneratorTimeout:
             "outcome": "error",
             "is_infill": "false",
         }
+
+    @pytest.mark.asyncio
+    async def test_swallowed_primary_failure_records_empty_debug_output(self, monkeypatch):
+        gen = _FailThenReturnGenerator("popular", [_candidate("at://infill/1", "popular")])
+        _stub_generators(monkeypatch, {"popular": gen})
+        rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+
+        with feed_debug_scope(rec):
+            result = await run_generate(
+                _make_request("popular", num_candidates=1, infill="popular"),
+                es=None,
+                swallow_errors=True,
+            )
+
+        assert [c.at_uri for c in result.candidates] == ["at://infill/1"]
+        assert [
+            (output.generator_name, [c.at_uri for c in output.candidates])
+            for output in rec.generator_outputs
+        ] == [
+            ("popular", []),
+            ("popular", ["at://infill/1"]),
+        ]
 
     @pytest.mark.asyncio
     async def test_success_records_success_count_metric(self, monkeypatch):

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -511,9 +511,9 @@ class TestGetFeedSkeleton:
                 params={"feed": FEED_URI, "limit": 5},
             ).json()
         assert len(data["feed"]) == 5
-        # Infill generator's generate method should not have been called
-        infill_gen = mock_get.side_effect("popularity")
-        infill_gen.generate.assert_not_called()
+        # popularity is a primary generator for this feed; no extra infill call should happen.
+        popularity_gen = mock_get.side_effect("popularity")
+        popularity_gen.generate.assert_awaited_once()
 
     def test_unranked_your_feed_uses_followed_users_generator(self):
         two_tower = _make_candidates("tower", 3, "two_tower")


### PR DESCRIPTION
Closes #219 

Add the `popularity` candidate generator as one of the main generators in Your Feed. Now we have 0.35 two-tower, 0.35 followed-users, and 0.3 popularity. Keep popularity as the infill generator. Because of this, added in logic to keep us from selecting the same posts that we already have at the infill stage. Also now returns an empty CandidateResult instead of None when swallow_errors is True, so that the feed_debug tool can differentiate between infill and primary generators.

Decided to add the `popularity` candidate generator into our feed because we anecdotally liked the results in the feed when the two tower generator was timing out and the results were coming from the popularity generator. (See discussion on discord).

Testing:
- Unit tests
- Deployed to stage
- Deployed locally connected to prod ES and sanity-checked the results