### PR TITLE
feat: add manage_post.py script for publishing and updating Bluesky posts

### DIFF
--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -5,8 +5,8 @@ Usage:
     cd api
 
     # Publish a new post
-    pipenv run python scripts/manage_post.py publish \\
-        --handle you.bsky.social --file post.txt
+    pipenv run python scripts/manage_post.py --handle you.bsky.social publish \\
+        --file post.txt
 
     # Update an existing post (preserves AT URI)
     pipenv run python scripts/manage_post.py --handle you.bsky.social update "at://did:plc:.../app.bsky.feed.post/3abc" \\

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -105,7 +105,52 @@ def cmd_publish(args) -> None:
 
 
 def cmd_update(args) -> None:
-    pass
+    if not args.at_uri.startswith("at://"):
+        print(f"Not an AT URI: {args.at_uri}", file=sys.stderr)
+        sys.exit(1)
+    parts = args.at_uri[5:].split("/", 2)
+    if len(parts) != 3:
+        print("AT URI must be at://repo/collection/rkey", file=sys.stderr)
+        sys.exit(1)
+    repo, collection, rkey = parts
+
+    content = _load_file(args.file)
+    segments = parse_content(content)
+    tb = build_text_builder(segments)
+
+    if args.dry_run:
+        print(f"=== DRY RUN — would update {args.at_uri} ===")
+        for seg in segments:
+            if seg["type"] == "text":
+                print(repr(seg["text"]))
+            else:
+                print(f'  [link] "{seg["text"]}" → {seg["url"]}')
+        return
+
+    client = _login(args.handle)
+
+    # Fetch existing record to preserve fields we're not changing (e.g. createdAt)
+    existing = client.com.atproto.repo.get_record({
+        "repo": repo,
+        "collection": collection,
+        "rkey": rkey,
+    })
+    val = existing.value
+    base = val.model_dump() if hasattr(val, "model_dump") else dict(val)
+
+    # Build updated record: keep all existing fields, replace text + facets
+    post_dict = tb.build_post()
+    updated_record = {**base, "text": post_dict["text"], "facets": post_dict.get("facets", [])}
+
+    client.com.atproto.repo.put_record({
+        "repo": client.me.did,
+        "collection": collection,
+        "rkey": rkey,
+        "record": updated_record,
+    })
+    print("Updated!")
+    print(f"  AT URI: {args.at_uri}  (preserved)")
+    print(f"  View:   https://bsky.app/profile/{args.handle}/post/{rkey}")
 
 
 def main() -> None:

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -9,8 +9,8 @@ Usage:
         --handle you.bsky.social --file post.txt
 
     # Update an existing post (preserves AT URI)
-    pipenv run python scripts/manage_post.py update "at://did:plc:.../app.bsky.feed.post/3abc" \\
-        --handle you.bsky.social --file updated_post.txt
+    pipenv run python scripts/manage_post.py --handle you.bsky.social update "at://did:plc:.../app.bsky.feed.post/3abc" \\
+        --file updated_post.txt
 
 post.txt format — plain text with markdown links:
     Hello world. [Click here](https://example.com) for more.
@@ -84,6 +84,9 @@ def _load_file(path: str) -> str:
 
 def cmd_publish(args) -> None:
     content = _load_file(args.file)
+    if not content:
+        print("Error: file is empty", file=sys.stderr)
+        sys.exit(1)
     segments = parse_content(content)
 
     if args.dry_run:
@@ -115,6 +118,9 @@ def cmd_update(args) -> None:
     repo, collection, rkey = parts
 
     content = _load_file(args.file)
+    if not content:
+        print("Error: file is empty", file=sys.stderr)
+        sys.exit(1)
     segments = parse_content(content)
     tb = build_text_builder(segments)
 
@@ -128,6 +134,9 @@ def cmd_update(args) -> None:
         return
 
     client = _login(args.handle)
+    if repo != client.me.did:
+        print(f"Error: AT URI repo ({repo}) does not match your DID ({client.me.did})", file=sys.stderr)
+        sys.exit(1)
 
     # Fetch existing record to preserve fields we're not changing (e.g. createdAt)
     existing = client.com.atproto.repo.get_record({
@@ -136,11 +145,12 @@ def cmd_update(args) -> None:
         "rkey": rkey,
     })
     val = existing.value
-    base = val.model_dump() if hasattr(val, "model_dump") else dict(val)
+    base = val.model_dump(by_alias=True) if hasattr(val, "model_dump") else dict(val)
 
     # Build updated record: keep all existing fields, replace text + facets
-    post_dict = tb.build_post()
-    updated_record = {**base, "text": post_dict["text"], "facets": post_dict.get("facets", [])}
+    new_text = tb.build_text()
+    new_facets = [f.model_dump(by_alias=True) for f in tb.build_facets()]
+    updated_record = {**base, "text": new_text, "facets": new_facets}
 
     client.com.atproto.repo.put_record({
         "repo": client.me.did,

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -24,6 +24,7 @@ import os
 import re
 import sys
 
+from atproto import client_utils
 from dotenv import load_dotenv
 
 LINK_RE = re.compile(r'\[([^\]]+)\]\((https?://[^)]+)\)')
@@ -41,3 +42,24 @@ def parse_content(text: str) -> list[dict]:
     if last < len(text):
         segments.append({"type": "text", "text": text[last:]})
     return segments
+
+
+def build_text_builder(segments: list[dict]) -> client_utils.TextBuilder:
+    """Build a TextBuilder from parsed content segments.
+
+    Converts a list of text and link segments into an atproto TextBuilder
+    with proper rich text markup.
+
+    Args:
+        segments: List of dicts with type="text" or "link" from parse_content()
+
+    Returns:
+        client_utils.TextBuilder with all segments added
+    """
+    tb = client_utils.TextBuilder()
+    for seg in segments:
+        if seg["type"] == "text":
+            tb.text(seg["text"])
+        elif seg["type"] == "link":
+            tb.link(seg["text"], seg["url"])
+    return tb

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Publish or update Bluesky posts with rich text support.
+"""Publish Bluesky posts with rich text support.
 
 Usage:
     cd api
@@ -8,14 +8,15 @@ Usage:
     pipenv run python scripts/manage_post.py --handle you.bsky.social publish \\
         --file post.txt
 
-    # Update an existing post (preserves AT URI)
-    pipenv run python scripts/manage_post.py --handle you.bsky.social update "at://did:plc:.../app.bsky.feed.post/3abc" \\
-        --file updated_post.txt
-
 post.txt format — plain text with markdown links:
     Hello world. [Click here](https://example.com) for more.
+    To show brackets in the display text: [[link]](https://example.com)
 
 Reads GE_BSKY_APP_PASSWORD from .env or environment, or prompts.
+
+Note: in-place updates (putRecord) are not supported — Bluesky's AppView does
+not reliably re-index updated records, so the visible post would remain stale.
+Delete and re-publish instead.
 """
 
 import argparse
@@ -27,7 +28,7 @@ import sys
 from atproto import Client, client_utils
 from dotenv import load_dotenv
 
-LINK_RE = re.compile(r'\[([^\]]+)\]\((https?://[^)]+)\)')
+LINK_RE = re.compile(r'\[(\[[^\]]+\]|[^\]]+)\]\((https?://[^)]+)\)')
 
 
 def parse_content(text: str) -> list[dict]:
@@ -107,62 +108,6 @@ def cmd_publish(args) -> None:
     print(f"  View:   https://bsky.app/profile/{args.handle}/post/{rkey}")
 
 
-def cmd_update(args) -> None:
-    if not args.at_uri.startswith("at://"):
-        print(f"Not an AT URI: {args.at_uri}", file=sys.stderr)
-        sys.exit(1)
-    parts = args.at_uri[5:].split("/", 2)
-    if len(parts) != 3:
-        print("AT URI must be at://repo/collection/rkey", file=sys.stderr)
-        sys.exit(1)
-    repo, collection, rkey = parts
-
-    content = _load_file(args.file)
-    if not content:
-        print("Error: file is empty", file=sys.stderr)
-        sys.exit(1)
-    segments = parse_content(content)
-    tb = build_text_builder(segments)
-
-    if args.dry_run:
-        print(f"=== DRY RUN — would update {args.at_uri} ===")
-        for seg in segments:
-            if seg["type"] == "text":
-                print(repr(seg["text"]))
-            else:
-                print(f'  [link] "{seg["text"]}" → {seg["url"]}')
-        return
-
-    client = _login(args.handle)
-    if repo != client.me.did:
-        print(f"Error: AT URI repo ({repo}) does not match your DID ({client.me.did})", file=sys.stderr)
-        sys.exit(1)
-
-    # Fetch existing record to preserve fields we're not changing (e.g. createdAt)
-    existing = client.com.atproto.repo.get_record({
-        "repo": repo,
-        "collection": collection,
-        "rkey": rkey,
-    })
-    val = existing.value
-    base = val.model_dump(by_alias=True) if hasattr(val, "model_dump") else dict(val)
-
-    # Build updated record: keep all existing fields, replace text + facets
-    new_text = tb.build_text()
-    new_facets = [f.model_dump(by_alias=True) for f in tb.build_facets()]
-    updated_record = {**base, "text": new_text, "facets": new_facets}
-
-    client.com.atproto.repo.put_record({
-        "repo": client.me.did,
-        "collection": collection,
-        "rkey": rkey,
-        "record": updated_record,
-    })
-    print("Updated!")
-    print(f"  AT URI: {args.at_uri}  (preserved)")
-    print(f"  View:   https://bsky.app/profile/{args.handle}/post/{rkey}")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="Publish or update Bluesky posts.")
     parser.add_argument("--handle", required=True, help="Bluesky handle (e.g. you.bsky.social)")
@@ -172,16 +117,9 @@ def main() -> None:
     pub.add_argument("--file", required=True, help="Path to post content file")
     pub.add_argument("--dry-run", action="store_true")
 
-    upd = sub.add_parser("update", help="Update an existing post in-place")
-    upd.add_argument("at_uri", help="AT URI of the post to update")
-    upd.add_argument("--file", required=True, help="Path to updated content file")
-    upd.add_argument("--dry-run", action="store_true")
-
     args = parser.parse_args()
     if args.command == "publish":
         cmd_publish(args)
-    elif args.command == "update":
-        cmd_update(args)
 
 
 if __name__ == "__main__":

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Publish or update Bluesky posts with rich text support.
+
+Usage:
+    cd api
+
+    # Publish a new post
+    pipenv run python scripts/manage_post.py publish \\
+        --handle you.bsky.social --file post.txt
+
+    # Update an existing post (preserves AT URI)
+    pipenv run python scripts/manage_post.py update "at://did:plc:.../app.bsky.feed.post/3abc" \\
+        --handle you.bsky.social --file updated_post.txt
+
+post.txt format — plain text with markdown links:
+    Hello world. [Click here](https://example.com) for more.
+
+Reads GE_BSKY_APP_PASSWORD from .env or environment, or prompts.
+"""
+
+import argparse
+import getpass
+import os
+import re
+import sys
+
+from dotenv import load_dotenv
+
+LINK_RE = re.compile(r'\[([^\]]+)\]\((https?://[^)]+)\)')
+
+
+def parse_content(text: str) -> list[dict]:
+    """Parse plain text with [label](url) markdown links into segments."""
+    segments = []
+    last = 0
+    for m in LINK_RE.finditer(text):
+        if m.start() > last:
+            segments.append({"type": "text", "text": text[last:m.start()]})
+        segments.append({"type": "link", "text": m.group(1), "url": m.group(2)})
+        last = m.end()
+    if last < len(text):
+        segments.append({"type": "text", "text": text[last:]})
+    return segments

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -85,7 +85,6 @@ def _load_file(path: str) -> str:
 def cmd_publish(args) -> None:
     content = _load_file(args.file)
     segments = parse_content(content)
-    tb = build_text_builder(segments)
 
     if args.dry_run:
         print("=== DRY RUN — post content ===")
@@ -96,12 +95,13 @@ def cmd_publish(args) -> None:
                 print(f'  [link] "{seg["text"]}" → {seg["url"]}')
         return
 
+    tb = build_text_builder(segments)
     client = _login(args.handle)
     post = client.send_post(tb)
     rkey = post.uri.split("/")[-1]
-    print(f"Published!")
+    print("Published!")
     print(f"  AT URI: {post.uri}")
-    print(f"  View:   https://bsky.app/profile/{client.me.handle}/post/{rkey}")
+    print(f"  View:   https://bsky.app/profile/{args.handle}/post/{rkey}")
 
 
 def cmd_update(args) -> None:

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -24,7 +24,7 @@ import os
 import re
 import sys
 
-from atproto import client_utils
+from atproto import Client, client_utils
 from dotenv import load_dotenv
 
 LINK_RE = re.compile(r'\[([^\]]+)\]\((https?://[^)]+)\)')
@@ -63,3 +63,71 @@ def build_text_builder(segments: list[dict]) -> client_utils.TextBuilder:
         elif seg["type"] == "link":
             tb.link(seg["text"], seg["url"])
     return tb
+
+
+def _login(handle: str) -> Client:
+    load_dotenv()
+    password = os.environ.get("GE_BSKY_APP_PASSWORD") or getpass.getpass("App password: ")
+    client = Client()
+    client.login(handle, password)
+    return client
+
+
+def _load_file(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        print(f"File not found: {path}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_publish(args) -> None:
+    content = _load_file(args.file)
+    segments = parse_content(content)
+    tb = build_text_builder(segments)
+
+    if args.dry_run:
+        print("=== DRY RUN — post content ===")
+        for seg in segments:
+            if seg["type"] == "text":
+                print(repr(seg["text"]))
+            else:
+                print(f'  [link] "{seg["text"]}" → {seg["url"]}')
+        return
+
+    client = _login(args.handle)
+    post = client.send_post(tb)
+    rkey = post.uri.split("/")[-1]
+    print(f"Published!")
+    print(f"  AT URI: {post.uri}")
+    print(f"  View:   https://bsky.app/profile/{client.me.handle}/post/{rkey}")
+
+
+def cmd_update(args) -> None:
+    pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish or update Bluesky posts.")
+    parser.add_argument("--handle", required=True, help="Bluesky handle (e.g. you.bsky.social)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    pub = sub.add_parser("publish", help="Publish a new post")
+    pub.add_argument("--file", required=True, help="Path to post content file")
+    pub.add_argument("--dry-run", action="store_true")
+
+    upd = sub.add_parser("update", help="Update an existing post in-place")
+    upd.add_argument("at_uri", help="AT URI of the post to update")
+    upd.add_argument("--file", required=True, help="Path to updated content file")
+    upd.add_argument("--dry-run", action="store_true")
+
+    args = parser.parse_args()
+    if args.command == "publish":
+        cmd_publish(args)
+    elif args.command == "update":
+        cmd_update(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/manage_post_test.py
+++ b/scripts/manage_post_test.py
@@ -34,6 +34,15 @@ def test_multiple_links():
     ]
 
 
+def test_bracketed_display_text():
+    result = parse_content("check [[link]](https://example.com) out")
+    assert result == [
+        {"type": "text", "text": "check "},
+        {"type": "link", "text": "[link]", "url": "https://example.com"},
+        {"type": "text", "text": " out"},
+    ]
+
+
 def test_no_trailing_empty_text():
     result = parse_content("[link](https://x.com)")
     assert all(not (s["type"] == "text" and s["text"] == "") for s in result)
@@ -62,49 +71,3 @@ def test_build_text_builder_with_link():
     tb.link.assert_called_once_with("site", "https://example.com")
 
 
-def test_cmd_update_merges_record_correctly(tmp_path):
-    from manage_post import cmd_update
-    import argparse
-
-    post_file = tmp_path / "post.txt"
-    post_file.write_text("Hello [link](https://example.com)")
-
-    existing_value = MagicMock()
-    existing_value.model_dump.return_value = {
-        "$type": "app.bsky.feed.post",
-        "text": "old text",
-        "createdAt": "2026-01-01T00:00:00.000Z",
-    }
-
-    mock_get_resp = MagicMock()
-    mock_get_resp.value = existing_value
-
-    captured = {}
-
-    def fake_put_record(params):
-        captured["record"] = params["record"]
-        return MagicMock()
-
-    mock_client = MagicMock()
-    mock_client.me.did = "did:plc:test"
-    mock_client.com.atproto.repo.get_record.return_value = mock_get_resp
-    mock_client.com.atproto.repo.put_record.side_effect = fake_put_record
-
-    args = argparse.Namespace(
-        at_uri="at://did:plc:test/app.bsky.feed.post/3abc",
-        handle="test.bsky.social",
-        file=str(post_file),
-        dry_run=False,
-    )
-
-    with patch("manage_post._login", return_value=mock_client):
-        cmd_update(args)
-
-    # Verify model_dump was called with by_alias=True
-    existing_value.model_dump.assert_called_once_with(by_alias=True)
-
-    record = captured["record"]
-    assert record["$type"] == "app.bsky.feed.post"
-    assert record["createdAt"] == "2026-01-01T00:00:00.000Z"
-    assert record["text"] == "Hello link"
-    assert len(record["facets"]) == 1

--- a/scripts/manage_post_test.py
+++ b/scripts/manage_post_test.py
@@ -1,0 +1,38 @@
+import pytest
+from manage_post import parse_content
+
+
+def test_plain_text():
+    result = parse_content("hello world")
+    assert result == [{"type": "text", "text": "hello world"}]
+
+
+def test_single_link():
+    result = parse_content("check [this](https://example.com) out")
+    assert result == [
+        {"type": "text", "text": "check "},
+        {"type": "link", "text": "this", "url": "https://example.com"},
+        {"type": "text", "text": " out"},
+    ]
+
+
+def test_link_at_end():
+    result = parse_content("visit [site](https://example.com)")
+    assert result == [
+        {"type": "text", "text": "visit "},
+        {"type": "link", "text": "site", "url": "https://example.com"},
+    ]
+
+
+def test_multiple_links():
+    result = parse_content("[a](https://a.com) and [b](https://b.com)")
+    assert result == [
+        {"type": "link", "text": "a", "url": "https://a.com"},
+        {"type": "text", "text": " and "},
+        {"type": "link", "text": "b", "url": "https://b.com"},
+    ]
+
+
+def test_no_trailing_empty_text():
+    result = parse_content("[link](https://x.com)")
+    assert all(not (s["type"] == "text" and s["text"] == "") for s in result)

--- a/scripts/manage_post_test.py
+++ b/scripts/manage_post_test.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import MagicMock, call, patch
 from manage_post import parse_content
 
 
@@ -36,3 +37,26 @@ def test_multiple_links():
 def test_no_trailing_empty_text():
     result = parse_content("[link](https://x.com)")
     assert all(not (s["type"] == "text" and s["text"] == "") for s in result)
+
+
+def test_build_text_builder_plain():
+    from manage_post import build_text_builder
+    segments = [{"type": "text", "text": "hello world"}]
+    tb = MagicMock()
+    with patch("manage_post.client_utils.TextBuilder", return_value=tb):
+        build_text_builder(segments)
+    tb.text.assert_called_once_with("hello world")
+    tb.link.assert_not_called()
+
+
+def test_build_text_builder_with_link():
+    from manage_post import build_text_builder
+    segments = [
+        {"type": "text", "text": "visit "},
+        {"type": "link", "text": "site", "url": "https://example.com"},
+    ]
+    tb = MagicMock()
+    with patch("manage_post.client_utils.TextBuilder", return_value=tb):
+        build_text_builder(segments)
+    tb.text.assert_called_once_with("visit ")
+    tb.link.assert_called_once_with("site", "https://example.com")

--- a/scripts/manage_post_test.py
+++ b/scripts/manage_post_test.py
@@ -60,3 +60,51 @@ def test_build_text_builder_with_link():
         build_text_builder(segments)
     tb.text.assert_called_once_with("visit ")
     tb.link.assert_called_once_with("site", "https://example.com")
+
+
+def test_cmd_update_merges_record_correctly(tmp_path):
+    from manage_post import cmd_update
+    import argparse
+
+    post_file = tmp_path / "post.txt"
+    post_file.write_text("Hello [link](https://example.com)")
+
+    existing_value = MagicMock()
+    existing_value.model_dump.return_value = {
+        "$type": "app.bsky.feed.post",
+        "text": "old text",
+        "createdAt": "2026-01-01T00:00:00.000Z",
+    }
+
+    mock_get_resp = MagicMock()
+    mock_get_resp.value = existing_value
+
+    captured = {}
+
+    def fake_put_record(params):
+        captured["record"] = params["record"]
+        return MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.me.did = "did:plc:test"
+    mock_client.com.atproto.repo.get_record.return_value = mock_get_resp
+    mock_client.com.atproto.repo.put_record.side_effect = fake_put_record
+
+    args = argparse.Namespace(
+        at_uri="at://did:plc:test/app.bsky.feed.post/3abc",
+        handle="test.bsky.social",
+        file=str(post_file),
+        dry_run=False,
+    )
+
+    with patch("manage_post._login", return_value=mock_client):
+        cmd_update(args)
+
+    # Verify model_dump was called with by_alias=True
+    existing_value.model_dump.assert_called_once_with(by_alias=True)
+
+    record = captured["record"]
+    assert record["$type"] == "app.bsky.feed.post"
+    assert record["createdAt"] == "2026-01-01T00:00:00.000Z"
+    assert record["text"] == "Hello link"
+    assert len(record["facets"]) == 1

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -47,7 +47,6 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="67-r",
         internal_display_name="67 R",
         avatar="assets/icons/random.png",
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5uvuzydy2o"
         diversify=False,
         exclude_seen_posts=False,
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5uvuzydy2o",

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -47,9 +47,10 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="67-r",
         internal_display_name="67 R",
         avatar="assets/icons/random.png",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5uvuzydy2o"
         diversify=False,
         exclude_seen_posts=False,
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprixpw42r25",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5uvuzydy2o",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
@@ -65,7 +66,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="a0-yf",
         internal_display_name="a0 YF",
         avatar="assets/icons/your-feed.png",
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprirzcv3a24",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5utph3ka26",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
                 GeneratorSpec(name="two_tower", weight=0.35),
@@ -91,7 +92,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="fd-bof",
         internal_display_name="fd BOF",
         avatar="assets/icons/best-of-friends.png",
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mprivkqqe224",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5uvi4exl2s",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],
             infill=None,


### PR DESCRIPTION
> TL;DR: Add scripts to publish/update Bluesky posts

## Usage

```bash
cd api

# Publish a new post
pipenv run python scripts/manage_post.py --handle you.bsky.social publish \
    --file post.txt

# Dry-run (no API calls)
pipenv run python scripts/manage_post.py --handle you.bsky.social publish \
    --file post.txt --dry-run
```

`post.txt` example:
```
A random slice of the ATProto universe. Still applies your moderation settings.

Part of the GreenEarth family. Tell us what you think! [[link]](https://www.greenearth.social/p/introducing-greenearth)
```

Reads `GE_BSKY_APP_PASSWORD` from `.env` or environment; falls back to interactive prompt.

Closes #240 