### PR TITLE
Minimum like count for two tower candidate posts

### DIFF
--- a/src/app/lib/candidates/es_candidates.py
+++ b/src/app/lib/candidates/es_candidates.py
@@ -20,6 +20,7 @@ async def knn_search_posts(
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
     ge_post_embedding_model_uuid: str | None = None,
+    min_like_count: int | None = None,
 ) -> list[CandidatePost]:
     """Run a kNN search against the ``posts_recent`` index and return candidate posts.
 
@@ -33,6 +34,9 @@ async def knn_search_posts(
 
     if ge_post_embedding_model_uuid:
         filters.append({"term": {"ge_post_embedding_model_uuid": ge_post_embedding_model_uuid}})
+
+    if min_like_count is not None:
+        filters.append({"range": {"like_count": {"gte": min_like_count}}})
 
     must_not: list[dict] = []
     if exclude_uris:

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -547,6 +547,16 @@ class TestKnnSearchPosts:
         assert {"term": {"ge_post_embedding_model_uuid": "model-uuid-123"}} in knn["filter"]["bool"]["filter"]
 
     @pytest.mark.asyncio
+    async def test_min_like_count_is_an_es_filter(self):
+        es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
+        await knn_search_posts(
+            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
+            min_like_count=20
+        )
+        knn = es.calls[0]["knn"]
+        assert {"range": {"like_count": {"gte": 20}}} in knn["filter"]["bool"]["filter"]
+
+    @pytest.mark.asyncio
     async def test_ge_post_embedding_model_uuid_filter_combines_with_exclude_uris(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 TWO_TOWER_GENERATOR_NAME = "two_tower"
+MIN_LIKE_COUNT = 20
 
 
 class TwoTowerCandidateGenerator(CandidateGenerator):
@@ -66,7 +67,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         candidates = await knn_search_posts(
             es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
             generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
-            ge_post_embedding_model_uuid=post_tower_uuid,
+            ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=MIN_LIKE_COUNT,
         )
 
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -7,6 +7,7 @@ import pytest
 from ...models import CandidatePost
 from ..candidates import get_generator, list_generators
 from ..candidates.two_tower import (
+    MIN_LIKE_COUNT,
     TWO_TOWER_GENERATOR_NAME,
     TwoTowerCandidateGenerator,
 )
@@ -96,6 +97,7 @@ class TestTwoTowerCandidateGenerator:
             video_only=True,
             exclude_uris=["at://old/1", "at://old/2"],
             ge_post_embedding_model_uuid="post-tower-uuid",
+            min_like_count=MIN_LIKE_COUNT,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == candidates
@@ -134,6 +136,7 @@ class TestTwoTowerCandidateGenerator:
             video_only=False,
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
+            min_like_count=MIN_LIKE_COUNT,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == []
@@ -172,6 +175,7 @@ class TestTwoTowerCandidateGenerator:
             video_only=False,
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
+            min_like_count=MIN_LIKE_COUNT,
         )
         assert result.candidates == []
 


### PR DESCRIPTION
Closes #230 

Simply put a like count filter on the query for the most relevant posts in the two tower candidate generator. This will ensure some minimum level of quality of posts.