### PR TITLE
Decayed Diversity Penalties and Increased Global Diversity Weight

### DIFF
--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -6,8 +6,14 @@ from .embeddings import decode_float32_b64
 from .feed_debug import current_recorder
 from ..models import CandidatePost
 
-BETA = 0.5
+# Global diversity weight (relevance weight is 1-BETA)
+BETA = 0.7
+
+# Author weight (content weight is 1-AUTHOR_WEIGHT)
 AUTHOR_WEIGHT = 0.5
+
+# Decay tau for position-based decay of author and content penalties
+DECAY_TAU = 15.0
 
 
 def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
@@ -35,13 +41,14 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     author_dids = [c.author_did for c in candidates]
     remaining = list(range(n))
     selected: list[int] = []
-    # max_content_sim[i] tracks the highest (content) similarity candidate i has to
+
+    # tracks the highest decayed (content) similarity candidate i has to
     # any selected candidate so far. Updated incrementally — one new comparison per
     # remaining item each round instead of recomputing the full max from scratch.
-    max_content_sims = [-math.inf] * n
-    # for each remaining post, keep track of the number of times that post's author
+    decayed_max_content_sims = [-math.inf] * n
+    # for each remaining post, keep track of the decayed number of times that post's author
     # has already been selected in the result set
-    same_author_counts = [0] * n
+    decayed_same_author_counts = [0] * n
 
     rec = current_recorder()
     # (at_uri, relevance, score, author_penalty, content_penalty) per pick, for
@@ -49,14 +56,17 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
     diag: list[tuple[str, float, float, float, float]] | None = [] if rec is not None else None
 
     def _calculate_author_penalty(i: int) -> float:
-        return BETA * AUTHOR_WEIGHT * same_author_counts[i]
+        return BETA * AUTHOR_WEIGHT * decayed_same_author_counts[i]
 
     def _calculate_content_penalty(i: int) -> float:
-        return BETA * (1 - AUTHOR_WEIGHT) * max_content_sims[i]
+        return BETA * (1 - AUTHOR_WEIGHT) * decayed_max_content_sims[i]
 
     def _calculate_penalized_score(i: int) -> float:
         total_penalty = _calculate_author_penalty(i) + _calculate_content_penalty(i)
         return (1 - BETA) * norm_scores[i] - total_penalty
+
+    # We incrementally decay the counts and similarities after each selection
+    single_decay_factor = math.exp(-1 / DECAY_TAU)
 
     while remaining:
         if not selected:
@@ -91,13 +101,17 @@ def mmr_rerank(candidates: list[CandidatePost]) -> list[CandidatePost]:
         selected.append(best)
         remaining.remove(best)
 
+        # position-decay same author counts and content similarities:
+        decayed_same_author_counts = [c * single_decay_factor for c in decayed_same_author_counts]
+        decayed_max_content_sims = [s * single_decay_factor for s in decayed_max_content_sims]
+
         for i in remaining:
             if author_dids[i] is not None and author_dids[best] is not None:
                 if author_dids[i] == author_dids[best]:
-                    same_author_counts[i] += 1
+                    decayed_same_author_counts[i] += 1
             content_sim = _calculate_content_sim(vecs[i], vecs[best])
-            if content_sim > max_content_sims[i]:
-                max_content_sims[i] = content_sim
+            if content_sim > decayed_max_content_sims[i]:
+                decayed_max_content_sims[i] = content_sim
 
     if rec is not None and diag is not None:
         rec.record_diversification(diag)

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -1,10 +1,13 @@
 """Tests for MMR-based feed diversification."""
 
+import math
+
 import pytest
 
 from ..models import CandidatePost
-from .diversify import _cosine_similarity, mmr_rerank
+from .diversify import AUTHOR_WEIGHT, BETA, DECAY_TAU, _cosine_similarity, mmr_rerank
 from .embeddings import encode_float32_b64
+from .feed_debug import FeedDebugRecorder, feed_debug_scope
 
 
 def _post(uri: str, score: float, author_did: str | None = None) -> CandidatePost:
@@ -44,17 +47,24 @@ def test_same_author_posts_spread_apart():
     assert uris.index("at://bob/1") < uris.index("at://alice/2")
 
 
-def test_author_penalty_increases_with_selected_author_count():
-    """A repeated author should become more penalized each time that author is selected."""
+def test_author_penalty_decays_after_intervening_selection():
+    """A repeated author should be penalized less after one intervening pick."""
     a1 = _post("at://alice/1", score=1.0, author_did="did:plc:alice")
     a2 = _post("at://alice/2", score=1.0, author_did="did:plc:alice")
-    a3 = _post("at://alice/3", score=1.0, author_did="did:plc:alice")
-    b1 = _post("at://bob/1", score=0.21, author_did="did:plc:bob")
+    b1 = _post("at://bob/1", score=0.5, author_did="did:plc:bob")
 
-    result = mmr_rerank([a1, a2, a3, b1])
+    rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+    with feed_debug_scope(rec):
+        result = mmr_rerank([a1, a2, b1])
     uris = [c.at_uri for c in result]
 
-    assert uris == ["at://alice/1", "at://alice/2", "at://bob/1", "at://alice/3"]
+    assert uris == ["at://alice/1", "at://bob/1", "at://alice/2"]
+    _, rel, score, author_pen, content_pen = rec.diversification[2]
+    expected_author_penalty = BETA * AUTHOR_WEIGHT * math.exp(-1 / DECAY_TAU)
+    assert rel == pytest.approx(1.0)
+    assert author_pen == pytest.approx(expected_author_penalty)
+    assert content_pen == pytest.approx(0.0)
+    assert score == pytest.approx((1 - BETA) * 1.0 - expected_author_penalty)
 
 
 def test_missing_author_dids_do_not_count_as_same_author():
@@ -157,6 +167,26 @@ def test_cosine_penalizes_topically_similar_cross_author_post():
     assert uris[0] == "at://alice/1"
     # p2 shares p1's topic; p3 is orthogonal — cosine pushes p3 ahead of p2
     assert uris.index("at://carol/1") < uris.index("at://bob/1")
+
+
+def test_content_penalty_decays_after_intervening_selection():
+    """A matching older post should contribute less after one intervening pick."""
+    p1 = _post_with_embed("at://topic/1", score=1.0, author_did="did:plc:a", vec=[1.0, 0.0])
+    p2 = _post_with_embed("at://topic/2", score=1.0, author_did="did:plc:b", vec=[1.0, 0.0])
+    p3 = _post_with_embed("at://other/1", score=0.5, author_did="did:plc:c", vec=[0.0, 1.0])
+
+    rec = FeedDebugRecorder(feed_name="f", regenerated=False)
+    with feed_debug_scope(rec):
+        result = mmr_rerank([p1, p2, p3])
+    uris = [c.at_uri for c in result]
+
+    assert uris == ["at://topic/1", "at://other/1", "at://topic/2"]
+    _, rel, score, author_pen, content_pen = rec.diversification[2]
+    expected_content_penalty = BETA * (1 - AUTHOR_WEIGHT) * math.exp(-1 / DECAY_TAU)
+    assert rel == pytest.approx(1.0)
+    assert author_pen == pytest.approx(0.0)
+    assert content_pen == pytest.approx(expected_content_penalty)
+    assert score == pytest.approx((1 - BETA) * 1.0 - expected_content_penalty)
 
 
 def test_cosine_similarity_value_matches_manual_calculation():

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -231,12 +231,12 @@ class TestDiversificationCapture:
         assert score == pytest.approx((1 - BETA) * 1.0)
         assert author_pen == pytest.approx(0.0)
         assert content_pen == pytest.approx(0.0)
-        # Second pick: author_penalty = BETA * AUTHOR_WEIGHT * 1 = 0.5 * 0.75.
+        # Second pick: author_penalty = BETA * AUTHOR_WEIGHT * 1.
         _, rel, score, author_pen, content_pen = rec.diversification[1]
         assert rel == pytest.approx(0.5)
         assert author_pen == pytest.approx(BETA * AUTHOR_WEIGHT * 1)
         assert content_pen == pytest.approx(0.0)
-        assert score == pytest.approx(0.5 * 0.5 - author_pen - content_pen)
+        assert score == pytest.approx((1 - BETA) * 0.5 - author_pen - content_pen)
 
     def test_content_penalty_recorded(self):
         # Different authors, identical embeddings -> penalty is purely content.
@@ -252,7 +252,7 @@ class TestDiversificationCapture:
             mmr_rerank([a, b])
 
         _, _, _, author_pen, content_pen = rec.diversification[1]
-        # content_penalty = BETA * (1 - AUTHOR_WEIGHT) * cosine(=1) = 0.5 * 0.25.
+        # content_penalty = BETA * (1 - AUTHOR_WEIGHT) * cosine(=1).
         assert author_pen == pytest.approx(0.0)
         assert content_pen == pytest.approx(BETA * (1 - AUTHOR_WEIGHT) * 1.0)
 


### PR DESCRIPTION
Closes #239 

Implements decayed MMR. So each post's author and content similarity score is now multiplied by exp(position_diff / tau). So you get less penalty for being similar to a post that occurred earlier in the feed vs one that is nearby. Tau is set to 15 for now which means posts 10 spots apart get about half the penalty of posts right next to each other. 

Also increased the global diversity weight (BETA) from 0.5 to 0.7.