### PR TITLE
Fix Perspective API connection-pool bottleneck

### DIFF
--- a/scripts/profile_perspective.py
+++ b/scripts/profile_perspective.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Simulate concurrent Perspective API scoring load for before/after profiling.
+
+Issue #250 investigation: the ranking pipeline scores every candidate
+concurrently via `asyncio.gather`, and PerspectiveClient historically shared
+the process-wide `httpx.AsyncClient` (default pool: 100 connections, 20
+keepalive, 30s timeout) with every other outbound API caller. Under a burst
+of concurrent scoring calls this queues requests behind the pool limit --
+indistinguishable, from a flame chart, from the Perspective API itself being
+slow.
+
+This script isolates that effect without needing a live GE_PERSPECTIVE_API_KEY
+or burning real API quota: it starts a local aiohttp mock server that mimics
+Perspective's response shape with a fixed artificial per-request latency,
+points PerspectiveClient at it via GE_PERSPECTIVE_HOST, and scores a large
+batch of synthetic candidates through the real score_candidates() path under
+a pyinstrument profiler -- the same Profiler(interval=0.001,
+async_mode="enabled") configuration used by app.lib.profiling's per-request
+middleware. Run it once on each side of the change to get comparable
+before/after flame charts and wall-clock numbers:
+
+    git stash                          # or: git checkout main -- src/app/lib/perspective.py
+    pipenv run python scripts/profile_perspective.py --candidates 500
+
+    git stash pop                      # or: git checkout <branch> -- src/app/lib/perspective.py
+    pipenv run python scripts/profile_perspective.py --candidates 500
+
+Output: an HTML flame chart under ./profiles/ and a printed wall-clock
+summary (total elapsed time and mean time per candidate). If the pool is
+the bottleneck, elapsed time will scale with (candidates / pool_size) *
+mock_latency before the fix, and stay ~flat at ~mock_latency after it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aiohttp import web
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_MOCK_PORT = 8099
+_MOCK_LATENCY_SECONDS = 0.2
+
+_ATTRIBUTES = [
+    "REASONING_EXPERIMENTAL",
+    "PERSONAL_STORY_EXPERIMENTAL",
+    "AFFINITY_EXPERIMENTAL",
+    "COMPASSION_EXPERIMENTAL",
+    "RESPECT_EXPERIMENTAL",
+    "CURIOSITY_EXPERIMENTAL",
+    "FEARMONGERING_EXPERIMENTAL",
+    "GENERALIZATION_EXPERIMENTAL",
+    "SCAPEGOATING_EXPERIMENTAL",
+    "MORAL_OUTRAGE_EXPERIMENTAL",
+    "ALIENATION_EXPERIMENTAL",
+    "TOXICITY",
+    "IDENTITY_ATTACK",
+    "INSULT",
+    "THREAT",
+]
+
+
+async def _mock_analyze(request: web.Request) -> web.Response:
+    await asyncio.sleep(_MOCK_LATENCY_SECONDS)
+    return web.json_response(
+        {"attributeScores": {name: {"summaryScore": {"value": 0.5}} for name in _ATTRIBUTES}}
+    )
+
+
+async def _start_mock_server() -> web.AppRunner:
+    app = web.Application()
+    app.router.add_post("/v1alpha1/comments:analyze", _mock_analyze)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", _MOCK_PORT)
+    await site.start()
+    return runner
+
+
+async def _main_async(n_candidates: int, profile_dir: Path) -> None:
+    os.environ.setdefault("GE_PERSPECTIVE_API_KEY", "local-mock-key")
+    os.environ["GE_PERSPECTIVE_HOST"] = f"http://127.0.0.1:{_MOCK_PORT}"
+
+    runner = await _start_mock_server()
+
+    from pyinstrument import Profiler
+
+    from app.lib.perspective import score_candidates
+    from app.models import CandidatePost
+
+    candidates = [
+        CandidatePost(
+            at_uri=f"at://profile/synthetic/{i}",
+            content=f"Synthetic profiling candidate #{i} with enough text to score.",
+            score=0.0,
+            minilm_l12_embedding=None,
+            generator_name="profile_perspective",
+        )
+        for i in range(n_candidates)
+    ]
+
+    profiler = Profiler(interval=0.001, async_mode="enabled")
+    profiler.start()
+    start = time.monotonic()
+    scores = await score_candidates(candidates)
+    elapsed = time.monotonic() - start
+    profiler.stop()
+
+    await runner.cleanup()
+
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+    output_path = profile_dir / f"{ts}-perspective-{n_candidates}candidates.html"
+    output_path.write_text(profiler.output_html())
+
+    scored = sum(1 for s in scores.values() if s is not None)
+    print(f"candidates={n_candidates} scored={scored} elapsed_s={elapsed:.2f}")
+    print(f"mean_s_per_candidate={elapsed / n_candidates:.4f}")
+    print(
+        f"mock_latency_s={_MOCK_LATENCY_SECONDS} "
+        f"(fully-parallel floor: ~{_MOCK_LATENCY_SECONDS:.2f}s)"
+    )
+    print(f"profile written to {output_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--candidates", type=int, default=500,
+        help="Number of synthetic candidates to score concurrently (default: 500)",
+    )
+    parser.add_argument(
+        "--profile-dir", type=Path, default=Path("profiles"),
+        help="Directory to write the pyinstrument HTML report to (default: ./profiles)",
+    )
+    args = parser.parse_args()
+    asyncio.run(_main_async(args.candidates, args.profile_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -15,7 +15,13 @@ from .telemetry import timed
 
 logger = logging.getLogger(__name__)
 
-_PERSPECTIVE_URL = "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze"
+_PERSPECTIVE_HOST_DEFAULT = "https://commentanalyzer.googleapis.com"
+
+
+def _perspective_url() -> str:
+    """Perspective API endpoint URL, overridable via GE_PERSPECTIVE_HOST for local profiling."""
+    host = os.environ.get("GE_PERSPECTIVE_HOST", _PERSPECTIVE_HOST_DEFAULT)
+    return f"{host}/v1alpha1/comments:analyze"
 
 
 class PerspectiveLanguageNotSupportedError(Exception):
@@ -111,7 +117,7 @@ class PerspectiveClient:
         client = get_http_client()
         async with timed(logger, "perspective.score.duration_ms", record_metric=True):
             response = await client.post(
-                _PERSPECTIVE_URL,
+                _perspective_url(),
                 params={"key": self._api_key},
                 json=payload,
             )

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -7,15 +7,17 @@ import logging
 import os
 import time
 
+import aiohttp
 import httpx
 
 from ..models import CandidatePost
-from .http_client import get_http_client
 from .telemetry import timed
 
 logger = logging.getLogger(__name__)
 
 _PERSPECTIVE_HOST_DEFAULT = "https://commentanalyzer.googleapis.com"
+_SCORE_TIMEOUT_SECONDS = 1.0
+_SCORE_ATTEMPTS = 2
 
 
 def _perspective_url() -> str:
@@ -107,45 +109,102 @@ class PerspectiveClient:
         if not key:
             raise RuntimeError("GE_PERSPECTIVE_API_KEY environment variable is not set")
         self._api_key = key
+        self._session: aiohttp.ClientSession | None = None
 
-    async def score(self, content: str) -> float:
-        """Return the PRC score for the given text content."""
-        payload = {
-            "comment": {"text": content},
-            "requestedAttributes": _REQUESTED_ATTRIBUTES,
-        }
-        client = get_http_client()
-        async with timed(logger, "perspective.score.duration_ms", record_metric=True):
-            response = await client.post(
-                _perspective_url(),
-                params={"key": self._api_key},
-                json=payload,
+    def _get_session(self) -> aiohttp.ClientSession:
+        """Lazily build the dedicated aiohttp session.
+
+        Constructed lazily (not in __init__) because aiohttp.ClientSession()
+        requires a running event loop, which isn't available at
+        PerspectiveClient() construction time (e.g. module import, pytest
+        collection). limit=0/limit_per_host=0 removes the connection-pool cap
+        that caused head-of-line blocking under concurrent asyncio.gather
+        scoring bursts (issue #250); keepalive_timeout=45 matches the PRC
+        reference implementation.
+        """
+        if self._session is None:
+            connector = aiohttp.TCPConnector(
+                limit=0,
+                limit_per_host=0,
+                enable_cleanup_closed=True,
+                keepalive_timeout=45,
             )
-        if not response.is_success:
-            if response.status_code == 400:
-                try:
-                    details = response.json().get("error", {}).get("details", [])
-                    if details and details[0].get("errorType") == "LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE":
-                        lang_error = details[0].get("languageNotSupportedByAttributeError", {})
-                        detected = (lang_error.get("detectedLanguages") or [None])[0]
-                        raise PerspectiveLanguageNotSupportedError(detected)
-                except PerspectiveLanguageNotSupportedError:
-                    raise
-                except Exception:
-                    pass
-            logger.warning(
-                "Perspective API %s for content %.80r: %s",
-                response.status_code,
-                content,
-                response.text,
-            )
-            response.raise_for_status()
-        data = response.json()
+            self._session = aiohttp.ClientSession(connector=connector)
+        return self._session
+
+    async def close(self) -> None:
+        """Close the session, if one was ever opened."""
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def _handle_error_response(self, response: aiohttp.ClientResponse, content: str) -> None:
+        if response.status == 400:
+            try:
+                body = await response.json()
+                details = body.get("error", {}).get("details", [])
+                if details and details[0].get("errorType") == "LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE":
+                    lang_error = details[0].get("languageNotSupportedByAttributeError", {})
+                    detected = (lang_error.get("detectedLanguages") or [None])[0]
+                    raise PerspectiveLanguageNotSupportedError(detected)
+            except PerspectiveLanguageNotSupportedError:
+                raise
+            except Exception:
+                pass
+        text = await response.text()
+        logger.warning(
+            "Perspective API %s for content %.80r: %s",
+            response.status,
+            content,
+            text,
+        )
+        response.raise_for_status()
+
+    @staticmethod
+    def _extract_score(data: dict) -> float:
         attr_scores = {
             name: data["attributeScores"][name]["summaryScore"]["value"]
             for name in _REQUESTED_ATTRIBUTES
         }
         return _prc_score(attr_scores)
+
+    async def score(self, content: str) -> float:
+        """Return the PRC score for the given text content.
+
+        Retries once on a per-request timeout (2 total attempts), matching
+        the PRC reference implementation
+        (https://github.com/HumanCompatibleAI/ranking-challenge-perspective/blob/main/perspective_ranker.py#L329).
+        """
+        payload = {
+            "comment": {"text": content},
+            "requestedAttributes": _REQUESTED_ATTRIBUTES,
+        }
+        session = self._get_session()
+        timeout = aiohttp.ClientTimeout(total=_SCORE_TIMEOUT_SECONDS)
+
+        for attempt in range(_SCORE_ATTEMPTS):
+            try:
+                async with timed(logger, "perspective.score.duration_ms", record_metric=True):
+                    async with session.post(
+                        _perspective_url(),
+                        params={"key": self._api_key},
+                        json=payload,
+                        timeout=timeout,
+                    ) as response:
+                        if response.status != 200:
+                            await self._handle_error_response(response, content)
+                        data = await response.json()
+                return self._extract_score(data)
+            except TimeoutError:
+                if attempt == _SCORE_ATTEMPTS - 1:
+                    raise
+                logger.warning(
+                    "Perspective API timeout (%ss) scoring content %.80r; retrying",
+                    _SCORE_TIMEOUT_SECONDS,
+                    content,
+                )
+
+        raise AssertionError("unreachable: loop above always returns or raises")
 
 
 # Client-side rate limiter tracking usage within the current calendar-minute

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -8,7 +8,6 @@ import os
 import time
 
 import aiohttp
-import httpx
 
 from ..models import CandidatePost
 from .telemetry import timed
@@ -240,6 +239,14 @@ def _get_client() -> PerspectiveClient:
     return _client
 
 
+async def close_perspective_client() -> None:
+    """Close the singleton PerspectiveClient's aiohttp session, if one was created."""
+    global _client
+    if _client is not None:
+        await _client.close()
+        _client = None
+
+
 async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float | None]:
     """Return PRC scores for *candidates*, keyed by ``at_uri``.
 
@@ -267,8 +274,8 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
                 c.at_uri,
             )
             return None
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 429:
+        except aiohttp.ClientResponseError as exc:
+            if exc.status == 429:
                 logger.warning("Perspective API rate limited for post %s; using missing score", c.at_uri)
             else:
                 logger.exception("Perspective API scoring failed for post %s", c.at_uri)

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -276,7 +276,9 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
             return None
         except aiohttp.ClientResponseError as exc:
             if exc.status == 429:
-                logger.warning("Perspective API rate limited for post %s; using missing score", c.at_uri)
+                logger.warning(
+                    "Perspective API rate limited for post %s; using missing score", c.at_uri
+                )
             else:
                 logger.exception("Perspective API scoring failed for post %s", c.at_uri)
             return None

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -4,7 +4,6 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
-import httpx
 import pytest
 
 from ..models import CandidatePost
@@ -405,9 +404,7 @@ class TestScoreCandidates:
             _make_candidate("at://a/1", content="some content"),
             _make_candidate("at://a/2", content="other content"),
         ]
-        rate_limit_response = MagicMock()
-        rate_limit_response.status_code = 429
-        rate_limit_exc = httpx.HTTPStatusError("429", request=MagicMock(), response=rate_limit_response)
+        rate_limit_exc = aiohttp.ClientResponseError(request_info=MagicMock(), history=(), status=429)
         fake = MagicMock()
         fake.score = AsyncMock(side_effect=[rate_limit_exc, 0.7])
 
@@ -440,3 +437,29 @@ class TestScoreCandidates:
             result = asyncio.run(score_candidates(candidates))
 
         assert len(result) == 5
+
+
+class TestClosePerspectiveClient:
+    @pytest.fixture(autouse=True)
+    def _reset_client(self):
+        perspective_module._client = None
+        yield
+        perspective_module._client = None
+
+    def test_closes_singleton_and_resets_module_state(self):
+        import asyncio
+
+        fake_client = MagicMock()
+        fake_client.close = AsyncMock()
+        perspective_module._client = fake_client
+
+        asyncio.run(perspective_module.close_perspective_client())
+
+        fake_client.close.assert_awaited_once()
+        assert perspective_module._client is None
+
+    def test_noop_when_no_singleton_created(self):
+        import asyncio
+
+        perspective_module._client = None
+        asyncio.run(perspective_module.close_perspective_client())  # must not raise

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -404,7 +404,9 @@ class TestScoreCandidates:
             _make_candidate("at://a/1", content="some content"),
             _make_candidate("at://a/2", content="other content"),
         ]
-        rate_limit_exc = aiohttp.ClientResponseError(request_info=MagicMock(), history=(), status=429)
+        rate_limit_exc = aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=429
+        )
         fake = MagicMock()
         fake.score = AsyncMock(side_effect=[rate_limit_exc, 0.7])
 

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -1,5 +1,6 @@
 """Tests for PRC scoring and Perspective API candidate scoring."""
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -18,6 +19,28 @@ def _reset_rate_limiter():
     yield
     perspective_module._rate_bucket_minute = -1
     perspective_module._rate_count = 0
+
+
+# ---------------------------------------------------------------------------
+# _perspective_url
+# ---------------------------------------------------------------------------
+
+
+class TestPerspectiveUrl:
+    def test_default_host(self):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GE_PERSPECTIVE_HOST", None)
+            assert (
+                perspective_module._perspective_url()
+                == "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze"
+            )
+
+    def test_custom_host_override(self):
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_HOST": "http://127.0.0.1:8099"}):
+            assert (
+                perspective_module._perspective_url()
+                == "http://127.0.0.1:8099/v1alpha1/comments:analyze"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -3,6 +3,7 @@
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import httpx
 import pytest
 
@@ -132,59 +133,192 @@ def _fake_client(scores: list[float]) -> MagicMock:
     return client
 
 
+class _FakeResponseCM:
+    """Async context manager mimicking aiohttp's ClientSession.post() return value."""
+
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _TimeoutCM:
+    """Async context manager that raises TimeoutError on entry, simulating a
+    request that blew past aiohttp.ClientTimeout."""
+
+    async def __aenter__(self):
+        raise TimeoutError()
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+def _fake_response(
+    status: int = 200, json_body: dict | None = None, text_body: str = ""
+) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_body or {})
+    response.text = AsyncMock(return_value=text_body)
+    if status >= 400:
+        response.raise_for_status = MagicMock(
+            side_effect=aiohttp.ClientResponseError(
+                request_info=MagicMock(), history=(), status=status
+            )
+        )
+    else:
+        response.raise_for_status = MagicMock()
+    return response
+
+
+_SUCCESS_ATTR_SCORES = {name: {"summaryScore": {"value": 0.5}} for name in _ALL_PRC_ATTRS}
+_SUCCESS_BODY = {"attributeScores": _SUCCESS_ATTR_SCORES}
+
+
 class TestPerspectiveClientScore:
     def test_language_not_supported_raises_specific_error(self):
         """A 400 LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE response should raise
-        PerspectiveLanguageNotSupportedError, not a generic HTTPStatusError,
+        PerspectiveLanguageNotSupportedError, not a generic ClientResponseError,
         so callers can handle it gracefully without treating it as an API bug."""
         import asyncio
-        import json
 
         from .perspective import PerspectiveClient
 
-        body = json.dumps({"error": {"code": 400, "details": [{"errorType": "LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE"}]}})
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 400
-        mock_response.text = body
-        mock_response.json.return_value = json.loads(body)
-        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
+        body = {
+            "error": {
+                "code": 400,
+                "details": [
+                    {
+                        "errorType": "LANGUAGE_NOT_SUPPORTED_BY_ATTRIBUTE",
+                        "languageNotSupportedByAttributeError": {"detectedLanguages": ["ja"]},
+                    }
+                ],
+            }
+        }
+        response = _fake_response(status=400, json_body=body)
+        session = MagicMock()
+        session.post = MagicMock(return_value=_FakeResponseCM(response))
 
-        mock_client = MagicMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
 
-        with (
-            patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}),
-            patch("app.lib.perspective.get_http_client", return_value=mock_client),
-        ):
+        with patch.object(PerspectiveClient, "_get_session", return_value=session):
             with pytest.raises(PerspectiveLanguageNotSupportedError):
-                asyncio.run(PerspectiveClient().score("にじほ"))
+                asyncio.run(client.score("にじほ"))
 
-    def test_other_400_still_raises_http_error(self):
-        """Non-language 400s should still propagate as HTTPStatusError."""
+    def test_other_400_still_raises_client_response_error(self):
+        """Non-language 400s should still propagate as aiohttp.ClientResponseError."""
         import asyncio
-        import json
 
         from .perspective import PerspectiveClient
 
-        body = json.dumps({"error": {"code": 400, "details": [{"errorType": "SOME_OTHER_ERROR"}]}})
-        mock_response = MagicMock()
-        mock_response.is_success = False
-        mock_response.status_code = 400
-        mock_response.text = body
-        mock_response.json.return_value = json.loads(body)
-        exc = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
-        mock_response.raise_for_status.side_effect = exc
+        body = {"error": {"code": 400, "details": [{"errorType": "SOME_OTHER_ERROR"}]}}
+        response = _fake_response(status=400, json_body=body)
+        session = MagicMock()
+        session.post = MagicMock(return_value=_FakeResponseCM(response))
 
-        mock_client = MagicMock()
-        mock_client.post = AsyncMock(return_value=mock_response)
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
 
-        with (
-            patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}),
-            patch("app.lib.perspective.get_http_client", return_value=mock_client),
-        ):
-            with pytest.raises(httpx.HTTPStatusError):
-                asyncio.run(PerspectiveClient().score("bad request"))
+        with patch.object(PerspectiveClient, "_get_session", return_value=session):
+            with pytest.raises(aiohttp.ClientResponseError):
+                asyncio.run(client.score("bad request"))
+
+    def test_timeout_retries_once_then_succeeds(self):
+        """A single timeout should be retried (2 total attempts), matching the
+        PRC reference implementation's retry-once behavior."""
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        response = _fake_response(status=200, json_body=_SUCCESS_BODY)
+        session = MagicMock()
+        session.post = MagicMock(side_effect=[_TimeoutCM(), _FakeResponseCM(response)])
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        with patch.object(PerspectiveClient, "_get_session", return_value=session):
+            score = asyncio.run(client.score("hello"))
+
+        assert score == pytest.approx(_prc_score({name: 0.5 for name in _ALL_PRC_ATTRS}))
+        assert session.post.call_count == 2
+
+    def test_timeout_exhausts_retries_raises(self):
+        """Two consecutive timeouts should give up and raise, not retry forever."""
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        session = MagicMock()
+        session.post = MagicMock(side_effect=[_TimeoutCM(), _TimeoutCM()])
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        with patch.object(PerspectiveClient, "_get_session", return_value=session):
+            with pytest.raises(TimeoutError):
+                asyncio.run(client.score("hello"))
+
+        assert session.post.call_count == 2
+
+    def test_session_uses_unlimited_connection_pool(self):
+        """The Perspective client's connector must set limit=0/limit_per_host=0
+        so a burst of concurrent scoring calls can't be starved by a default
+        pool size -- the root cause investigated in issue #250."""
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        async def _build():
+            with (
+                patch("app.lib.perspective.aiohttp.TCPConnector") as mock_connector,
+                patch("app.lib.perspective.aiohttp.ClientSession") as mock_session_cls,
+            ):
+                client._get_session()
+                mock_connector.assert_called_once_with(
+                    limit=0,
+                    limit_per_host=0,
+                    enable_cleanup_closed=True,
+                    keepalive_timeout=45,
+                )
+                mock_session_cls.assert_called_once_with(connector=mock_connector.return_value)
+
+        asyncio.run(_build())
+
+    def test_close_closes_session_and_resets(self):
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        fake_session = MagicMock()
+        fake_session.close = AsyncMock()
+        client._session = fake_session
+
+        asyncio.run(client.close())
+
+        fake_session.close.assert_awaited_once()
+        assert client._session is None
+
+    def test_close_is_noop_when_never_opened(self):
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        asyncio.run(client.close())  # must not raise
 
 
 class TestScoreCandidates:

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -42,6 +42,7 @@ from .lib.es_client import SlowQueryLoggingES
 from .lib.feed_cache import FirestoreFeedCache
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
+from .lib.perspective import close_perspective_client
 from .lib.metrics import MetricCollector, set_metric_collector
 from .lib.posthog_client import get_posthog_client, init_posthog_client, set_posthog_client
 from .lib.profiling import install_profiling
@@ -120,6 +121,10 @@ async def lifespan(app: FastAPI):
             pass
         try:
             await close_http_client()
+        except Exception:
+            pass
+        try:
+            await close_perspective_client()
         except Exception:
             pass
         try:


### PR DESCRIPTION
Closes #250

The ranking pipeline scores every candidate concurrently via `asyncio.gather`, but `PerspectiveClient` shared the process-wide `httpx.AsyncClient` with default (bounded) connection-pool limits, causing head-of-line blocking under concurrent scoring bursts.

# This PR

- Add `GE_PERSPECTIVE_HOST` env var override for the Perspective API URL, enabling local profiling against a mock server
- Migrate `PerspectiveClient` to its own dedicated `aiohttp.ClientSession` with an unbounded connection pool (`limit=0`, `limit_per_host=0`, `keepalive_timeout=45`), matching the PRC reference implementation — the shared `httpx.AsyncClient` in `http_client.py` and its other callers (`two_tower.py`, `inference.py`, `bsky.py`) are untouched
- Add a 1s per-request timeout with one retry (2 total attempts) on timeout only
- Update `score_candidates()`'s exception handling for `aiohttp.ClientResponseError` (was `httpx.HTTPStatusError`), and add `close_perspective_client()` wired into app shutdown
- Add `scripts/profile_perspective.py`: a local mock-server harness that reuses the existing `pyinstrument` profiling config from `app.lib.profiling` to drive synthetic concurrent scoring load, so before/after impact can be measured without a live `GE_PERSPECTIVE_API_KEY` or real API quota

# Testing

- `pipenv run pytest src/app -q` — 552 passed
- `pipenv run ruff check` / `pipenv run pyright` clean on all touched files
- Profiling harness run before/after the fix (500 synthetic candidates, 0.2s mock server latency per request):
  - Before: 11.31s elapsed (56x the theoretical fully-parallel floor)
  - After: 0.40s elapsed (within 2x of the floor) — a ~28x speedup, confirming the connection pool was the bottleneck and is resolved by this change