### PR TITLE
Fix intermittent metric outages caused by multi-instance write collisions

### DIFF
--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -52,6 +52,15 @@ class MetricCollector:
             )
             exporter = CloudMonitoringMetricsExporter(
                 prefix="custom.googleapis.com/greenearth-api",
+                # Cloud Run scales this service to multiple concurrent
+                # instances, each running its own exporter. GCP's generic_node
+                # monitored resource doesn't distinguish between instances, so
+                # without a per-exporter unique identifier, two instances
+                # exporting the same metric+label combination in the same
+                # interval collide on GCP's cumulative-point ordering check
+                # and the entire batch write is rejected -- silently dropping
+                # metrics for every series in that batch (see issue #263).
+                add_unique_identifier=True,
             )
             reader: Any | None = PeriodicExportingMetricReader(
                 exporter,

--- a/src/app/lib/metrics_test.py
+++ b/src/app/lib/metrics_test.py
@@ -1,5 +1,7 @@
 """Tests for MetricCollector."""
 
+from unittest.mock import patch
+
 import pytest
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
@@ -170,6 +172,29 @@ def test_same_instrument_reused_across_calls():
                     # Both values should be in the same histogram
                     dp = metric.data.data_points[0]
                     assert dp.count == 2
+
+
+# ---------------------------------------------------------------------------
+# GCP exporter construction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("env", ["stage", "prod"])
+def test_gcp_exporter_uses_unique_identifier(env):
+    """Cloud Run scales greenearth-api to multiple concurrent instances, each
+    running its own exporter. Without a unique identifier per exporter, two
+    instances exporting the same metric+label combination in the same
+    interval collide on GCP's cumulative point ordering and the whole batch
+    write is rejected (see issue #263)."""
+    with patch(
+        "opentelemetry.exporter.cloud_monitoring.CloudMonitoringMetricsExporter"
+    ) as mock_exporter_cls:
+        MetricCollector(
+            service_name="test-svc",
+            env=env,
+            export_interval_sec=60,
+        )
+    _, kwargs = mock_exporter_cls.call_args
+    assert kwargs.get("add_unique_identifier") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #263

Cloud Run scales `greenearth-api-prod` to multiple concurrent instances (`minScale=1`, `maxScale=10`). GCP's Cloud Monitoring `generic_node` resource used for our custom OTel metrics doesn't distinguish between instances, so when 2+ instances export the same metric+label series within the same interval, GCP rejects the entire batch write with `400 Points must be written in order` — silently dropping metrics for every series in that batch. Confirmed via GCP logs: the error started 2026-07-12 21:00 UTC and stopped exactly at the 2026-07-13 03:30 UTC deploy (revisions 00123/00124), matching the "deploy fixed it" comment on the issue — a redeploy only resets to a single instance temporarily, so it recurs once autoscaling adds a second instance under load, with no human trigger.

# This PR

- Pass `add_unique_identifier=True` to `CloudMonitoringMetricsExporter` in `src/app/lib/metrics.py`, which is the library's built-in mechanism for exactly this scenario (multiple exporters writing the same metric name within the export interval)
- Add `test_gcp_exporter_uses_unique_identifier` in `metrics_test.py` asserting the exporter is constructed with this flag for `stage`/`prod`

# Testing

- New test confirmed red (asserts `add_unique_identifier=True`) before the fix, green after
- Full test suite: `pytest src/` — 551 passed
- Root cause confirmed via `gcloud logging read` against `greenearth-471522`, correlating error timestamps with `gcloud run revisions list` deploy times