### PR TITLE
Default GE_FAIL_FAST=false in deploy.sh to prevent accidental enable

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -250,7 +250,12 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-env-vars=GE_PROBE_USER_DID=did:plc:s4tl2ajfsnstzuxtegl7r33g"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_CANDIDATE_GENERATOR_TIMEOUT_SEC=15"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_POSTHOG_HOST=$GE_POSTHOG_HOST"
-    deploy_cmd="$deploy_cmd --set-env-vars=GE_FAIL_FAST=true"
+    # NOTE: keep this false until the Perspective API timeout and ES generator
+    # connection errors under investigation in #270/#271 are resolved --
+    # enabling fail-fast while those are unaddressed would turn silent,
+    # swallowed failures into user-visible "feed unavailable" errors on every
+    # occurrence.
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_FAIL_FAST=false"
 
     if [ -n "$GE_INFERENCE_BASE_URL" ]; then
         deploy_cmd="$deploy_cmd --set-env-vars=GE_INFERENCE_BASE_URL=$GE_INFERENCE_BASE_URL"


### PR DESCRIPTION
Related to #270 and #271. Investigation for both issues is in progress; this PR is a standalone safety measure that doesn't depend on that investigation's conclusions.

PR #216 added the `GE_FAIL_FAST` flag with `deploy.sh` hardcoding it to `true` for both stage and prod. However, `deploy.sh` has not actually been run against prod since #216 merged (Jul 17 22:21 UTC) — the current prod revision (`greenearth-api-prod-00132-wcv`) predates that merge and does not have the fail-fast code path at all.

# This PR

- Change `deploy.sh` to set `GE_FAIL_FAST=false` on deploy instead of `true`, so the next deployment of `main` doesn't silently turn on fail-fast.

Investigation into #270/#271 found active Perspective API timeouts and intermittent ES generator connection errors that are currently being swallowed (soft-fail) in prod. Flipping `GE_FAIL_FAST=true` before those are addressed would convert those into user-visible "feed unavailable" 500s on every occurrence, which is a worse outcome than the current silent degradation. Once the underlying errors are resolved/mitigated, this can be flipped back to `true` in a follow-up PR alongside deploying #216's actual fail-fast behavior on purpose.

# Testing

- Reviewed `scripts/deploy.sh` diff manually — single-line env var change, no other logic touched
- No code path changes; `lib/config.py:fail_fast()` behavior itself is untouched, only the deploy-time default