### PR TITLE
Grant firebase-adminsdk deployer prod IAM roles for Cloud Function/Firebase deploys

### DIFF
--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -441,6 +441,45 @@ create_service_account() {
     log_info "IAM roles granted successfully"
 }
 
+ensure_frontend_deployer_roles() {
+    # The frontend repo (greenearth-social/frontend) deploys Cloud Functions,
+    # Firebase Hosting, and Firebase Rules via this service account. Stage
+    # deploys don't touch Cloud Functions, so these roles are only needed
+    # for prod. See https://github.com/greenearth-social/api/issues/273
+    local deployer_sa="firebase-adminsdk-fbsvc@$PROJECT_ID.iam.gserviceaccount.com"
+    local runtime_sa="21637448064-compute@developer.gserviceaccount.com"
+    local cloudbuild_sa="21637448064@cloudbuild.gserviceaccount.com"
+
+    log_info "Granting frontend deployer roles to $deployer_sa..."
+
+    local project_roles=(
+        "roles/serviceusage.serviceUsageViewer"
+        "roles/serviceusage.apiKeysViewer"
+        "roles/firebasehosting.admin"
+        "roles/cloudfunctions.admin"
+        "roles/firebaserules.admin"
+    )
+
+    for role in "${project_roles[@]}"; do
+        gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+            --member="serviceAccount:$deployer_sa" \
+            --role="$role" \
+            --condition=None > /dev/null
+    done
+
+    gcloud iam service-accounts add-iam-policy-binding "$runtime_sa" \
+        --member="serviceAccount:$deployer_sa" \
+        --role="roles/iam.serviceAccountUser" \
+        --project="$PROJECT_ID" > /dev/null
+
+    gcloud iam service-accounts add-iam-policy-binding "$cloudbuild_sa" \
+        --member="serviceAccount:$deployer_sa" \
+        --role="roles/iam.serviceAccountUser" \
+        --project="$PROJECT_ID" > /dev/null
+
+    log_info "Frontend deployer roles granted successfully"
+}
+
 setup_secrets() {
     log_info "Setting up secrets in Secret Manager..."
 
@@ -769,6 +808,10 @@ main() {
     setup_posthog_secret
     check_vpc_connector
     setup_feed_probe_cloud_scheduler
+
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        ensure_frontend_deployer_roles
+    fi
 
     echo ""
     log_info "✓ GCP setup complete!"


### PR DESCRIPTION
Closes #273

Frontend prod deploys (from https://github.com/greenearth-social/frontend/) need to deploy Cloud Functions, Firebase Hosting, and Firebase Rules. The deployer service account didn't have the IAM roles for these operations in prod — they were only configured for stage.

# This PR

- Add `ensure_frontend_deployer_roles` to `scripts/gcp_setup.sh`, granting `firebase-adminsdk-fbsvc@<project>.iam.gserviceaccount.com`:
  - `roles/serviceusage.serviceUsageViewer`, `roles/serviceusage.apiKeysViewer`, `roles/firebasehosting.admin`, `roles/cloudfunctions.admin`, `roles/firebaserules.admin` at the project level
  - `roles/iam.serviceAccountUser` on the runtime service account (`21637448064-compute@developer.gserviceaccount.com`) and the Cloud Build service account (`21637448064@cloudbuild.gserviceaccount.com`)
- Call this only when `--environment prod`, since stage doesn't deploy Cloud Functions

# Testing

- `bash -n scripts/gcp_setup.sh` — syntax check passes
- Not yet run against the live prod project — run `./scripts/gcp_setup.sh --environment prod` to apply the grants