### PR TITLE
fix: provision Cloud Build service agent before granting it a role

### DIFF
--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -448,9 +448,18 @@ ensure_frontend_deployer_roles() {
     # for prod. See https://github.com/greenearth-social/api/issues/273
     local deployer_sa="firebase-adminsdk-fbsvc@$PROJECT_ID.iam.gserviceaccount.com"
     local runtime_sa="21637448064-compute@developer.gserviceaccount.com"
-    local cloudbuild_sa="21637448064@cloudbuild.gserviceaccount.com"
 
     log_info "Granting frontend deployer roles to $deployer_sa..."
+
+    # The legacy Cloud Build service agent isn't provisioned until something
+    # triggers its creation (e.g. a build, or this identity call). Projects
+    # that have enabled the Cloud Build API but never run a build won't have
+    # it yet, so ensure it exists before granting a role on it.
+    local cloudbuild_sa
+    cloudbuild_sa=$(gcloud services identity create \
+        --service=cloudbuild.googleapis.com \
+        --project="$PROJECT_ID" \
+        --format="value(email)")
 
     local project_roles=(
         "roles/serviceusage.serviceUsageViewer"


### PR DESCRIPTION
Closes #273

Running `./scripts/gcp_setup.sh --environment prod` failed with:

```
ERROR: (gcloud.iam.service-accounts.add-iam-policy-binding) NOT_FOUND: Service account
projects/greenearth-471522/serviceAccounts/21637448064@cloudbuild.gserviceaccount.com does not exist.
```

The Cloud Build API was enabled on the project, but no build had ever run, so GCP hadn't lazily provisioned the legacy Cloud Build service agent yet.

# This PR

- In `ensure_frontend_deployer_roles`, call `gcloud services identity create --service=cloudbuild.googleapis.com` to provision (or fetch, if already provisioned) the Cloud Build service agent before granting it `roles/iam.serviceAccountUser`, instead of assuming the account already exists

# Testing

- `bash -n scripts/gcp_setup.sh` — syntax check passes
- Not yet re-run against the live prod project — run `./scripts/gcp_setup.sh --environment prod` to confirm the grant now succeeds