### PR TITLE
fix: grant frontend deployer role on Compute Engine default SA only

### DIFF
--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -456,7 +456,7 @@ ensure_frontend_deployer_roles() {
     # that have enabled the Cloud Build API but never run a build won't have
     # it yet, so ensure it exists before granting a role on it.
     local cloudbuild_sa
-    cloudbuild_sa=$(gcloud services identity create \
+    cloudbuild_sa=$(gcloud beta services identity create \
         --service=cloudbuild.googleapis.com \
         --project="$PROJECT_ID" \
         --format="value(email)")

--- a/scripts/gcp_setup.sh
+++ b/scripts/gcp_setup.sh
@@ -451,16 +451,6 @@ ensure_frontend_deployer_roles() {
 
     log_info "Granting frontend deployer roles to $deployer_sa..."
 
-    # The legacy Cloud Build service agent isn't provisioned until something
-    # triggers its creation (e.g. a build, or this identity call). Projects
-    # that have enabled the Cloud Build API but never run a build won't have
-    # it yet, so ensure it exists before granting a role on it.
-    local cloudbuild_sa
-    cloudbuild_sa=$(gcloud beta services identity create \
-        --service=cloudbuild.googleapis.com \
-        --project="$PROJECT_ID" \
-        --format="value(email)")
-
     local project_roles=(
         "roles/serviceusage.serviceUsageViewer"
         "roles/serviceusage.apiKeysViewer"
@@ -476,12 +466,13 @@ ensure_frontend_deployer_roles() {
             --condition=None > /dev/null
     done
 
+    # Cloud Build now defaults to the Compute Engine default service account
+    # for builds (Google rolled this out project-wide in May/June 2024), so
+    # granting serviceAccountUser here is sufficient. The legacy Cloud Build
+    # service account (PROJECT_NUMBER@cloudbuild.gserviceaccount.com) isn't
+    # provisioned for projects created after that change, and Google-managed
+    # accounts don't accept IAM policy bindings even if they did exist.
     gcloud iam service-accounts add-iam-policy-binding "$runtime_sa" \
-        --member="serviceAccount:$deployer_sa" \
-        --role="roles/iam.serviceAccountUser" \
-        --project="$PROJECT_ID" > /dev/null
-
-    gcloud iam service-accounts add-iam-policy-binding "$cloudbuild_sa" \
         --member="serviceAccount:$deployer_sa" \
         --role="roles/iam.serviceAccountUser" \
         --project="$PROJECT_ID" > /dev/null


### PR DESCRIPTION
Closes #273

Follow-up on the earlier fix attempt in this PR (switching to `gcloud beta services identity create`). That got past the "Invalid choice" error, but hit a new one:

```
ERROR: (gcloud.iam.service-accounts.add-iam-policy-binding) NOT_FOUND: Service account
projects/greenearth-471522/serviceAccounts/21637448064@cloudbuild.gserviceaccount.com does not exist.
```

Turns out this project doesn't have (and can't get) the legacy Cloud Build service account. Google changed the default Cloud Build behavior project-wide in May/June 2024: new projects use the Compute Engine default service account for builds instead of the legacy `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` account. That legacy account is Google-managed and simply isn't provisioned for projects created after the change — and even where it does exist, Google docs say it doesn't accept IAM policy bindings. See:
- https://docs.cloud.google.com/build/docs/cloud-build-service-account-updates
- https://docs.cloud.google.com/build/docs/cloud-build-service-account

# This PR

- Remove the `gcloud beta services identity create` call and the legacy Cloud Build SA `serviceAccountUser` grant from `ensure_frontend_deployer_roles` in `scripts/gcp_setup.sh`
- Keep the `serviceAccountUser` grant on the Compute Engine default service account (`21637448064-compute@developer.gserviceaccount.com`), which is what Cloud Build actually uses for builds in this project

# Testing

- `bash -n scripts/gcp_setup.sh` — syntax check passes
- Not yet re-run against the live prod project — run `./scripts/gcp_setup.sh --environment prod` to confirm the grants now succeed end-to-end