### PR TITLE
Change Ranker Ranges to 0..1

### DIFF
--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -534,7 +534,7 @@ def _render_show(doc: FeedDebugDocument) -> None:
     if doc.model_scores:
         console.print(
             "[dim]model scores = each rank model's per-candidate score normalized to "
-            "[-1, 1], with its configured weight — the inputs to the combined "
+            "[0, 1], with its configured weight — the inputs to the combined "
             "(model) score above[/dim]"
         )
     console.print()

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -212,7 +212,7 @@ class FeedDebugScoreEntry(BaseModel):
 class FeedDebugModelScoreEntry(BaseModel):
     """One rank model's contribution to the combined ranking.
 
-    Captures the model's normalized (to [-1, 1]) per-candidate scores and its
+    Captures the model's normalized (to [0, 1]) per-candidate scores and its
     configured relative weight — i.e. the inputs to the weighted-average
     combination — so the combined score in ``ranking`` can be explained.
     The final combined score is intentionally *not* duplicated here.
@@ -222,7 +222,7 @@ class FeedDebugModelScoreEntry(BaseModel):
     weight: float = Field(..., description="Configured relative weight for this model")
     scores: list[FeedDebugScoreEntry] = Field(
         default_factory=list,
-        description="Per-candidate scores after normalization to [-1, 1]",
+        description="Per-candidate scores after normalization to [0, 1]",
     )
 
 
@@ -298,7 +298,7 @@ class FeedDebugDocument(BaseModel):
     )
     model_scores: list[FeedDebugModelScoreEntry] = Field(
         default_factory=list,
-        description="Per-model normalized ([-1, 1]) scores and configured weight, "
+        description="Per-model normalized ([0, 1]) scores and configured weight, "
         "in the order rank models ran (empty when no ranking ran)",
     )
     order_after_rank: list[str] = Field(

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -106,7 +106,7 @@ FEEDS: dict[str, FeedConfig] = {
         # See "cutoff-preview" below for the live preview of this feed's pipeline
         # with the same thresholds.
         max_render_share=0.5,
-        min_rank_score=-0.15,
+        min_rank_score=0.4,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
@@ -141,7 +141,8 @@ FEEDS: dict[str, FeedConfig] = {
         # wasn't separately sampled, so treat it as a starting point to revisit
         # once its own metrics are live.
         max_render_share=0.5,
-        min_rank_score=-0.15,
+        min_rank_score=0.4,
+        min_rank_score=0.5,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -97,12 +97,11 @@ FEEDS: dict[str, FeedConfig] = {
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mrash36z5b2c",
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
-        # min_rank_score=-0.15 is calibrated from real combined rank_score
-        # distributions pulled from stage feed_debug records for this feed (242
-        # ranked candidates across 4 real loads): the theoretical [-1, 1] midpoint
-        # (0.0) sits around the empirical p40-50, so it would cut roughly half of
-        # all candidates by itself; -0.15 sits at ~p12-13, trimming only the clear
-        # tail and leaving max_render_share as the dominant lever on render volume.
+        # min_rank_score=0.425 maps the old -0.15 floor into the current [0, 1]
+        # combined rank-score range. That value was calibrated from stage
+        # feed_debug records for this feed (242 ranked candidates across 4 real
+        # loads), where it sat at ~p12-13 and trimmed only the clear tail,
+        # leaving max_render_share as the dominant lever on render volume.
         # See "cutoff-preview" below for the live preview of this feed's pipeline
         # with the same thresholds.
         max_render_share=0.5,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -186,22 +186,26 @@ FEEDS: dict[str, FeedConfig] = {
         # Values below are calibrated from real combined rank_score and MMR
         # pick_score distributions pulled from stage feed_debug records (242
         # ranked candidates across 4 real "your-feed" loads from 2 debug-enabled
-        # stage users, 2026-07-14 to 2026-07-21), not the theoretical [-1, 1]
-        # midpoint used as the initial guess for your-feed/best-of-friends.
+        # stage users, 2026-07-14 to 2026-07-21). Those records used the old
+        # [-1, 1] combined rank-score range, so the rank-score numbers below
+        # are mapped into the current [0, 1] range.
         #
-        # Empirically the combined score skews well below 0 (p10=-0.21,
-        # p25=-0.07, p50=+0.07) — a floor at the theoretical midpoint (0.0)
-        # would cut roughly half of all candidates by itself, before MMR or the
-        # share cap get a say. min_rank_score=-0.15 sits at ~p12-13, trimming
-        # only the clearly-bad tail and leaving max_render_share as the
-        # dominant lever on render volume, matching the issue's 10-50% band.
+        # Empirically the old combined score skewed below the old midpoint
+        # (old p10=-0.21, p25=-0.07, p50=+0.07; current p10=0.395,
+        # p25=0.465, p50=0.535). A floor at the current midpoint (0.5) would
+        # cut roughly half of all candidates by itself, before MMR or the share
+        # cap get a say. min_rank_score=0.425 is the old -0.15 floor mapped via
+        # (score + 1) / 2; it sits at ~p12-13, trimming only the clearly-bad
+        # tail and leaving max_render_share as the dominant lever on render
+        # volume, matching the issue's 10-50% band.
         #
-        # MMR pick_score p10=+0.01, and the observed minimums (-0.52, -0.08,
-        # -0.08, -0.06) show -0.05 already sits below almost all real picks —
-        # it only fires on genuine outliers, so it's left at the same starting
-        # value used for your-feed/best-of-friends.
+        # MMR pick_score is a post-diversification penalized score, not a rank
+        # score, so it can still be negative. The old observed p10=+0.01 and
+        # minimums (-0.52, -0.08, -0.08, -0.06) show -0.05 already sits below
+        # almost all real picks; keep it as the starting point until fresh
+        # post-migration debug records are available.
         max_render_share=0.5,
-        min_rank_score=-0.15,
+        min_rank_score=0.425,
         min_mmr_score=-0.05,
     ),
 

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -106,7 +106,7 @@ FEEDS: dict[str, FeedConfig] = {
         # See "cutoff-preview" below for the live preview of this feed's pipeline
         # with the same thresholds.
         max_render_share=0.5,
-        min_rank_score=0.4,
+        min_rank_score=0.425,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
@@ -141,8 +141,7 @@ FEEDS: dict[str, FeedConfig] = {
         # wasn't separately sampled, so treat it as a starting point to revisit
         # once its own metrics are live.
         max_render_share=0.5,
-        min_rank_score=0.4,
-        min_rank_score=0.5,
+        min_rank_score=0.425,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="followed_users", weight=1.0)],

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -63,7 +63,7 @@ class TestFeedsRegistry:
         for feed_name in ("your-feed", "best-of-friends"):
             cfg = FEEDS[feed_name]
             assert cfg.max_render_share is not None
-            assert cfg.min_rank_score == pytest.approx(0.5)
+            assert cfg.min_rank_score == pytest.approx(0.425)
             assert cfg.min_mmr_score is not None
 
     def test_unranked_feeds_have_no_slate_cutoffs(self):

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -90,5 +90,5 @@ class TestFeedsRegistry:
             == FEEDS["your-feed"].gen_request_template.generators
         )
         assert cfg.max_render_share == pytest.approx(0.5)
-        assert cfg.min_rank_score == pytest.approx(-0.15)
+        assert cfg.min_rank_score == pytest.approx(0.425)
         assert cfg.min_mmr_score == pytest.approx(-0.05)

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -63,7 +63,7 @@ class TestFeedsRegistry:
         for feed_name in ("your-feed", "best-of-friends"):
             cfg = FEEDS[feed_name]
             assert cfg.max_render_share is not None
-            assert cfg.min_rank_score is not None
+            assert cfg.min_rank_score == pytest.approx(0.5)
             assert cfg.min_mmr_score is not None
 
     def test_unranked_feeds_have_no_slate_cutoffs(self):

--- a/src/app/lib/feed_debug.py
+++ b/src/app/lib/feed_debug.py
@@ -96,7 +96,7 @@ class FeedDebugRecorder:
     def record_model_scores(self, model_name: str, weight: float, scores: dict[str, float]) -> None:
         """Record one rank model's normalized per-candidate scores and weight.
 
-        Captures the score *after* normalization to [-1, 1] (the form the
+        Captures the score *after* normalization to [0, 1] (the form the
         scores are in when combined), not the model's raw output — and not
         the final combined score, which is already captured via `ranking`.
         """

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -137,19 +137,19 @@ class TestBuildDocument:
 
     def test_includes_model_scores(self):
         rec = self._recorder()
-        rec.record_model_scores("two_tower", 1.0, {"at://p/1": 0.8, "at://p/2": -0.2})
-        rec.record_model_scores("perspective", 2.0, {"at://p/1": -0.5, "at://p/2": 0.1})
+        rec.record_model_scores("two_tower", 1.0, {"at://p/1": 0.8, "at://p/2": 0.2})
+        rec.record_model_scores("perspective", 2.0, {"at://p/1": 0.25, "at://p/2": 0.1})
         doc = self._build(rec)
 
         assert [e.model_name for e in doc.model_scores] == ["two_tower", "perspective"]
         assert doc.model_scores[0].weight == 1.0
         assert {s.at_uri: s.score for s in doc.model_scores[0].scores} == {
             "at://p/1": 0.8,
-            "at://p/2": -0.2,
+            "at://p/2": 0.2,
         }
         assert doc.model_scores[1].weight == 2.0
         assert {s.at_uri: s.score for s in doc.model_scores[1].scores} == {
-            "at://p/1": -0.5,
+            "at://p/1": 0.25,
             "at://p/2": 0.1,
         }
 
@@ -224,11 +224,11 @@ class TestModelScoreCapture:
     def test_records_one_entry_per_model_in_order(self):
         rec = FeedDebugRecorder(feed_name="f", regenerated=False)
         rec.record_model_scores("two_tower", 1.0, {"at://p/1": 0.8})
-        rec.record_model_scores("perspective", 2.0, {"at://p/1": -0.5})
+        rec.record_model_scores("perspective", 2.0, {"at://p/1": 0.25})
 
         assert rec.model_scores == [
             ("two_tower", 1.0, {"at://p/1": 0.8}),
-            ("perspective", 2.0, {"at://p/1": -0.5}),
+            ("perspective", 2.0, {"at://p/1": 0.25}),
         ]
 
     def test_copies_scores_dict_defensively(self):

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -50,13 +50,12 @@ class PerspectiveLanguageNotSupportedError(Exception):
 # part of this reference formula and is intentionally omitted.
 #
 # Each attribute score from the Perspective API is in [0, 1], so for any
-# weighted sum of attributes the theoretical score bounds are
+# weighted sum of attributes the raw theoretical score bounds are
 # (sum of negative weights, sum of positive weights) — see
-# `_weighted_score_bounds`. This formula's positive weights sum to 1.0
+# `_raw_weighted_score_bounds`. This formula's positive weights sum to 1.0
 # (6 * 1/6) and negative weights sum to -1.0 (2*(-1/6) + 3*(-1/18) +
-# 4*(-1/8)), giving bounds of exactly (-1.0, 1.0) — no rescaling needed
-# beyond the float-precision clamp `_weighted_score_bounds` already performs
-# implicitly via `_normalize`'s clamping in the rank-model pipeline.
+# 4*(-1/8)), giving raw bounds of exactly (-1.0, 1.0). The final PRC score
+# is linearly rescaled into [0, 1] before it enters the rank-model pipeline.
 _PRC_WEIGHTS: dict[str, float] = {
     "REASONING_EXPERIMENTAL": 1 / 6,
     "PERSONAL_STORY_EXPERIMENTAL": 1 / 6,
@@ -97,7 +96,7 @@ def _raw_weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]
 
 def weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
     """Theoretical (min, max) bounds for a weighted sum of Perspective attributes,
-    rescaled to the final score bounds [-1, 1].
+    rescaled to the final score bounds [0, 1].
 
     See `_raw_weighted_score_bounds` for the underlying calculation.
     """
@@ -109,7 +108,7 @@ def weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
 
 
 def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds: tuple[float, float]) -> float:
-    """Linearly map *raw* from *bounds* into the final score bounds [-1, 1]."""
+    """Linearly map *raw* from *original_bounds* into *new_bounds*."""
     orig_lo, orig_hi = original_bounds
     if orig_hi <= orig_lo:
         raise ValueError(f"degenerate original bounds: {original_bounds}")
@@ -120,7 +119,7 @@ def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds:
 
 
 def _prc_score(attr: dict[str, float], weights: dict[str, float] = _PRC_WEIGHTS) -> float:
-    """Score a post as a weighted sum of its Perspective attribute scores."""
+    """Score a post as a weighted sum rescaled into final [0, 1] bounds."""
     raw_score = sum(weight * attr[name] for name, weight in weights.items())
     return _change_bounds(raw_score, _raw_weighted_score_bounds(weights), _FINAL_SCORE_BOUNDS)
 

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -76,7 +76,7 @@ _PRC_WEIGHTS: dict[str, float] = {
 
 _REQUESTED_ATTRIBUTES = {name: {} for name in _PRC_WEIGHTS}
 
-_FINAL_SCORE_BOUNDS = (0.0, 1.0)
+PERSPECTIVE_SCORE_BOUNDS = (0.0, 1.0)
 
 
 def _raw_weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
@@ -94,19 +94,6 @@ def _raw_weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]
     return (lo, hi)
 
 
-def weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
-    """Theoretical (min, max) bounds for a weighted sum of Perspective attributes,
-    rescaled to the final score bounds [0, 1].
-
-    See `_raw_weighted_score_bounds` for the underlying calculation.
-    """
-    raw_lo, raw_hi = _raw_weighted_score_bounds(weights)
-    return (
-        _change_bounds(raw_lo, (raw_lo, raw_hi), _FINAL_SCORE_BOUNDS),
-        _change_bounds(raw_hi, (raw_lo, raw_hi), _FINAL_SCORE_BOUNDS),
-    )
-
-
 def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds: tuple[float, float]) -> float:
     """Linearly map *raw* from *original_bounds* into *new_bounds*."""
     orig_lo, orig_hi = original_bounds
@@ -121,7 +108,7 @@ def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds:
 def _prc_score(attr: dict[str, float], weights: dict[str, float] = _PRC_WEIGHTS) -> float:
     """Score a post as a weighted sum rescaled into final [0, 1] bounds."""
     raw_score = sum(weight * attr[name] for name, weight in weights.items())
-    return _change_bounds(raw_score, _raw_weighted_score_bounds(weights), _FINAL_SCORE_BOUNDS)
+    return _change_bounds(raw_score, _raw_weighted_score_bounds(weights), PERSPECTIVE_SCORE_BOUNDS)
 
 
 class PerspectiveClient:

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -77,8 +77,10 @@ _PRC_WEIGHTS: dict[str, float] = {
 
 _REQUESTED_ATTRIBUTES = {name: {} for name in _PRC_WEIGHTS}
 
+_FINAL_SCORE_BOUNDS = (0.0, 1.0)
 
-def _weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
+
+def _raw_weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
     """Theoretical (min, max) bounds for a weighted sum of Perspective attributes.
 
     Each Perspective API attribute score is in [0, 1]. For a weighted sum
@@ -93,9 +95,34 @@ def _weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
     return (lo, hi)
 
 
+def weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]:
+    """Theoretical (min, max) bounds for a weighted sum of Perspective attributes,
+    rescaled to the final score bounds [-1, 1].
+
+    See `_raw_weighted_score_bounds` for the underlying calculation.
+    """
+    raw_lo, raw_hi = _raw_weighted_score_bounds(weights)
+    return (
+        _change_bounds(raw_lo, (raw_lo, raw_hi), _FINAL_SCORE_BOUNDS),
+        _change_bounds(raw_hi, (raw_lo, raw_hi), _FINAL_SCORE_BOUNDS),
+    )
+
+
+def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds: tuple[float, float]) -> float:
+    """Linearly map *raw* from *bounds* into the final score bounds [-1, 1]."""
+    orig_lo, orig_hi = original_bounds
+    if orig_hi <= orig_lo:
+        raise ValueError(f"degenerate original bounds: {original_bounds}")
+    new_lo, new_hi = new_bounds
+    if new_hi <= new_lo:
+        raise ValueError(f"degenerate new bounds: {new_bounds}")
+    return new_lo + (raw - orig_lo) * (new_hi - new_lo) / (orig_hi - orig_lo)
+
+
 def _prc_score(attr: dict[str, float], weights: dict[str, float] = _PRC_WEIGHTS) -> float:
     """Score a post as a weighted sum of its Perspective attribute scores."""
-    return sum(weight * attr[name] for name, weight in weights.items())
+    raw_score = sum(weight * attr[name] for name, weight in weights.items())
+    return _change_bounds(raw_score, _raw_weighted_score_bounds(weights), _FINAL_SCORE_BOUNDS)
 
 
 class PerspectiveClient:

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -50,7 +50,8 @@ class TestPerspectiveUrl:
 # the PRC reference implementation: 6 positively-weighted "bridging"
 # attributes at +1/6 each, and 9 negatively-weighted attributes split into
 # three groups — 2 "outrage" attrs at -1/6, 3 "outrage" attrs at -1/18, and
-# 4 "toxic" attrs at -1/8 — summing to weights of (-1.0, +1.0).
+# 4 "toxic" attrs at -1/8 — summing to raw weights of (-1.0, +1.0), then
+# rescaled to final scores in [0, 1].
 # ---------------------------------------------------------------------------
 
 _BRIDGING_ATTRS = [
@@ -76,15 +77,15 @@ def _zero_attr() -> dict[str, float]:
 
 
 class TestPrcScore:
-    def test_all_zeros_returns_zero(self):
-        assert _prc_score(_zero_attr()) == pytest.approx(0.0)
+    def test_all_zeros_returns_midpoint(self):
+        assert _prc_score(_zero_attr()) == pytest.approx(0.5)
 
     def test_pure_bridging_returns_positive(self):
         attr = {**_zero_attr(), **dict.fromkeys(_BRIDGING_ATTRS, 1.0)}
-        # 6 attrs at weight 1/6 each, all at 1.0 -> score = 1.0
+        # 6 attrs at weight 1/6 each, all at 1.0 -> raw score = 1.0 -> final score = 1.0
         assert _prc_score(attr) == pytest.approx(1.0)
 
-    def test_pure_negative_returns_negative(self):
+    def test_pure_negative_returns_bottom_score(self):
         attr = {
             **_zero_attr(),
             **dict.fromkeys(_OUTRAGE_SIXTH_ATTRS, 1.0),
@@ -92,8 +93,8 @@ class TestPrcScore:
             **dict.fromkeys(_TOXIC_EIGHTH_ATTRS, 1.0),
         }
         # negative weights sum to -1.0 (2*(-1/6) + 3*(-1/18) + 4*(-1/8)),
-        # all at 1.0 -> score = -1.0
-        assert _prc_score(attr) == pytest.approx(-1.0)
+        # all at 1.0 -> raw score = -1.0 -> final score = 0.0
+        assert _prc_score(attr) == pytest.approx(0.0)
 
     def test_known_mixed_inputs(self):
         attr = {
@@ -102,12 +103,13 @@ class TestPrcScore:
             **dict.fromkeys(_OUTRAGE_EIGHTEENTH_ATTRS, 0.9),
             **dict.fromkeys(_TOXIC_EIGHTH_ATTRS, 0.4),
         }
-        expected = (
+        raw_expected = (
             len(_BRIDGING_ATTRS) * (1 / 6) * 0.6
             + len(_OUTRAGE_SIXTH_ATTRS) * (-1 / 6) * 0.3
             + len(_OUTRAGE_EIGHTEENTH_ATTRS) * (-1 / 18) * 0.9
             + len(_TOXIC_EIGHTH_ATTRS) * (-1 / 8) * 0.4
         )
+        expected = (raw_expected + 1.0) / 2.0
         assert _prc_score(attr) == pytest.approx(expected)
 
 

--- a/src/app/lib/rankers/base.py
+++ b/src/app/lib/rankers/base.py
@@ -46,7 +46,7 @@ class Ranker(ABC):
     def score_bounds(self) -> tuple[float, float]:
         """Theoretical (min, max) bounds of this ranker's raw `rank_score` values.
 
-        Used to linearly normalize raw scores into [-1, 1] before combining
+        Used to linearly normalize raw scores into [0, 1] before combining
         multiple rankers' outputs into a single weighted score.
         """
         ...

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -32,7 +32,7 @@ class HeavyRanker(Ranker):
 
     @property
     def score_bounds(self) -> tuple[float, float]:
-        return (-1.0, 1.0)
+        return (0.0, 1.0)
 
     async def predict(
         self,

--- a/src/app/lib/rankers/heavy_ranker_test.py
+++ b/src/app/lib/rankers/heavy_ranker_test.py
@@ -15,6 +15,10 @@ def _time(hour: int) -> datetime:
     return datetime(2026, 1, 1, hour, tzinfo=timezone.utc)
 
 
+def test_score_bounds_match_inference_service_output_range():
+    assert HeavyRanker().score_bounds == (0.0, 1.0)
+
+
 def test_predict_requires_inference_env_vars(monkeypatch):
     monkeypatch.delenv("GE_INFERENCE_BASE_URL", raising=False)
     monkeypatch.delenv("GE_INFERENCE_API_KEY", raising=False)

--- a/src/app/lib/rankers/perspective.py
+++ b/src/app/lib/rankers/perspective.py
@@ -1,7 +1,7 @@
 """Perspective API ranker.
 
 Scores each candidate's text content for conversational quality via the
-Perspective API (see :mod:`app.lib.perspective`) and exposes the raw PRC
+Perspective API (see :mod:`app.lib.perspective`) and exposes the rescaled PRC
 scores as a `Ranker` so they can be normalized and combined with other rank
 models (e.g. the two-tower model) by `run_predict`.
 """

--- a/src/app/lib/rankers/perspective.py
+++ b/src/app/lib/rankers/perspective.py
@@ -9,7 +9,7 @@ models (e.g. the two-tower model) by `run_predict`.
 import logging
 
 from ...models import CandidatePost, RankedCandidate, RankPredictResult
-from ..perspective import _PRC_WEIGHTS, weighted_score_bounds, score_candidates
+from ..perspective import PERSPECTIVE_SCORE_BOUNDS, score_candidates
 from .base import Ranker, RankerResult
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class PerspectiveRanker(Ranker):
 
     @property
     def score_bounds(self) -> tuple[float, float]:
-        return weighted_score_bounds(_PRC_WEIGHTS)
+        return PERSPECTIVE_SCORE_BOUNDS
 
     async def predict(
         self,

--- a/src/app/lib/rankers/perspective.py
+++ b/src/app/lib/rankers/perspective.py
@@ -9,7 +9,7 @@ models (e.g. the two-tower model) by `run_predict`.
 import logging
 
 from ...models import CandidatePost, RankedCandidate, RankPredictResult
-from ..perspective import _PRC_WEIGHTS, _weighted_score_bounds, score_candidates
+from ..perspective import _PRC_WEIGHTS, weighted_score_bounds, score_candidates
 from .base import Ranker, RankerResult
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ class PerspectiveRanker(Ranker):
 
     @property
     def score_bounds(self) -> tuple[float, float]:
-        return _weighted_score_bounds(_PRC_WEIGHTS)
+        return weighted_score_bounds(_PRC_WEIGHTS)
 
     async def predict(
         self,

--- a/src/app/lib/rankers/perspective_test.py
+++ b/src/app/lib/rankers/perspective_test.py
@@ -25,8 +25,8 @@ class TestPerspectiveRanker:
         # _PRC_WEIGHTS' positive weights sum to 1.0 (6 * 1/6) and negative
         # weights sum to -1.0 (2*(-1/6) + 3*(-1/18) + 4*(-1/8)) — see
         # lib/perspective.py — so the theoretical bounds of the weighted-sum
-        # PRC score are exactly (-1.0, 1.0).
-        assert PerspectiveRanker().score_bounds == (-1.0, 1.0)
+        # PRC score are exactly (-1.0, 1.0), then rescaled to (0.0, 1.0).
+        assert PerspectiveRanker().score_bounds == (0.0, 1.0)
 
     def test_predict_orders_by_prc_score_descending(self):
         candidates = [
@@ -48,9 +48,8 @@ class TestPerspectiveRanker:
         assert [r.rank for r in rankings] == [1, 2, 3]
         assert [r.rank_score for r in rankings] == [0.9, 0.5, 0.1]
 
-    def test_predict_reports_raw_prc_scores_not_normalized(self):
-        """`predict` returns raw PRC scores; normalization into [-1, 1] using
-        `score_bounds` is `run_predict`'s responsibility, not the ranker's."""
+    def test_predict_reports_rescaled_prc_scores(self):
+        """`predict` returns the rescaled PRC scores produced by score_candidates."""
         candidates = [_make_candidate("at://a/1")]
         with patch(
             "app.lib.rankers.perspective.score_candidates",
@@ -93,28 +92,28 @@ class TestPerspectiveRanker:
         by_uri = {r.at_uri: r.rank_score for r in result.result.rankings}
         assert by_uri == {"at://a/1": 0.5, "at://a/2": None}
 
-    def test_predict_orders_real_scores_descending_with_missing_last(self):
+    def test_predict_orders_scores_descending_with_missing_last(self):
         candidates = [
             _make_candidate("at://a/missing", content="missing"),
-            _make_candidate("at://a/negative", content="negative"),
-            _make_candidate("at://a/zero", content="zero"),
-            _make_candidate("at://a/positive", content="positive"),
+            _make_candidate("at://a/low", content="low"),
+            _make_candidate("at://a/mid", content="mid"),
+            _make_candidate("at://a/high", content="high"),
         ]
         with patch(
             "app.lib.rankers.perspective.score_candidates",
             new_callable=AsyncMock,
             return_value={
                 "at://a/missing": None,
-                "at://a/negative": -0.2,
-                "at://a/zero": 0.0,
-                "at://a/positive": 0.7,
+                "at://a/low": 0.2,
+                "at://a/mid": 0.5,
+                "at://a/high": 0.85,
             },
         ):
             result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
 
         assert [(r.at_uri, r.rank, r.rank_score) for r in result.result.rankings] == [
-            ("at://a/positive", 1, 0.7),
-            ("at://a/zero", 2, 0.0),
-            ("at://a/negative", 3, -0.2),
+            ("at://a/high", 1, 0.85),
+            ("at://a/mid", 2, 0.5),
+            ("at://a/low", 3, 0.2),
             ("at://a/missing", 4, None),
         ]

--- a/src/app/lib/rankers/perspective_test.py
+++ b/src/app/lib/rankers/perspective_test.py
@@ -21,13 +21,6 @@ class TestPerspectiveRanker:
     def test_name(self):
         assert PerspectiveRanker().name == "perspective"
 
-    def test_score_bounds_match_weighted_prc_formula(self):
-        # _PRC_WEIGHTS' positive weights sum to 1.0 (6 * 1/6) and negative
-        # weights sum to -1.0 (2*(-1/6) + 3*(-1/18) + 4*(-1/8)) — see
-        # lib/perspective.py — so the theoretical bounds of the weighted-sum
-        # PRC score are exactly (-1.0, 1.0), then rescaled to (0.0, 1.0).
-        assert PerspectiveRanker().score_bounds == (0.0, 1.0)
-
     def test_predict_orders_by_prc_score_descending(self):
         candidates = [
             _make_candidate("at://a/1", content="low quality"),

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -34,9 +34,9 @@ def _normalize(
     """Linearly map *raw* from *bounds* into [0, 1], clamping the result.
 
     Missing scores (``None`` — e.g. a ranker couldn't score a candidate)
-    normalize to ``fallback_normalized_score`` (neutral), matching how individual rankers already
-    treat unscoreable candidates. Degenerate bounds (``hi <= lo``) also
-    normalize to ``fallback_normalized_score`` to avoid division by zero.
+    normalize to ``fallback_normalized_score``. Degenerate bounds
+    (``hi <= lo``) also normalize to ``fallback_normalized_score`` to avoid
+    division by zero.
     """
     if raw is None:
         return fallback_normalized_score
@@ -79,9 +79,9 @@ async def run_predict(
     """Rank the supplied candidates by combining the requested rank models.
 
     Each model runs in parallel; its raw `rank_score`s are normalized into
-    [-1, 1] using its `score_bounds`, then combined into a single score per
+    [0, 1] using its `score_bounds`, then combined into a single score per
     candidate via a weighted average (weights normalized to sum to 1, so the
-    combined score also stays within [-1, 1]). The final ordering is by
+    combined score also stays within [0, 1]). The final ordering is by
     combined score, descending, with ties broken by original candidate order.
     If a candidate at_uri has no valid scores from any model, it is dropped.
     If it has a score from at least one model but not the others, the median

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -1,7 +1,7 @@
 """Shared ranking pipeline.
 
 Given a `RankPredictRequest`, runs each configured rank model in parallel,
-normalizes each model's raw scores into [-1, 1] using its theoretical
+normalizes each model's raw scores into [0, 1] using its theoretical
 `score_bounds`, and combines them into a single ordering via a weighted
 average using each model's configured relative weight.
 """
@@ -31,7 +31,7 @@ def _normalize(
     bounds: tuple[float, float],
     fallback_normalized_score: float,
 ) -> float:
-    """Linearly map *raw* from *bounds* into [-1, 1], clamping the result.
+    """Linearly map *raw* from *bounds* into [0, 1], clamping the result.
 
     Missing scores (``None`` — e.g. a ranker couldn't score a candidate)
     normalize to ``fallback_normalized_score`` (neutral), matching how individual rankers already
@@ -43,8 +43,8 @@ def _normalize(
     lo, hi = bounds
     if hi <= lo:
         return fallback_normalized_score
-    normalized = 2.0 * (raw - lo) / (hi - lo) - 1.0
-    return max(-1.0, min(1.0, normalized))
+    normalized = (raw - lo) / (hi - lo)
+    return max(0.0, min(1.0, normalized))
 
 
 async def _run_one(
@@ -123,7 +123,7 @@ async def run_predict(
         if raw_by_uri:
             bounds = ranker.score_bounds
             raw_median = statistics.median(raw_by_uri.values())
-            medians_by_model[name] = _normalize(raw_median, bounds, 0.0)
+            medians_by_model[name] = _normalize(raw_median, bounds, 0.5)
             models_with_valid_results.append((name, weight, ranker))
         for uri, score in raw_by_uri.items():
             if uri not in results_by_candidate:

--- a/src/app/lib/rankers/predict_test.py
+++ b/src/app/lib/rankers/predict_test.py
@@ -108,15 +108,15 @@ def test_run_predict_raises_for_unknown_model(monkeypatch):
 
 def test_run_predict_normalizes_and_combines_with_weights(monkeypatch):
     """Each model's raw scores are linearly mapped from its `score_bounds` into
-    [-1, 1], then combined via a weighted average (weights normalized to sum
+    [0, 1], then combined via a weighted average (weights normalized to sum
     to 1)."""
     candidates = [
         CandidatePost(at_uri="at://post/a", score=0.5),
         CandidatePost(at_uri="at://post/b", score=0.5),
     ]
 
-    # Model "x": bounds [0, 1] -> raw 1.0 normalizes to 1.0, raw 0.0 to -1.0
-    # Model "y": bounds [-10, 10] -> raw 0.0 normalizes to 0.0 for both
+    # Model "x": bounds [0, 1] -> raw 1.0 normalizes to 1.0, raw 0.0 to 0.0
+    # Model "y": bounds [-10, 10] -> raw 0.0 normalizes to 0.5 for both
     rankers = {
         "x": StubRanker("x", (0.0, 1.0), {"at://post/a": 1.0, "at://post/b": 0.0}),
         "y": StubRanker("y", (-10.0, 10.0), {"at://post/a": 0.0, "at://post/b": 0.0}),
@@ -136,11 +136,11 @@ def test_run_predict_normalizes_and_combines_with_weights(monkeypatch):
         )
     )
 
-    # combined(a) = (3/4)*1.0 + (1/4)*0.0 = 0.75
-    # combined(b) = (3/4)*(-1.0) + (1/4)*0.0 = -0.75
+    # combined(a) = (3/4)*1.0 + (1/4)*0.5 = 0.875
+    # combined(b) = (3/4)*0.0 + (1/4)*0.5 = 0.125
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
-        ("at://post/a", 1, pytest.approx(0.75)),
-        ("at://post/b", 2, pytest.approx(-0.75)),
+        ("at://post/a", 1, pytest.approx(0.875)),
+        ("at://post/b", 2, pytest.approx(0.125)),
     ]
 
 
@@ -198,9 +198,9 @@ def test_run_predict_uses_ranker_median_for_explicit_missing_score(monkeypatch):
     )
 
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
-        ("at://post/a", 1, pytest.approx(0.75)),
-        ("at://post/b", 2, pytest.approx(0.0)),
-        ("at://post/c", 3, pytest.approx(-0.75)),
+        ("at://post/a", 1, pytest.approx(0.875)),
+        ("at://post/b", 2, pytest.approx(0.5)),
+        ("at://post/c", 3, pytest.approx(0.125)),
     ]
 
 
@@ -240,9 +240,9 @@ def test_run_predict_uses_ranker_median_for_omitted_score(monkeypatch):
     )
 
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
-        ("at://post/a", 1, pytest.approx(0.75)),
-        ("at://post/b", 2, pytest.approx(0.0)),
-        ("at://post/c", 3, pytest.approx(-0.75)),
+        ("at://post/a", 1, pytest.approx(0.875)),
+        ("at://post/b", 2, pytest.approx(0.5)),
+        ("at://post/c", 3, pytest.approx(0.125)),
     ]
 
 
@@ -273,7 +273,7 @@ def test_run_predict_ignores_ranker_with_no_valid_scores(monkeypatch):
 
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
         ("at://post/a", 1, pytest.approx(1.0)),
-        ("at://post/b", 2, pytest.approx(-1.0)),
+        ("at://post/b", 2, pytest.approx(0.0)),
     ]
 
 
@@ -305,7 +305,7 @@ def test_run_predict_records_empty_model_scores_for_empty_ranker(monkeypatch):
         )
 
     assert rec.model_scores == [
-        ("x", 1.0, {"at://post/a": pytest.approx(1.0), "at://post/b": pytest.approx(-1.0)}),
+        ("x", 1.0, {"at://post/a": pytest.approx(1.0), "at://post/b": pytest.approx(0.0)}),
         ("empty", 9.0, {}),
     ]
 
@@ -348,7 +348,7 @@ def test_run_predict_treats_zero_scores_as_valid(monkeypatch):
     )
 
     assert [(r.at_uri, r.rank, r.rank_score) for r in result.rankings] == [
-        ("at://post/a", 1, pytest.approx(0.0)),
+        ("at://post/a", 1, pytest.approx(0.5)),
     ]
 
 
@@ -383,8 +383,8 @@ def test_run_predict_records_normalized_model_scores_and_weight(monkeypatch):
         )
 
     assert rec.model_scores == [
-        ("x", 2.0, {"at://post/a": pytest.approx(1.0), "at://post/b": pytest.approx(-1.0)}),
-        ("y", 1.0, {"at://post/a": pytest.approx(0.5), "at://post/b": pytest.approx(-0.5)}),
+        ("x", 2.0, {"at://post/a": pytest.approx(1.0), "at://post/b": pytest.approx(0.0)}),
+        ("y", 1.0, {"at://post/a": pytest.approx(0.75), "at://post/b": pytest.approx(0.25)}),
     ]
 
 
@@ -410,7 +410,7 @@ def test_run_predict_preserves_duplicate_candidate_count(monkeypatch):
     )
 
     assert [r.at_uri for r in result.rankings] == ["at://post/a", "at://post/a", "at://post/b"]
-    assert all(r.rank_score == pytest.approx(0.0) for r in result.rankings)
+    assert all(r.rank_score == pytest.approx(0.5) for r in result.rankings)
     assert [r.rank for r in result.rankings] == [1, 2, 3]
 
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -149,7 +149,7 @@ class RankPredictRequest(BaseModel):
         min_length=1,
         description=(
             "Rank models to run and combine. Each model's scores are normalized "
-            "to [-1, 1] using its theoretical bounds, then combined via a "
+            "to [0, 1] using its theoretical bounds, then combined via a "
             "weighted average using the configured relative weights."
         ),
     )

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -231,7 +231,7 @@ class FeedConfig(BaseModel):
     )
     min_rank_score: float | None = Field(
         None,
-        gt=0.0,
+        ge=0.0,
         le=1.0,
         description="Combined rank-score floor in [0, 1]. Candidates scoring below it "
         "are cut from the slate and recorded as discarded so future generation "

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -231,7 +231,7 @@ class FeedConfig(BaseModel):
     )
     min_rank_score: float | None = Field(
         None,
-        description="Combined rank-score floor in [-1, 1]. Candidates scoring below it "
+        description="Combined rank-score floor in [0, 1]. Candidates scoring below it "
         "are cut from the slate and recorded as discarded so future generation "
         "excludes them. Only applies when rank_request_template is set. None disables.",
     )

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -231,6 +231,8 @@ class FeedConfig(BaseModel):
     )
     min_rank_score: float | None = Field(
         None,
+        gt=0.0,
+        le=1.0,
         description="Combined rank-score floor in [0, 1]. Candidates scoring below it "
         "are cut from the slate and recorded as discarded so future generation "
         "excludes them. Only applies when rank_request_template is set. None disables.",

--- a/src/app/routers/feed_transparency_test.py
+++ b/src/app/routers/feed_transparency_test.py
@@ -783,7 +783,7 @@ def test_get_feed_detail_diverse_pipeline_metadata(
                 ],
                 model_scores=[
                     ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.92),
-                    ModelScoreMeta(name="perspective", weight=1.0, score=-0.15),
+                    ModelScoreMeta(name="perspective", weight=1.0, score=0.425),
                 ],
             )
         ],
@@ -826,4 +826,4 @@ def test_get_feed_detail_diverse_pipeline_metadata(
     assert item["model_scores"][0]["weight"] == 1.0
     assert item["model_scores"][0]["score"] == 0.92
     assert item["model_scores"][1]["weight"] == 1.0
-    assert item["model_scores"][1]["score"] == -0.15
+    assert item["model_scores"][1]["score"] == 0.425

--- a/src/app/routers/rank.py
+++ b/src/app/routers/rank.py
@@ -63,7 +63,7 @@ async def rank_predict(
     """Score and order candidate posts by combining one or more rank models.
 
     Each model in `models` is run in parallel; its raw scores are normalized
-    into [-1, 1] using the model's theoretical score bounds, then combined
+    into [0, 1] using the model's theoretical score bounds, then combined
     into a single score per candidate via a weighted average using each
     model's relative `weight`.  The response lists candidates in descending
     combined-score order with 1-based `rank` positions.  Pass the output of

--- a/src/app/routers/rank_test.py
+++ b/src/app/routers/rank_test.py
@@ -71,25 +71,25 @@ def test_predict_ranks_candidates_by_score_desc(app):
         },
     )
 
-    # candidate_score's bounds are [0, 1]; run_predict normalizes raw scores
-    # into [-1, 1] (rank_score = 2*raw - 1) before combining/ranking.
+    # candidate_score's bounds are [0, 1], so run_predict keeps the raw scores
+    # in [0, 1] before combining/ranking.
     assert resp.status_code == 200
     assert resp.json() == {
         "rankings": [
             {
                 "at_uri": "at://post/high",
                 "rank": 1,
-                "rank_score": pytest.approx(0.8),
+                "rank_score": pytest.approx(0.9),
             },
             {
                 "at_uri": "at://post/mid",
                 "rank": 2,
-                "rank_score": pytest.approx(-0.2),
+                "rank_score": pytest.approx(0.4),
             },
             {
                 "at_uri": "at://post/low",
                 "rank": 3,
-                "rank_score": pytest.approx(-0.8),
+                "rank_score": pytest.approx(0.1),
             },
         ],
     }
@@ -119,17 +119,17 @@ def test_predict_keeps_duplicate_candidate_count_and_collapses_scores_by_uri(app
         {
             "at_uri": "at://post/b",
             "rank": 1,
-            "rank_score": pytest.approx(0.4),
+            "rank_score": pytest.approx(0.7),
         },
         {
             "at_uri": "at://post/a",
             "rank": 2,
-            "rank_score": pytest.approx(0.0),
+            "rank_score": pytest.approx(0.5),
         },
         {
             "at_uri": "at://post/a",
             "rank": 3,
-            "rank_score": pytest.approx(0.0),
+            "rank_score": pytest.approx(0.5),
         },
     ]
 

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1577,11 +1577,11 @@ class TestSlateCutoffs:
 
     def test_rank_floor_cuts_low_scores_and_records_discards(self, monkeypatch):
         """Sub-floor candidates are cut (boundary-equal kept) and persisted as discarded."""
-        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.0)
+        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.5)
         candidates = _make_candidates("p", 4, with_embedding=True)
         discarded = AsyncMock()
 
-        data = self._get_feed(candidates, self._rank_result([0.5, 0.2, 0.0, -0.3]), discarded)
+        data = self._get_feed(candidates, self._rank_result([0.8, 0.6, 0.5, 0.4]), discarded)
 
         posts = [item["post"] for item in data["feed"]]
         assert posts == ["at://p/0", "at://p/1", "at://p/2"]
@@ -1630,11 +1630,11 @@ class TestSlateCutoffs:
 
     def test_fail_open_serves_precut_slate_when_everything_cut(self, monkeypatch):
         """If the gates reject everything retrieved, the pre-cutoff slate is served."""
-        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.0)
+        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.5)
         candidates = _make_candidates("p", 3, with_embedding=True)
         discarded = AsyncMock()
 
-        data = self._get_feed(candidates, self._rank_result([-0.1, -0.2, -0.3]), discarded)
+        data = self._get_feed(candidates, self._rank_result([0.4, 0.3, 0.2]), discarded)
 
         posts = [item["post"] for item in data["feed"]]
         assert posts == ["at://p/0", "at://p/1", "at://p/2"]
@@ -1647,21 +1647,21 @@ class TestSlateCutoffs:
         from app.routers import xrpc as xrpc_mod
 
         monkeypatch.setattr(xrpc_mod, "EMPTY_SLATE_FAIL_OPEN", False)
-        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.0)
+        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.5)
         candidates = _make_candidates("p", 3, with_embedding=True)
 
-        data = self._get_feed(candidates, self._rank_result([-0.1, -0.2, -0.3]))
+        data = self._get_feed(candidates, self._rank_result([0.4, 0.3, 0.2]))
 
         assert data["feed"] == []
         assert "cursor" not in data
 
     def test_discarded_uris_excluded_on_fresh_request(self, monkeypatch):
         """Feeds with a rank floor exclude previously-discarded posts from generation."""
-        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.0)
+        monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.5)
         candidates = _make_candidates("p", 2, with_embedding=True)
         gen_patch, primary_gen = self._patch_generators(candidates)
 
-        rank_result = self._rank_result([0.5, 0.4])
+        rank_result = self._rank_result([0.7, 0.6])
         with gen_patch, \
              patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
              patch("app.routers.xrpc.record_discarded_posts", new_callable=AsyncMock), \
@@ -1711,9 +1711,9 @@ class TestSlateCutoffs:
         reader = InMemoryMetricReader()
         set_metric_collector(MetricCollector._from_reader(reader, service_name="t", env="test"))
         try:
-            monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.0)
+            monkeypatch.setattr(FEEDS["your-feed"], "min_rank_score", 0.5)
             candidates = _make_candidates("p", 4, with_embedding=True)
-            self._get_feed(candidates, self._rank_result([0.5, 0.2, 0.0, -0.3]))
+            self._get_feed(candidates, self._rank_result([0.8, 0.6, 0.5, 0.4]))
 
             metrics = {}
             metrics_data = reader.get_metrics_data()


### PR DESCRIPTION
Closes #257 

## This PR
- Update perspective scores to be returned in 0..1 instead of -1..1. Previously the bounds were determined based on the individual scorer weights. We keep the weights, to match the PRC values, but then scale the score after the weighted average so that it ends up in 0..1 instead of -1..1.
- Declare the heavy ranker bounds to be 0..1. The [previously merged PR here in inference-service](https://github.com/greenearth-social/inference-service/pull/24) handled outputting heavy ranker scores in 0..1 instead of -1..1.
- Combined ranker scores stay in 0..1 in _normalize() in predict.py (instead of being linearly scaled to -1..1) and default value is 0.5 instead of 0.
- Use 0.425 as the new min_rank_score. This is the equivalent of what it was before, -0.15, mapped to the new 0..1 bounds.
- Numerous touched files are just replacing "-1" with "0" in comments.
- Enforce that the min_rank_score config value is in 0..1.


## Testing
- Updated tests - all 788 passed. 
- Tested locally 
  - Verified new number ranges with debug print() statements
  - Confirmed that the feed itself is mostly unchanged - the number of candidates dropped for the various cutoff rules is very similar with the new vs the old code