### PR TITLE
Update your-feed pinned post with app.greenearth.social link

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -94,7 +94,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="a0-yf",
         internal_display_name="a0 YF",
         avatar="assets/icons/green-earth.png",
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mq5utph3ka26",
+        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3mrash36z5b2c",
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
         # min_rank_score=-0.15 is calibrated from real combined rank_score


### PR DESCRIPTION
Publishes a new pinned post on `greenearth-social.bsky.social` with updated text and a link to [app.greenearth.social](https://app.greenearth.social/)

## Results
<img width="630" height="597" alt="Screenshot 2026-07-22 at 10 23 35 AM" src="https://github.com/user-attachments/assets/feee4a12-4e95-4245-b290-07e319f0b73b" />

Closes #289