### PR TITLE
Record a user session even when their handle won't resolve

### DIFF
--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -107,12 +107,17 @@ async def get_user(db: AsyncClient, user_did: str) -> UserDocument | None:
     return UserDocument.model_validate(data)
 
 
-async def upsert_user(db: AsyncClient, user_did: str, username: str) -> UserDocument:
+async def upsert_user(db: AsyncClient, user_did: str, username: str | None) -> UserDocument:
     """Create or update a user document.
 
     On first visit the document is created with all timestamps set to now.
     On subsequent visits ``last_seen_at`` is refreshed and ``username`` is
     updated if it changed.
+
+    ``username`` may be ``None`` when the caller's handle couldn't be resolved
+    (the DID is the identity; the handle is enrichment). A ``None`` never
+    overwrites a handle we already know — a transient resolution failure
+    shouldn't erase good data.
     """
     ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
     doc = await ref.get()
@@ -127,7 +132,7 @@ async def upsert_user(db: AsyncClient, user_did: str, username: str) -> UserDocu
             )
 
         update_fields: dict[str, object] = {"last_seen_at": now}
-        if data.get("username") != username:
+        if username is not None and data.get("username") != username:
             update_fields["username"] = username
             update_fields["updated_at"] = now
 

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -286,6 +286,40 @@ class TestUpsertUser:
         doc_ref.set.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_creates_user_without_a_resolved_handle(self):
+        # Handle resolution is best-effort; the DID is the identity, so a
+        # failed lookup must still produce a user document.
+        db, _, doc_ref = _mock_firestore_client()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        user = await upsert_user(db, USER_DID, None)
+
+        assert user.user_did == USER_DID
+        assert user.username is None
+        doc_ref.set.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unresolved_handle_does_not_erase_a_known_one(self):
+        # A directory blip shouldn't wipe a handle we already resolved.
+        db, _, doc_ref = _mock_firestore_client()
+        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        doc_ref.get.return_value = _mock_doc_snapshot(True, {
+            "user_did": USER_DID,
+            "username": USERNAME,
+            "created_at": original_time,
+            "updated_at": original_time,
+            "last_seen_at": original_time,
+        })
+
+        user = await upsert_user(db, USER_DID, None)
+
+        assert user.username == USERNAME
+        update_fields = doc_ref.update.call_args[0][0]
+        assert "username" not in update_fields
+        # last_seen_at is still refreshed: the visit did happen.
+        assert user.last_seen_at > original_time
+
+    @pytest.mark.asyncio
     async def test_updates_username_when_changed(self):
         db, _, doc_ref = _mock_firestore_client()
         original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -38,20 +38,26 @@ def init_posthog_client(api_key: str, host: str) -> Posthog:
 def track_session(
     client: Posthog | None,
     user_did: str,
-    username: str,
+    username: str | None,
     feed_name: str,
     timestamp: datetime,
 ) -> None:
-    """Capture a feedLoaded event and update the user's person properties."""
+    """Capture a feedLoaded event and update the user's person properties.
+
+    ``username`` may be ``None`` when the handle couldn't be resolved. The
+    event is still captured — it's keyed on the DID — but the person property
+    is left alone rather than set to null, so a transient resolution failure
+    doesn't erase a handle PostHog already has.
+    """
     if client is None:
         return
+    properties: dict[str, object] = {"feed_name": feed_name}
+    if username is not None:
+        properties["$set"] = {"username": username}
     client.capture(
         distinct_id=user_did,
         event="feedLoaded",
-        properties={
-            "feed_name": feed_name,
-            "$set": {"username": username},
-        },
+        properties=properties,
         timestamp=timestamp,
     )
 

--- a/src/app/lib/posthog_client_test.py
+++ b/src/app/lib/posthog_client_test.py
@@ -65,6 +65,27 @@ def test_track_session_captures_feed_loaded():
     )
 
 
+def test_track_session_without_a_handle_still_captures_the_event():
+    # The event is keyed on the DID, so an unresolved handle shouldn't cost us
+    # the analytics signal...
+    mock = MagicMock()
+    track_session(mock, USER_DID, None, "your-feed", NOW)
+    mock.capture.assert_called_once_with(
+        distinct_id=USER_DID,
+        event="feedLoaded",
+        properties={"feed_name": "your-feed"},
+        timestamp=NOW,
+    )
+
+
+def test_track_session_without_a_handle_leaves_the_person_property_alone():
+    # ...and must not null out a username PostHog already knows.
+    mock = MagicMock()
+    track_session(mock, USER_DID, None, "your-feed", NOW)
+    properties = mock.capture.call_args.kwargs["properties"]
+    assert "$set" not in properties
+
+
 def test_track_interaction_none_client_is_noop():
     track_interaction(None, USER_DID, "interactionLike", "your-feed", "at://did/post/1", NOW)
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -726,11 +726,20 @@ async def _record_session(request: Request, user_did: str, feed_name: str, db) -
     isn't paying for firebase roundtrips.
     Failures are logged but do not surface to the caller.
     """
+    # Handle resolution goes over the network to the PLC directory, so it fails
+    # for reasons that have nothing to do with this user existing — a directory
+    # blip, a DID document that's briefly unresolvable. Treat it as enrichment:
+    # losing the handle shouldn't also lose the session record, which is keyed
+    # on the DID we already have.
     try:
         username = await _resolve_username(request, user_did)
     except Exception:
-        logger.exception("Failed to resolve username for %s in background", user_did)
-        return
+        logger.warning(
+            "Could not resolve handle for %s; recording session without it",
+            user_did,
+            exc_info=True,
+        )
+        username = None
 
     now = datetime.now(timezone.utc)
 

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1164,7 +1164,8 @@ class TestGetFeedSkeletonAuth:
 
     def test_username_resolution_failure_is_logged_but_non_fatal(self, caplog):
         """Username resolution runs in a background task; failures are logged
-        but don't block the response."""
+        but don't block the response, and the session is still recorded
+        without the handle."""
         from unittest.mock import MagicMock
 
         mock_payload = MagicMock()
@@ -1186,7 +1187,7 @@ class TestGetFeedSkeletonAuth:
             )
 
         assert resp.status_code == 200
-        assert "Failed to resolve username" in caplog.text
+        assert "Could not resolve handle" in caplog.text
 
     def test_firestore_upsert_failure_is_logged_but_non_fatal(self, caplog):
         """Firestore user upserts run in a background task; failures are
@@ -2637,6 +2638,44 @@ class TestPosthogTracking:
                 assert call_kwargs.args[1] == "did:plc:abc"
                 assert call_kwargs.args[2] == "alice.bsky.app"
                 assert call_kwargs.args[3] == "your-feed"
+
+    @pytest.mark.asyncio
+    async def test_record_session_survives_handle_resolution_failure(self):
+        """A DID that won't resolve must not cost us the session record.
+
+        Resolution goes over the network to the PLC directory, so it fails for
+        reasons unrelated to the user existing. Before this, one such failure
+        skipped the user upsert, the feed-activity write and the analytics
+        event outright.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from ..routers.xrpc import _record_session
+
+        db = AsyncMock()
+        request = MagicMock()
+        request.app.state.id_resolver = AsyncMock()
+        request.app.state.id_resolver.did.resolve = AsyncMock(
+            side_effect=RuntimeError("PLC directory unavailable")
+        )
+
+        with patch("app.routers.xrpc.get_posthog_client", return_value=MagicMock()):
+            with patch("app.routers.xrpc.track_session") as mock_track:
+                with patch("app.routers.xrpc.upsert_user", new=AsyncMock()) as mock_upsert:
+                    with patch(
+                        "app.routers.xrpc.upsert_feed_activity", new=AsyncMock()
+                    ) as mock_activity:
+                        await _record_session(request, "did:plc:abc", "your-feed", db)
+
+        mock_upsert.assert_awaited_once()
+        upsert_args = mock_upsert.await_args
+        assert upsert_args is not None
+        # The DID is the identity; the handle is enrichment we simply lack.
+        assert upsert_args.args[1] == "did:plc:abc"
+        assert upsert_args.args[2] is None
+        mock_activity.assert_awaited_once()
+        mock_track.assert_called_once()
+        assert mock_track.call_args.args[2] is None
 
     @pytest.mark.asyncio
     async def test_record_interactions_calls_track_interaction(self):


### PR DESCRIPTION
Base branch: `main`.

`_record_session` resolved the caller's handle before writing anything and **returned early if that failed** — so one failed lookup skipped the user document, the feed-activity write, and the PostHog event entirely.

Handle resolution goes over the network to the PLC directory, so it fails for reasons that have nothing to do with the user existing: a directory blip, a DID document that's briefly unresolvable. Losing the handle shouldn't also lose the record of the visit, which is keyed on the DID we already have. `UserDocument.username` has always been `str | None`; only this path insisted on it.

Resolution failure is now a warning and the session is recorded with a null handle. Two places had to stop treating null as a value to write, so a transient failure can't **erase** a handle we already know:

- `upsert_user` leaves an existing username alone when passed `None` (it still refreshes `last_seen_at` — the visit did happen).
- `track_session` omits the `$set` person property rather than nulling it, while still capturing the `feedLoaded` event.

## How this surfaced

Found while bringing the frontend up in the shared dev environment ([#301](https://github.com/greenearth-social/api/issues/301)). Its seeded personas are pseudonymized, so they never resolve — which meant no user document was ever created, and `scripts/feed_debug.py --enable` had nothing to attach to. That made the failure mode easy to see, but it isn't dev-only: the same thing happens in production whenever the directory is briefly unavailable, silently dropping user records and feed activity for affected requests.

## Tests

792 pass. Added coverage for each guarantee: a user document is created with no handle, an unresolved handle doesn't overwrite a known one, `track_session` still fires without setting the person property, and `_record_session` completes all three writes when resolution raises.

One existing test asserted the old log wording; updated to match, and its docstring now states the stronger guarantee.

Verified in the dev environment: after the change the api creates the user document on its own (`username: null`) and `feed_debug.py --enable` succeeds with no manual setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)