### PR TITLE
Terminal feed viewer for the dev environment (#285)

### DIFF
--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -28,7 +28,7 @@ import argparse
 import asyncio
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import NoReturn
 
 from rich import box
@@ -37,7 +37,12 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+sys.path.insert(0, os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from feed_format import fmt_score as _fmt_score
+from feed_format import media_badges
+from feed_format import relative_time as _relative_time
 
 from app.documents import FeedDebugDocument
 from app.lib.firestore import (
@@ -94,28 +99,6 @@ def _die(message: str) -> NoReturn:
 # ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
-
-
-def _relative_time(dt: datetime) -> str:
-    """Compact relative-time string for a tz-aware datetime."""
-    try:
-        delta = datetime.now(timezone.utc) - dt
-        secs = delta.total_seconds()
-        if secs < 60:
-            return "just now"
-        if secs < 3_600:
-            return f"{int(secs / 60)}m ago"
-        if secs < 86_400:
-            return f"{int(secs / 3_600)}h ago"
-        if delta.days < 30:
-            return f"{delta.days}d ago"
-        return dt.strftime("%b %d, %Y")
-    except Exception:
-        return str(dt)
-
-
-def _fmt_score(score: float | None) -> str:
-    return f"{score:.4f}" if score is not None else "—"
 
 
 def _diversification_relevance_contribution(div) -> float:
@@ -215,20 +198,13 @@ def _candidate_stats_rows(doc: FeedDebugDocument) -> list[tuple[str, str, str, s
 
 def _media_summary(c) -> Text | None:
     """Yellow media badges for a candidate, or None when it has no media."""
-    parts = []
-    if c.image_count:
-        parts.append(f"{c.image_count} image{'s' if c.image_count != 1 else ''}")
-    elif c.contains_images:
-        parts.append("image")
-    if c.video_count:
-        parts.append(f"{c.video_count} video{'s' if c.video_count != 1 else ''}")
-    elif c.contains_video:
-        parts.append("video")
-    if c.external_uri:
-        parts.append("link")
-    if not parts:
-        return None
-    return Text(f"[{', '.join(parts)}]", style="dim yellow")
+    return media_badges(
+        image_count=c.image_count,
+        contains_images=c.contains_images,
+        video_count=c.video_count,
+        contains_video=c.contains_video,
+        external_uri=c.external_uri,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/feed_format.py
+++ b/scripts/feed_format.py
@@ -1,0 +1,63 @@
+"""Formatting helpers shared by the feed CLIs.
+
+``feed_debug.py`` (Firestore debug records) and ``feed_view.py`` (a terminal
+feed client) present the same concepts — timestamps, scores, media badges — so
+they render them identically from here rather than drifting apart.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from rich.text import Text
+
+
+def relative_time(dt: datetime) -> str:
+    """Compact relative-time string for a tz-aware datetime."""
+    try:
+        delta = datetime.now(timezone.utc) - dt
+        secs = delta.total_seconds()
+        if secs < 60:
+            return "just now"
+        if secs < 3_600:
+            return f"{int(secs / 60)}m ago"
+        if secs < 86_400:
+            return f"{int(secs / 3_600)}h ago"
+        if delta.days < 30:
+            return f"{delta.days}d ago"
+        return dt.strftime("%b %d, %Y")
+    except Exception:
+        return str(dt)
+
+
+def fmt_score(score: float | None) -> str:
+    return f"{score:.4f}" if score is not None else "—"
+
+
+def media_badges(
+    *,
+    image_count: int | None = None,
+    contains_images: bool = False,
+    video_count: int | None = None,
+    contains_video: bool = False,
+    external_uri: str | None = None,
+) -> Text | None:
+    """Yellow media badges for a post, or None when it has no media.
+
+    Counts win over the booleans when present: a post carrying
+    ``image_count=3`` renders "3 images" rather than a bare "image".
+    """
+    parts = []
+    if image_count:
+        parts.append(f"{image_count} image{'s' if image_count != 1 else ''}")
+    elif contains_images:
+        parts.append("image")
+    if video_count:
+        parts.append(f"{video_count} video{'s' if video_count != 1 else ''}")
+    elif contains_video:
+        parts.append("video")
+    if external_uri:
+        parts.append("link")
+    if not parts:
+        return None
+    return Text(f"[{', '.join(parts)}]", style="dim yellow")

--- a/scripts/feed_format_test.py
+++ b/scripts/feed_format_test.py
@@ -1,0 +1,79 @@
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("feed_format.py")
+spec = importlib.util.spec_from_file_location("feed_format_mod", MODULE_PATH)
+assert spec and spec.loader
+feed_format = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(feed_format)
+
+relative_time = feed_format.relative_time
+fmt_score = feed_format.fmt_score
+media_badges = feed_format.media_badges
+
+
+def _ago(**kwargs) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(**kwargs)
+
+
+class TestRelativeTime:
+    def test_seconds_reads_as_just_now(self):
+        assert relative_time(_ago(seconds=5)) == "just now"
+
+    def test_minutes(self):
+        assert relative_time(_ago(minutes=5)) == "5m ago"
+
+    def test_hours(self):
+        assert relative_time(_ago(hours=3)) == "3h ago"
+
+    def test_days(self):
+        assert relative_time(_ago(days=4)) == "4d ago"
+
+    def test_old_dates_fall_back_to_absolute(self):
+        old = datetime(2020, 1, 15, tzinfo=timezone.utc)
+        assert relative_time(old) == "Jan 15, 2020"
+
+    def test_bad_input_does_not_raise(self):
+        # A naive datetime can't be subtracted from an aware now(); the helper
+        # must degrade to a string rather than blow up mid-render.
+        assert relative_time(datetime(2020, 1, 1)) == str(datetime(2020, 1, 1))
+
+
+class TestFmtScore:
+    def test_none_is_a_dash(self):
+        assert fmt_score(None) == "—"
+
+    def test_formats_four_decimals(self):
+        assert fmt_score(0.5) == "0.5000"
+
+    def test_zero_is_not_treated_as_missing(self):
+        assert fmt_score(0.0) == "0.0000"
+
+
+class TestMediaBadges:
+    def test_no_media_returns_none(self):
+        assert media_badges() is None
+
+    def test_count_wins_over_bool_and_pluralizes(self):
+        badge = media_badges(image_count=3, contains_images=True)
+        assert badge is not None
+        assert badge.plain == "[3 images]"
+
+    def test_singular_image(self):
+        badge = media_badges(image_count=1)
+        assert badge is not None
+        assert badge.plain == "[1 image]"
+
+    def test_bare_bool_without_count(self):
+        badge = media_badges(contains_images=True)
+        assert badge is not None
+        assert badge.plain == "[image]"
+
+    def test_video_and_link_combine(self):
+        badge = media_badges(video_count=2, external_uri="https://example.com")
+        assert badge is not None
+        assert badge.plain == "[2 videos, link]"
+
+    def test_zero_counts_are_not_media(self):
+        assert media_badges(image_count=0, video_count=0) is None

--- a/scripts/feed_view.py
+++ b/scripts/feed_view.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Terminal Bluesky client for viewing a locally-generated feed (issue #285).
+
+Requests ``getFeedSkeleton`` from a running api as a chosen dev persona,
+hydrates each post from Elasticsearch, and prints the feed. Nothing is
+published and no write path is exercised — it just lets a developer see the
+feed they are working on.
+
+Hydration is deliberately local-only: the skeleton returns bare AT URIs, and
+we resolve them against the environment's own Elasticsearch rather than the
+public AppView, so this works entirely against seeded fixture data with no
+network access and no Bluesky credentials.
+
+Pipeline detail (per-item rank, ranker score, which generator retrieved a
+post) comes from the feed snapshot the api writes for every feed load. The
+``feedContext`` token on each skeleton item carries the snapshot's request id
+in its payload, so we read the id straight out of it. Pass ``--no-pipeline``
+to skip that lookup and show the feed exactly as a real client would see it.
+
+Usually invoked through the dev environment, which supplies the persona,
+endpoints, and secrets:
+
+    devctl feed popularity
+    devctl feed your-feed --user did:plc:... --limit 50
+
+Run it directly against a devenv api with the same environment the api
+container has:
+
+    pipenv run python scripts/feed_view.py popularity --user did:plc:...
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import binascii
+import json
+import os
+import sys
+from datetime import datetime
+from typing import Any, NoReturn
+
+from rich.console import Console
+from rich.text import Text
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from feed_format import fmt_score, media_badges, relative_time
+
+console = Console()
+
+DEFAULT_FEED_PUBLISHER = "did:web:test"
+POSTS_ALIAS = "posts_recent"
+
+# Fields worth pulling for display. Post embeddings live in the same documents
+# and are large enough that fetching them makes paging visibly slow.
+_SOURCE_FIELDS = [
+    "at_uri",
+    "author_did",
+    "content",
+    "created_at",
+    "like_count",
+    "contains_images",
+    "image_count",
+    "contains_video",
+    "video_count",
+    "external_embed",
+    "quote_post",
+]
+
+
+def _die(message: str) -> NoReturn:
+    console.print(f"[red]{message}[/red]")
+    sys.exit(1)
+
+
+def feed_uri(feed: str, publisher: str) -> str:
+    """Full AT URI for a feed, passing through one that is already a URI."""
+    if feed.startswith("at://"):
+        return feed
+    return f"at://{publisher}/app.bsky.feed.generator/{feed}"
+
+
+def request_id_from_feed_context(feed_context: str | None) -> str | None:
+    """Pull the snapshot request id out of a ``feedContext`` token.
+
+    The token is ``<base64url payload>.<signature>``; the payload is plain JSON
+    carrying ``rid``. We only read it, never trust it — the id is used to look
+    up a local snapshot for display, so a malformed or unsigned token costs
+    nothing beyond losing the pipeline detail.
+    """
+    if not feed_context:
+        return None
+    payload = feed_context.split(".", 1)[0]
+    padded = payload + "=" * (-len(payload) % 4)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(padded))
+    except (ValueError, binascii.Error):
+        return None
+    rid = decoded.get("rid") if isinstance(decoded, dict) else None
+    return rid if isinstance(rid, str) else None
+
+
+async def fetch_skeleton(
+    *,
+    base_url: str,
+    uri: str,
+    user_did: str,
+    secret: str,
+    limit: int,
+    cursor: str | None,
+) -> dict[str, Any]:
+    """Call getFeedSkeleton as *user_did* via the dev-session header."""
+    import httpx
+
+    params: dict[str, Any] = {"feed": uri, "limit": limit}
+    if cursor:
+        params["cursor"] = cursor
+    headers = {"X-Dev-Session": secret, "X-Dev-Session-DID": user_did}
+    async with httpx.AsyncClient(timeout=60) as client:
+        resp = await client.get(
+            f"{base_url}/xrpc/app.bsky.feed.getFeedSkeleton", params=params, headers=headers
+        )
+    if resp.status_code != 200:
+        _die(f"api returned {resp.status_code}: {resp.text[:400]}")
+    return resp.json()
+
+
+async def hydrate_posts(es, uris: list[str]) -> dict[str, dict[str, Any]]:
+    """Fetch post documents for *uris*, keyed by AT URI.
+
+    Uses an ``ids`` query rather than mget: posts are indexed with
+    ``routing=author_did``, and a direct id lookup would need that routing
+    value, which the skeleton doesn't give us.
+    """
+    if not uris:
+        return {}
+    resp = await es.search(
+        index=POSTS_ALIAS,
+        query={"ids": {"values": uris}},
+        _source=_SOURCE_FIELDS,
+        size=len(uris),
+    )
+    return {hit["_source"]["at_uri"]: hit["_source"] for hit in resp["hits"]["hits"]}
+
+
+async def load_pipeline_meta(user_did: str, request_id: str) -> dict[str, Any] | None:
+    """Per-URI pipeline metadata from the feed snapshot, or None if unavailable.
+
+    Best-effort: the snapshot is written in a background task, so a very fast
+    caller can beat it, and an environment without Firestore configured has no
+    snapshots at all. Either way the feed still renders.
+    """
+    try:
+        from app.lib.firestore import get_feed_snapshot, init_firestore_client
+
+        db = init_firestore_client()
+        doc = await get_feed_snapshot(db, user_did, request_id)
+    except Exception:
+        return None
+    if doc is None:
+        return None
+    return {
+        "ranker_model": doc.ranker_model,
+        "diversify": doc.diversify,
+        "items": {m.at_uri: m for m in doc.items_meta},
+    }
+
+
+def _parse_created_at(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _author_label(did: str | None) -> str:
+    """Display label for a post author.
+
+    Elasticsearch stores only ``author_did`` — handles live in the AppView,
+    which this tool deliberately doesn't call — so the DID is what we can show.
+    """
+    return did or "unknown author"
+
+
+def render_post(
+    *,
+    position: int,
+    uri: str,
+    source: dict[str, Any] | None,
+    meta: Any | None,
+) -> Text:
+    """One post as it appears in the feed listing."""
+    out = Text()
+    out.append(f"{position:>3}. ", style="bold green")
+
+    if source is None:
+        out.append("(not in Elasticsearch) ", style="red")
+        out.append(uri, style="dim cyan")
+        return out
+
+    out.append(_author_label(source.get("author_did")), style="bold white")
+
+    created = _parse_created_at(source.get("created_at"))
+    if created is not None:
+        out.append(f"  {relative_time(created)}", style="dim cyan")
+
+    likes = source.get("like_count")
+    if likes:
+        out.append(f"  ♥ {likes}", style="magenta")
+
+    badges = media_badges(
+        image_count=source.get("image_count"),
+        contains_images=bool(source.get("contains_images")),
+        video_count=source.get("video_count"),
+        contains_video=bool(source.get("contains_video")),
+        external_uri=source.get("external_embed"),
+    )
+    if badges is not None:
+        out.append("  ")
+        out.append_text(badges)
+
+    content = (source.get("content") or "").strip()
+    if content:
+        for line in content.splitlines():
+            out.append("\n     ")
+            out.append(line, style="default")
+    else:
+        out.append("\n     (no text)", style="dim")
+
+    if meta is not None:
+        pipeline = Text("\n     ", style="dim")
+        gens = ", ".join(f"{g.name} ({fmt_score(g.score)})" for g in meta.generators)
+        pipeline.append("via ", style="dim")
+        pipeline.append(gens or "infill/unknown", style="cyan")
+        if meta.rank is not None:
+            pipeline.append("  ranked ", style="dim")
+            pipeline.append(f"#{meta.rank}", style="yellow")
+        if meta.rank_score is not None:
+            pipeline.append(f" ({fmt_score(meta.rank_score)})", style="dim")
+        out.append_text(pipeline)
+
+    out.append(f"\n     {uri}", style="dim cyan")
+    return out
+
+
+def render_page(
+    *,
+    feed: str,
+    user_did: str,
+    skeleton: dict[str, Any],
+    hydrated: dict[str, dict[str, Any]],
+    pipeline: dict[str, Any] | None,
+    start_position: int,
+) -> None:
+    items = skeleton.get("feed", [])
+    header = Text()
+    header.append(feed, style="bold magenta")
+    header.append(f"  as {user_did}", style="dim")
+    header.append(f"  {len(items)} item{'s' if len(items) != 1 else ''}", style="dim")
+    if pipeline and pipeline.get("ranker_model"):
+        header.append(f"  ranker {pipeline['ranker_model']}", style="dim")
+    console.print()
+    console.print(header)
+    console.print()
+
+    if not items:
+        console.print("[yellow]Feed is empty.[/yellow]")
+        return
+
+    meta_by_uri = pipeline["items"] if pipeline else {}
+    missing = 0
+    for offset, item in enumerate(items):
+        uri = item.get("post", "")
+        source = hydrated.get(uri)
+        if source is None:
+            missing += 1
+        console.print(
+            render_post(
+                position=start_position + offset,
+                uri=uri,
+                source=source,
+                meta=meta_by_uri.get(uri),
+            )
+        )
+        console.print()
+
+    if missing:
+        console.print(
+            f"[yellow]{missing} post{'s' if missing != 1 else ''} could not be hydrated — "
+            f"the feed references URIs that aren't in this environment's index.[/yellow]"
+        )
+
+
+async def run(args: argparse.Namespace) -> None:
+    secret = os.environ.get("GE_DEV_SESSION_SECRET")
+    if not secret:
+        _die(
+            "GE_DEV_SESSION_SECRET is not set. This tool talks to the api as a dev "
+            "session; run it through `devctl feed`, or export the same secret the "
+            "api container uses."
+        )
+
+    user_did = args.user or os.environ.get("GE_PROBE_USER_DID", "")
+    if not user_did:
+        _die("No persona given. Pass --user did:plc:... (or seed the environment first).")
+    if not user_did.startswith("did:plc:"):
+        _die(f"--user must be a did:plc DID, got: {user_did}")
+
+    uri = feed_uri(args.feed, args.publisher)
+
+    es_key = os.environ.get("GE_ELASTICSEARCH_API_KEY")
+    if not es_key:
+        _die("GE_ELASTICSEARCH_API_KEY is not set — needed to hydrate posts.")
+
+    from elasticsearch import AsyncElasticsearch
+
+    es = AsyncElasticsearch(
+        hosts=[os.environ.get("GE_ELASTICSEARCH_URL", "http://localhost:9200")],
+        api_key=es_key,
+        verify_certs=False,
+        request_timeout=30,
+    )
+
+    try:
+        cursor = args.cursor
+        position = 1
+        for page in range(args.pages):
+            skeleton = await fetch_skeleton(
+                base_url=args.api_url,
+                uri=uri,
+                user_did=user_did,
+                secret=secret,
+                limit=args.limit,
+                cursor=cursor,
+            )
+
+            if args.json:
+                print(json.dumps(skeleton, indent=2))
+            else:
+                items = skeleton.get("feed", [])
+                uris = [i["post"] for i in items if i.get("post")]
+                hydrated = await hydrate_posts(es, uris)
+
+                pipeline = None
+                if not args.no_pipeline and items:
+                    rid = request_id_from_feed_context(items[0].get("feedContext"))
+                    if rid:
+                        pipeline = await load_pipeline_meta(user_did, rid)
+
+                render_page(
+                    feed=args.feed,
+                    user_did=user_did,
+                    skeleton=skeleton,
+                    hydrated=hydrated,
+                    pipeline=pipeline,
+                    start_position=position,
+                )
+                position += len(items)
+
+            cursor = skeleton.get("cursor")
+            if not cursor or not skeleton.get("feed"):
+                break
+            if page + 1 < args.pages:
+                console.print("[dim]— next page —[/dim]")
+
+        if cursor and not args.json:
+            console.print(f"[dim]next cursor: {cursor}[/dim]")
+            console.print("[dim]continue with: --cursor <cursor>  (or --pages N)[/dim]")
+    finally:
+        await es.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="View a locally-generated Green Earth feed in the terminal"
+    )
+    parser.add_argument("feed", nargs="?", default="popularity", help="Feed name or full at:// URI")
+    parser.add_argument("--user", help="Persona DID (defaults to the seeded GE_PROBE_USER_DID)")
+    parser.add_argument("--limit", type=int, default=20, help="Posts per page (default 20)")
+    parser.add_argument("--cursor", help="Resume from a cursor returned by an earlier run")
+    parser.add_argument(
+        "--pages", type=int, default=1, help="Fetch this many pages, following cursors (default 1)"
+    )
+    parser.add_argument(
+        "--no-pipeline",
+        action="store_true",
+        help="Skip the snapshot lookup and show the feed as a plain client would",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print the raw getFeedSkeleton response instead"
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("GE_DEV_API_URL", "http://localhost:8000"),
+        help="Base URL of the api (default http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--publisher",
+        default=os.environ.get("GE_DEV_FEED_PUBLISHER", DEFAULT_FEED_PUBLISHER),
+        help=f"Feed publisher DID (default {DEFAULT_FEED_PUBLISHER})",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if args.pages < 1:
+        _die("--pages must be at least 1")
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feed_view_test.py
+++ b/scripts/feed_view_test.py
@@ -1,0 +1,151 @@
+import base64
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+MODULE_PATH = Path(__file__).with_name("feed_view.py")
+spec = importlib.util.spec_from_file_location("feed_view_cli", MODULE_PATH)
+assert spec and spec.loader
+feed_view = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(feed_view)
+
+
+def _feed_context(payload: dict) -> str:
+    """A feedContext-shaped token: base64url(payload).signature."""
+    raw = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{raw}.made-up-signature"
+
+
+class TestFeedUri:
+    def test_bare_name_expands_with_publisher(self):
+        assert (
+            feed_view.feed_uri("popularity", "did:web:test")
+            == "at://did:web:test/app.bsky.feed.generator/popularity"
+        )
+
+    def test_full_uri_passes_through(self):
+        uri = "at://did:web:other/app.bsky.feed.generator/custom"
+        assert feed_view.feed_uri(uri, "did:web:test") == uri
+
+
+class TestRequestIdFromFeedContext:
+    def test_extracts_rid(self):
+        token = _feed_context({"did": "did:plc:x", "feed": "popularity", "rid": "abc123"})
+        assert feed_view.request_id_from_feed_context(token) == "abc123"
+
+    def test_none_context_returns_none(self):
+        assert feed_view.request_id_from_feed_context(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert feed_view.request_id_from_feed_context("") is None
+
+    def test_missing_rid_returns_none(self):
+        token = _feed_context({"did": "did:plc:x", "feed": "popularity"})
+        assert feed_view.request_id_from_feed_context(token) is None
+
+    def test_garbage_payload_returns_none(self):
+        assert feed_view.request_id_from_feed_context("not-a-token.sig") is None
+
+    def test_non_dict_payload_returns_none(self):
+        raw = base64.urlsafe_b64encode(json.dumps([1, 2, 3]).encode()).decode().rstrip("=")
+        assert feed_view.request_id_from_feed_context(f"{raw}.sig") is None
+
+    def test_non_string_rid_returns_none(self):
+        token = _feed_context({"rid": 42})
+        assert feed_view.request_id_from_feed_context(token) is None
+
+
+class TestParseCreatedAt:
+    def test_parses_z_suffix(self):
+        dt = feed_view._parse_created_at("2026-07-21T16:18:15Z")
+        assert dt == datetime(2026, 7, 21, 16, 18, 15, tzinfo=timezone.utc)
+
+    def test_none_returns_none(self):
+        assert feed_view._parse_created_at(None) is None
+
+    def test_bad_value_returns_none(self):
+        assert feed_view._parse_created_at("not a date") is None
+
+
+class TestAuthorLabel:
+    def test_did_when_present(self):
+        assert feed_view._author_label("did:plc:abc") == "did:plc:abc"
+
+    def test_none_falls_back(self):
+        assert feed_view._author_label(None) == "unknown author"
+
+
+def _meta(**kwargs):
+    base = dict(generators=[], rank=None, rank_score=None)
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+class TestRenderPost:
+    def _source(self, **overrides):
+        base = {
+            "at_uri": "at://did:plc:abc/app.bsky.feed.post/xyz",
+            "author_did": "did:plc:abc",
+            "content": "hello world",
+            "created_at": "2026-07-21T16:18:15Z",
+            "like_count": 12,
+        }
+        base.update(overrides)
+        return base
+
+    def test_missing_source_is_flagged(self):
+        text = feed_view.render_post(
+            position=1, uri="at://did:plc:abc/app.bsky.feed.post/xyz", source=None, meta=None
+        )
+        assert "not in Elasticsearch" in text.plain
+
+    def test_renders_author_content_and_likes(self):
+        text = feed_view.render_post(
+            position=2, uri="at://x", source=self._source(), meta=None
+        ).plain
+        assert "did:plc:abc" in text
+        assert "hello world" in text
+        assert "12" in text
+
+    def test_empty_content_shows_placeholder(self):
+        text = feed_view.render_post(
+            position=1, uri="at://x", source=self._source(content=""), meta=None
+        ).plain
+        assert "(no text)" in text
+
+    def test_pipeline_meta_adds_generator_and_rank(self):
+        meta = _meta(
+            generators=[SimpleNamespace(name="popularity", score=1.0)], rank=3, rank_score=0.42
+        )
+        text = feed_view.render_post(
+            position=1, uri="at://x", source=self._source(), meta=meta
+        ).plain
+        assert "popularity" in text
+        assert "#3" in text
+        assert "0.4200" in text
+
+    def test_no_meta_omits_pipeline_line(self):
+        text = feed_view.render_post(
+            position=1, uri="at://x", source=self._source(), meta=None
+        ).plain
+        assert "via" not in text
+
+
+class TestBuildParser:
+    def test_defaults(self):
+        args = feed_view.build_parser().parse_args([])
+        assert args.feed == "popularity"
+        assert args.limit == 20
+        assert args.pages == 1
+        assert args.no_pipeline is False
+
+    def test_feed_and_flags(self):
+        args = feed_view.build_parser().parse_args(
+            ["random", "--user", "did:plc:z", "--limit", "5", "--no-pipeline"]
+        )
+        assert args.feed == "random"
+        assert args.user == "did:plc:z"
+        assert args.limit == 5
+        assert args.no_pipeline is True


### PR DESCRIPTION
Closes #285.

> **Stacked on [#303](https://github.com/greenearth-social/api/pull/303)** (`raindrift/dev-session`). Review/merge that first; the viewer authenticates via the dev-session header #303 adds. Once #303 lands this retargets to `main`.

Adds `scripts/feed_view.py`, a read-only terminal client for viewing a locally-generated feed. It requests `getFeedSkeleton` from a running api as a chosen dev persona, hydrates each post from the environment's **own Elasticsearch** — no AppView call, so it works entirely against seeded fixture data — and prints author, timestamp, like count, text, and per-post pipeline detail (which generator retrieved the post, its rank, and the ranker score).

The pipeline detail comes from the feed snapshot the api records on every load, located via the request id carried in each item's `feedContext` token. Flags: `--json` falls back to the raw skeleton (the previous `devctl feed` output), `--no-pipeline` shows the feed as a plain client would, `--pages`/`--cursor` page through it.

`feed_debug.py` and `feed_view.py` render the same concepts (timestamps, scores, media badges), so those formatters move to a shared `scripts/feed_format.py` and both call it rather than drifting apart.

Driven from the dev environment as `devctl feed <feed> [--user <did>]` (internal-tools PR).

Tests: `feed_view_test.py`, `feed_format_test.py`, plus the existing `feed_debug_test.py` still passing over the refactor — 837 total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)