### PR TITLE
feed_view: default to your-feed

### DIFF
--- a/scripts/feed_view.py
+++ b/scripts/feed_view.py
@@ -20,13 +20,13 @@ to skip that lookup and show the feed exactly as a real client would see it.
 Usually invoked through the dev environment, which supplies the persona,
 endpoints, and secrets:
 
-    devctl feed popularity
+    devctl feed
     devctl feed your-feed --user did:plc:... --limit 50
 
 Run it directly against a devenv api with the same environment the api
 container has:
 
-    pipenv run python scripts/feed_view.py popularity --user did:plc:...
+    pipenv run python scripts/feed_view.py your-feed --user did:plc:...
 """
 
 from __future__ import annotations
@@ -51,6 +51,9 @@ from feed_format import fmt_score, media_badges, relative_time
 
 console = Console()
 
+# The flagship feed: the full retrieve -> rank -> diversify path, which is
+# what someone running this usually wants to look at.
+DEFAULT_FEED = "your-feed"
 DEFAULT_FEED_PUBLISHER = "did:web:test"
 POSTS_ALIAS = "posts_recent"
 
@@ -379,7 +382,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="View a locally-generated Green Earth feed in the terminal"
     )
-    parser.add_argument("feed", nargs="?", default="popularity", help="Feed name or full at:// URI")
+    parser.add_argument(
+        "feed",
+        nargs="?",
+        default=DEFAULT_FEED,
+        help=f"Feed name or full at:// URI (default {DEFAULT_FEED})",
+    )
     parser.add_argument("--user", help="Persona DID (defaults to the seeded GE_PROBE_USER_DID)")
     parser.add_argument("--limit", type=int, default=20, help="Posts per page (default 20)")
     parser.add_argument("--cursor", help="Resume from a cursor returned by an earlier run")

--- a/scripts/feed_view_test.py
+++ b/scripts/feed_view_test.py
@@ -136,7 +136,7 @@ class TestRenderPost:
 class TestBuildParser:
     def test_defaults(self):
         args = feed_view.build_parser().parse_args([])
-        assert args.feed == "popularity"
+        assert args.feed == feed_view.DEFAULT_FEED
         assert args.limit == 20
         assert args.pages == 1
         assert args.no_pipeline is False


### PR DESCRIPTION
`devctl feed` / `feed_view.py` now default to `your-feed` instead of `popularity`.

`your-feed` exercises the full retrieve → rank → diversify path, which is what someone opening the viewer usually wants to look at. It defaulted to `popularity` only because `your-feed` couldn't run locally — it needs the `heavy_ranker` and `perspective` rankers, which the dev environment now serves with stubs ([internal-tools#8](https://github.com/greenearth-social/internal-tools/pull/8)).

The default is now a named constant so the flag help and the test both read it from one place.

837 tests pass; pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)