### PR TITLE
Make candidate generators time window configurable

### DIFF
--- a/scripts/migrate_stage_freshness.py
+++ b/scripts/migrate_stage_freshness.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Migrate the former 24-hour freshness default to seven days in stage.
+
+This script is deliberately stage-only and dry-runs unless ``--apply`` is
+provided. It updates only user documents whose stored ``freshness`` value is
+exactly ``2``, changing that single field to ``5``.
+
+Usage:
+    pipenv run python scripts/migrate_stage_freshness.py
+    pipenv run python scripts/migrate_stage_freshness.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from google.cloud.firestore import AsyncClient, FieldFilter, async_transactional
+
+from app.lib.firestore import USERS_COLLECTION, init_firestore_client
+
+GCP_PROJECT = "greenearth-471522"
+STAGE_DATABASE = "greenearth-stage"
+OLD_FRESHNESS = 2
+NEW_FRESHNESS = 5
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    matched: int
+    updated: int
+    skipped: int
+
+
+def configure_stage() -> None:
+    """Force the process onto the stage Firestore database."""
+    os.environ["GE_FIRESTORE_PROJECT"] = GCP_PROJECT
+    os.environ["GE_FIRESTORE_DATABASE"] = STAGE_DATABASE
+    os.environ.pop("GE_FIRESTORE_EMULATOR_HOST", None)
+    os.environ.pop("FIRESTORE_EMULATOR_HOST", None)
+
+
+async def _update_if_unchanged(db: AsyncClient, document_ref) -> bool:
+    """Update one document only if its value is still the former default."""
+    transaction = db.transaction()
+
+    @async_transactional
+    async def update(transaction) -> bool:
+        snapshot = await document_ref.get(transaction=transaction)
+        data = snapshot.to_dict() if snapshot.exists else None
+        if data is None or data.get("freshness") != OLD_FRESHNESS:
+            return False
+        transaction.update(document_ref, {"freshness": NEW_FRESHNESS})
+        return True
+
+    return await update(transaction)
+
+
+async def migrate_stage_freshness(
+    db: AsyncClient,
+    *,
+    apply: bool,
+    update_document: Callable[[AsyncClient, object], Awaitable[bool]] = _update_if_unchanged,
+) -> MigrationResult:
+    """Find stage users at index 2 and optionally migrate them to index 5."""
+    query = db.collection(USERS_COLLECTION).where(
+        filter=FieldFilter("freshness", "==", OLD_FRESHNESS)
+    )
+    documents = [document async for document in query.stream()]
+
+    if not apply:
+        return MigrationResult(matched=len(documents), updated=0, skipped=0)
+
+    updated = 0
+    for document in documents:
+        if await update_document(db, document.reference):
+            updated += 1
+
+    return MigrationResult(
+        matched=len(documents),
+        updated=updated,
+        skipped=len(documents) - updated,
+    )
+
+
+async def run(*, apply: bool) -> MigrationResult:
+    configure_stage()
+    db = init_firestore_client()
+    return await migrate_stage_freshness(db, apply=apply)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Migrate stage users from freshness index 2 (24h) to 5 (7d)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply updates. Without this flag, the command is a read-only dry run.",
+    )
+    args = parser.parse_args()
+
+    mode = "APPLY" if args.apply else "DRY RUN"
+    print(f"{mode}: project={GCP_PROJECT} database={STAGE_DATABASE}")
+    result = asyncio.run(run(apply=args.apply))
+    print(f"matched={result.matched} updated={result.updated} skipped={result.skipped}")
+    if not args.apply:
+        print("No documents were changed. Re-run with --apply to migrate stage.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_stage_freshness_test.py
+++ b/scripts/migrate_stage_freshness_test.py
@@ -1,0 +1,71 @@
+"""Tests for the stage freshness migration."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from migrate_stage_freshness import (
+    NEW_FRESHNESS,
+    OLD_FRESHNESS,
+    migrate_stage_freshness,
+)
+
+
+def _async_iter(items):
+    async def generate():
+        for item in items:
+            yield item
+
+    return generate()
+
+
+def _mock_db(document_count: int):
+    db = MagicMock()
+    query = MagicMock()
+    documents = []
+    for index in range(document_count):
+        document = MagicMock()
+        document.reference = f"users/user-{index}"
+        documents.append(document)
+    query.stream.return_value = _async_iter(documents)
+    db.collection.return_value.where.return_value = query
+    return db, documents
+
+
+@pytest.mark.asyncio
+async def test_dry_run_counts_matches_without_writing():
+    db, _documents = _mock_db(3)
+    update_document = AsyncMock()
+
+    result = await migrate_stage_freshness(
+        db,
+        apply=False,
+        update_document=update_document,
+    )
+
+    assert result.matched == 3
+    assert result.updated == 0
+    assert result.skipped == 0
+    update_document.assert_not_awaited()
+    field_filter = db.collection.return_value.where.call_args.kwargs["filter"]
+    assert field_filter.field_path == "freshness"
+    assert field_filter.value == OLD_FRESHNESS
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_only_documents_still_at_old_value():
+    db, documents = _mock_db(3)
+    update_document = AsyncMock(side_effect=[True, False, True])
+
+    result = await migrate_stage_freshness(
+        db,
+        apply=True,
+        update_document=update_document,
+    )
+
+    assert result.matched == 3
+    assert result.updated == 2
+    assert result.skipped == 1
+    assert [call.args[1] for call in update_document.await_args_list] == [
+        document.reference for document in documents
+    ]
+    assert NEW_FRESHNESS == 5

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -57,7 +57,7 @@ class UserDocument(BaseModel):
         "Used to override the generator weights in your-feed.",
     )
     freshness: int = Field(
-        default=2,
+        default=5,
         ge=0,
         le=5,
         description="Freshness preference: 0=6h, 1=12h, 2=24h, 3=48h, 4=72h, 5=7d.  "

--- a/src/app/lib/candidates/base.py
+++ b/src/app/lib/candidates/base.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +52,7 @@ class CandidateGenerator(ABC):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         """Produce candidate posts for the given user.
 
@@ -67,6 +68,8 @@ class CandidateGenerator(ABC):
             When ``True``, restrict results to posts containing video.
         exclude_uris:
             AT URIs to exclude from results via an ES ``must_not`` filter.
+        max_age_hours:
+            Maximum candidate-post age based on ``created_at``.
 
         Returns
         -------

--- a/src/app/lib/candidates/es_candidates.py
+++ b/src/app/lib/candidates/es_candidates.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 from ..elasticsearch import POSTS_KNN_INDEX
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 from ..telemetry import timed
@@ -21,6 +21,7 @@ async def knn_search_posts(
     exclude_uris: list[str] | None = None,
     ge_post_embedding_model_uuid: str | None = None,
     min_like_count: int | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
     """Run a kNN search against the ``posts_recent`` index and return candidate posts.
 
@@ -28,7 +29,11 @@ async def knn_search_posts(
     traversal. The ``posts_recent`` index contains only top-level posts (no
     replies), so no reply-exclusion filter is needed.
     """
-    filters: list[dict] = []
+    # Freshness filters returned candidate posts only. Actual availability can
+    # be shorter when posts_recent retains less data than the requested bound.
+    filters: list[dict] = [
+        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
+    ]
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
@@ -71,4 +76,3 @@ async def knn_search_posts(
         )
 
     return candidate_posts_from_es_response(resp, generator_name=generator_name)
-

--- a/src/app/lib/candidates/es_candidates_test.py
+++ b/src/app/lib/candidates/es_candidates_test.py
@@ -116,15 +116,16 @@ class TestKnnSearchPosts:
         assert candidates[0].generator_name == "post_similarity"
 
     @pytest.mark.asyncio
-    async def test_no_filters_when_no_args(self):
-        """No filter clause sent to ES when there is nothing to filter on."""
+    async def test_default_freshness_filter_is_inside_knn(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
             es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD
         )
         knn = es.calls[0]["knn"]
         assert es.calls[0]["query"] is None
-        assert "filter" not in knn
+        assert {"range": {"created_at": {"gte": "now-168h"}}} in (
+            knn["filter"]["bool"]["filter"]
+        )
 
     @pytest.mark.asyncio
     async def test_video_only_true_sends_es_filter(self):
@@ -138,15 +139,16 @@ class TestKnnSearchPosts:
         assert {"term": {"contains_video": True}} in knn["filter"]["bool"]["filter"]
 
     @pytest.mark.asyncio
-    async def test_video_only_false_omits_filter(self):
-        """When video_only is False and no exclude_uris, no filter is sent."""
+    async def test_video_only_false_keeps_only_freshness_filter(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
             es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
             video_only=False
         )
         knn = es.calls[0]["knn"]
-        assert "filter" not in knn
+        assert knn["filter"]["bool"]["filter"] == [
+            {"range": {"created_at": {"gte": "now-168h"}}}
+        ]
 
     @pytest.mark.asyncio
     async def test_exclude_uris_is_an_es_filter(self):

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -1,10 +1,12 @@
 """Candidate generator for posts from followed users.
 
-Returns the last N posts from users that the requesting user follows"""
+Returns the newest posts, within the requested freshness window, from users
+that the requesting user follows.
+"""
 
 import logging
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 from ..bsky import FollowedUsersLookupError, get_followed_user_dids
 from ..config import fail_fast
 from ..telemetry import timed
@@ -13,20 +15,8 @@ from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Parameters
-# ---------------------------------------------------------------------------
-
-# Maximum number of followed users to use in the query
 MAX_FOLLOWED_USERS = 1_000
-RECENT_FRIENDS_WINDOW = "24h"
-MAX_FRIENDS_WINDOW = "7d"
 
-
-# ---------------------------------------------------------------------------
-# Query helper
-# ---------------------------------------------------------------------------
 
 async def followed_users_search(
     es,
@@ -35,69 +25,38 @@ async def followed_users_search(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
-    """Fetch posts from users followed by user_did from the ``posts_recent`` index."""
-    try:
-        candidates, _ = await _followed_users_search_details(
-            es,
-            user_did,
-            num_candidates,
-            generator_name=generator_name,
-            video_only=video_only,
-            exclude_uris=exclude_uris,
-        )
-        return candidates
-    except FollowedUsersLookupError:
-        if fail_fast():
-            raise
-        return []
-
-
-async def _followed_users_search_details(
-    es,
-    user_did: str,
-    num_candidates: int,
-    generator_name: str | None = None,
-    video_only: bool = False,
-    exclude_uris: list[str] | None = None,
-    created_at_gte: str | None = None,
-    created_at_lt: str | None = None,
-    followed_dids: list[str] | None = None,
-) -> tuple[list[CandidatePost], str | None]:
-
+    """Fetch followed-user posts from ``posts_recent`` within one strict window."""
     filters: list[dict] = []
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
-    if followed_dids is None:
-        try:
-            async with timed(logger, "bsky_get_follows", user_did=user_did):
-                followed_dids = await get_followed_user_dids(
-                    user_did,
-                    limit=MAX_FOLLOWED_USERS,
-                )
-        except FollowedUsersLookupError as exc:
-            logger.warning(
-                "Skipping followed_users candidate generation for %s after follow "
-                "lookup failed: %s",
+    try:
+        async with timed(logger, "bsky_get_follows", user_did=user_did):
+            followed_dids = await get_followed_user_dids(
                 user_did,
-                exc,
+                limit=MAX_FOLLOWED_USERS,
             )
-            if fail_fast():
-                raise
-            return [], "follow_lookup_failed"
+    except FollowedUsersLookupError as exc:
+        logger.warning(
+            "Skipping followed_users candidate generation for %s after follow "
+            "lookup failed: %s",
+            user_did,
+            exc,
+        )
+        if fail_fast():
+            raise
+        return []
 
     if not followed_dids:
-        return [], "no_followed_users"
+        return []
 
-    if created_at_gte is not None or created_at_lt is not None:
-        bounds = {}
-        if created_at_gte is not None:
-            bounds["gte"] = created_at_gte
-        if created_at_lt is not None:
-            bounds["lt"] = created_at_lt
-        filters.append({"range": {"created_at": bounds}})
-
+    # Freshness applies to the candidate post's creation time. The query does
+    # not expand beyond this bound when the requested allocation cannot be filled.
+    filters.append(
+        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}}
+    )
     query = {
         "bool": {
             "filter": [
@@ -108,7 +67,6 @@ async def _followed_users_search_details(
     }
 
     fetch_size = num_candidates + len(exclude_uris or [])
-
     async with timed(
         logger,
         "es_followed_users",
@@ -126,108 +84,16 @@ async def _followed_users_search_details(
     candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
     if exclude_uris:
         exclude_set = set(exclude_uris)
-        candidates = [c for c in candidates if c.at_uri not in exclude_set]
-    candidates = candidates[:num_candidates]
-    return candidates, None if candidates else "no_recent_followed_posts"
+        candidates = [candidate for candidate in candidates if candidate.at_uri not in exclude_set]
+    return candidates[:num_candidates]
 
 
 class FollowedUsersCandidateGenerator(CandidateGenerator):
-    """Returns the last N posts from users that the requesting user follows."""
+    """Returns recent posts from users that the requesting user follows."""
 
     @property
     def name(self) -> str:
         return "followed_users"
-
-    async def generate_stages(
-        self,
-        es,
-        user_did: str,
-        num_candidates: int = 100,
-        video_only: bool = False,
-        exclude_uris: list[str] | None = None,
-    ) -> list[CandidateResult]:
-        """Fill the social quota from 24h posts, then posts up to seven days old."""
-        try:
-            async with timed(logger, "bsky_get_follows", user_did=user_did):
-                followed_dids = await get_followed_user_dids(
-                    user_did,
-                    limit=MAX_FOLLOWED_USERS,
-                )
-        except FollowedUsersLookupError:
-            if fail_fast():
-                raise
-            return [
-                CandidateResult(
-                    generator_name=self.name,
-                    candidates=[],
-                    status="error",
-                    reason="follow_lookup_failed",
-                    mode="direct_friends_recent",
-                )
-            ]
-
-        if not followed_dids:
-            return [
-                CandidateResult(
-                    generator_name=self.name,
-                    candidates=[],
-                    status="empty",
-                    reason="no_followed_users",
-                    mode="direct_friends_recent",
-                )
-            ]
-
-        recent, recent_reason = await _followed_users_search_details(
-            es,
-            user_did,
-            num_candidates,
-            generator_name=self.name,
-            video_only=video_only,
-            exclude_uris=exclude_uris,
-            created_at_gte=f"now-{RECENT_FRIENDS_WINDOW}",
-            followed_dids=followed_dids,
-        )
-        results = [
-            CandidateResult(
-                generator_name=self.name,
-                candidates=recent,
-                status="success" if recent else "empty",
-                reason=recent_reason,
-                mode="direct_friends_recent",
-            )
-        ]
-
-        shortfall = num_candidates - len(recent)
-        if shortfall <= 0:
-            return results
-
-        recent_uris = [
-            candidate.at_uri for candidate in recent if candidate.at_uri is not None
-        ]
-        older_exclusions: list[str] = list(
-            dict.fromkeys([*(exclude_uris or []), *recent_uris])
-        )
-        older, older_reason = await _followed_users_search_details(
-            es,
-            user_did,
-            shortfall,
-            generator_name=self.name,
-            video_only=video_only,
-            exclude_uris=older_exclusions,
-            created_at_gte=f"now-{MAX_FRIENDS_WINDOW}",
-            created_at_lt=f"now-{RECENT_FRIENDS_WINDOW}",
-            followed_dids=followed_dids,
-        )
-        results.append(
-            CandidateResult(
-                generator_name=self.name,
-                candidates=older,
-                status="success" if older else "empty",
-                reason=older_reason or (None if older else "no_older_followed_posts"),
-                mode="direct_friends_7d",
-            )
-        )
-        return results
 
     async def generate(
         self,
@@ -236,19 +102,15 @@ class FollowedUsersCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
-        stages = await self.generate_stages(
+        candidates = await followed_users_search(
             es,
             user_did,
             num_candidates,
-            video_only,
-            exclude_uris,
-        )
-        candidates = [candidate for stage in stages for candidate in stage.candidates]
-        failure = next((stage for stage in stages if stage.status == "error"), None)
-        return CandidateResult(
             generator_name=self.name,
-            candidates=candidates,
-            status="success" if candidates else "empty",
-            reason=failure.reason if failure else (stages[-1].reason if stages else None),
+            video_only=video_only,
+            exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         )
+        return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -119,6 +119,7 @@ class TestFollowedUsersSearch:
         assert query == {
             "bool": {
                 "filter": [
+                    {"range": {"created_at": {"gte": "now-168h"}}},
                     {"terms": {"author_did": ["did:plc:follow1", "did:plc:follow2"]}},
                 ],
             }
@@ -280,43 +281,17 @@ class TestFollowedUsersCandidateGenerator:
         assert result.candidates[0].generator_name == "followed_users"
 
     @pytest.mark.asyncio
-    async def test_generate_stages_uses_recent_then_seven_day_window(self, generator, monkeypatch):
+    async def test_generate_uses_one_strict_selected_window(self, generator, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        es = FakeEs()
 
-        class SequencedEs(FakeEs):
-            def __init__(self):
-                super().__init__()
-                self.responses = [
-                    {"hits": {"hits": [{
-                        "_score": 1.0,
-                        "_source": {"at_uri": "at://recent/1", "content": "recent"},
-                    }]}},
-                    {"hits": {"hits": [{
-                        "_score": 0.8,
-                        "_source": {"at_uri": "at://older/1", "content": "older"},
-                    }]}},
-                ]
+        await generator.generate(
+            es, "did:plc:user1", num_candidates=2, max_age_hours=48
+        )
 
-            async def search(self, **kwargs):
-                self.calls.append(kwargs)
-                return self.responses.pop(0)
-
-        es = SequencedEs()
-        stages = await generator.generate_stages(es, "did:plc:user1", num_candidates=2)
-
-        assert [stage.mode for stage in stages] == [
-            "direct_friends_recent", "direct_friends_7d"
-        ]
-        assert [candidate.at_uri for stage in stages for candidate in stage.candidates] == [
-            "at://recent/1", "at://older/1"
-        ]
-        recent_filters = es.calls[0]["query"]["bool"]["filter"]
-        older_filters = es.calls[1]["query"]["bool"]["filter"]
-        assert {"range": {"created_at": {"gte": "now-24h"}}} in recent_filters
-        assert {
-            "range": {"created_at": {"gte": "now-7d", "lt": "now-24h"}}
-        } in older_filters
-        assert es.calls[1]["size"] == 2  # one needed + recent URI exclusion overfetch
+        assert len(es.calls) == 1
+        filters = es.calls[0]["query"]["bool"]["filter"]
+        assert {"range": {"created_at": {"gte": "now-48h"}}} in filters
 
     @pytest.mark.asyncio
     async def test_generate_empty_when_no_followed_users(self, generator, monkeypatch):

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -22,7 +22,6 @@ from ..feed_debug import current_recorder
 from ..metrics import get_metric_collector
 from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult, get_generator
-from .followed_users import FollowedUsersCandidateGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -131,30 +130,19 @@ async def run_generate(
     ) -> list[CandidateResult]:
         try:
             async with timed(logger, "candidates.generate.duration_ms", record_metric=True, metric_attrs={"generator_name": spec.name}, count=count):
-                if isinstance(gen, FollowedUsersCandidateGenerator):
-                    results = await asyncio.wait_for(
-                        gen.generate_stages(
+                results = [
+                    await asyncio.wait_for(
+                        gen.generate(
                             es=es,
                             user_did=request.user_did,
                             num_candidates=count,
                             video_only=request.video_only,
                             exclude_uris=request.exclude_uris or None,
+                            max_age_hours=request.max_age_hours,
                         ),
                         timeout=_GENERATOR_TIMEOUT_SEC,
                     )
-                else:
-                    results = [
-                        await asyncio.wait_for(
-                            gen.generate(
-                                es=es,
-                                user_did=request.user_did,
-                                num_candidates=count,
-                                video_only=request.video_only,
-                                exclude_uris=request.exclude_uris or None,
-                            ),
-                            timeout=_GENERATOR_TIMEOUT_SEC,
-                        )
-                    ]
+                ]
             if mc := get_metric_collector():
                 mc.record(
                     "candidates.generate.success_count",
@@ -238,7 +226,8 @@ async def run_generate(
                 infill_exclude_uris.append(c.at_uri)
 
         try:
-            # Ask for extra to compensate for likely dedup losses
+            # Infill receives the same freshness window as primary generation;
+            # it may compensate for deduplication but must never widen eligibility.
             infill_result = await asyncio.wait_for(
                 infill_gen.generate(
                     es=es,
@@ -246,6 +235,7 @@ async def run_generate(
                     num_candidates=shortfall * 2,
                     video_only=request.video_only,
                     exclude_uris=infill_exclude_uris or None,
+                    max_age_hours=request.max_age_hours,
                 ),
                 timeout=_GENERATOR_TIMEOUT_SEC,
             )

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -488,6 +488,7 @@ def _request(*generator_names: str) -> CandidateGenerateRequest:
         num_candidates=10,
         video_only=False,
         infill=None,
+        max_age_hours=168,
     )
 
 
@@ -501,7 +502,15 @@ class _FakeGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
+    ):
         if self._fail:
             raise self._cause
         return CandidateResult(
@@ -597,6 +606,7 @@ class TestWithPipelineContext:
             num_candidates=10,
             video_only=False,
             infill="popularity",
+            max_age_hours=168,
         )
         with pipeline_context_scope(ctx):
             result = await run_generate(req, es=object())

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import pytest
 
-from ...models import CandidateGenerateRequest, CandidatePost, GeneratorSpec
+from ...models import CandidateGenerateRequest, CandidatePost, GeneratorSpec, MaxAgeHours
 from ..candidates import generate as generate_module
 from ..candidates.base import CandidateGenerator, CandidateResult
 from ..candidates.generate import GeneratorError, run_generate
@@ -27,7 +27,10 @@ class _HangingGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self, es, user_did, num_candidates=100, video_only=False,
+        exclude_uris=None, max_age_hours=168,
+    ):
         await asyncio.sleep(9999)
         raise AssertionError("unreachable")
 
@@ -41,7 +44,10 @@ class _FailingGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self, es, user_did, num_candidates=100, video_only=False,
+        exclude_uris=None, max_age_hours=168,
+    ):
         raise self._exc
 
 
@@ -53,7 +59,10 @@ class _EmptyGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self, es, user_did, num_candidates=100, video_only=False,
+        exclude_uris=None, max_age_hours=168,
+    ):
         return CandidateResult(generator_name=self.name, candidates=[])
 
 
@@ -67,12 +76,16 @@ class _StaticGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self, es, user_did, num_candidates=100, video_only=False,
+        exclude_uris=None, max_age_hours=168,
+    ):
         self.calls.append(
             {
                 "num_candidates": num_candidates,
                 "video_only": video_only,
                 "exclude_uris": exclude_uris,
+                "max_age_hours": max_age_hours,
             }
         )
         excluded = set(exclude_uris or [])
@@ -90,7 +103,10 @@ class _FailThenReturnGenerator(CandidateGenerator):
     def name(self) -> str:
         return self._name
 
-    async def generate(self, es, user_did, num_candidates=100, video_only=False, exclude_uris=None):
+    async def generate(
+        self, es, user_did, num_candidates=100, video_only=False,
+        exclude_uris=None, max_age_hours=168,
+    ):
         self.calls += 1
         if self.calls == 1:
             raise RuntimeError("primary failed")
@@ -116,6 +132,7 @@ def _make_request(
     num_candidates: int = 5,
     infill: str | None = None,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> CandidateGenerateRequest:
     return CandidateGenerateRequest(
         generators=[GeneratorSpec(name=generator_name, weight=1.0)],
@@ -124,6 +141,7 @@ def _make_request(
         video_only=False,
         infill=infill,
         exclude_uris=exclude_uris or [],
+        max_age_hours=max_age_hours,
     )
 
 
@@ -424,6 +442,8 @@ class TestInfillGeneratorTimeout:
             "at://primary/1",
             "at://primary/2",
         ]
+        assert primary.calls[0]["max_age_hours"] == 168
+        assert infill.calls[0]["max_age_hours"] == 168
         assert [c.at_uri for c in result.candidates] == [
             "at://primary/1",
             "at://primary/2",

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 from ..bsky import FollowedUsersLookupError, get_followed_user_dids
 from ..config import fail_fast
 from ..elasticsearch import unwrap_es_response
@@ -105,12 +105,17 @@ async def fetch_posts_by_uris(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
     """Fetch posts for the supplied URIs, preserving the requested URI order."""
     if not at_uris:
         return []
 
-    filters: list[dict] = []
+    # Freshness applies to candidate post created_at, not the timestamp of the
+    # followed user's like event.
+    filters: list[dict] = [
+        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
+    ]
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
@@ -150,6 +155,7 @@ async def network_likes_search(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
     """Fetch posts liked by users followed by user_did."""
 
@@ -213,6 +219,7 @@ async def network_likes_search(
             generator_name=generator_name,
             video_only=video_only,
             exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         ):
             if candidate.at_uri:
                 candidates_by_uri[candidate.at_uri] = candidate
@@ -249,6 +256,7 @@ class NetworkLikesCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         candidates = await network_likes_search(
             es,
@@ -257,6 +265,7 @@ class NetworkLikesCandidateGenerator(CandidateGenerator):
             generator_name=self.name,
             video_only=video_only,
             exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         )
 
         if not candidates:

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -206,6 +206,7 @@ class TestFetchPostsByUris:
 
         query = es.calls[0]["query"]
         assert {"term": {"contains_video": True}} in query["bool"]["filter"]
+        assert {"range": {"created_at": {"gte": "now-168h"}}} in query["bool"]["filter"]
         assert {"terms": {"at_uri": ["at://post/a", "at://post/seen"]}} in query["bool"]["filter"]
         assert "must_not" not in query["bool"]
         assert [c.at_uri for c in candidates] == ["at://post/a"]

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -18,7 +18,7 @@ via configuration.
 
 import logging
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 from ..telemetry import timed
@@ -29,14 +29,6 @@ logger = logging.getLogger(__name__)
 # Tunables
 # ---------------------------------------------------------------------------
 
-# How far back to look for posts (ES date-math expression).
-RECENCY_WINDOW = "24h"
-
-# Gaussian decay parameters for created_at.
-# ``origin`` is implicitly "now".
-# ``scale`` controls how quickly the score falls off — posts older than
-#  this lose about half their recency boost.
-DECAY_SCALE = "6h"
 # ``offset`` — posts within this window of "now" are treated as equally new.
 DECAY_OFFSET = "1h"
 # ``decay`` — the score at ``scale`` distance from the origin (0–1).
@@ -46,6 +38,14 @@ DECAY_FACTOR = 0.5
 LIKE_FACTOR = 1.5
 # log(1 + like_count), clamping bad negative values to avoid NaN.
 LIKE_MISSING = 0
+
+
+def recency_decay_scale(max_age_hours: MaxAgeHours) -> str:
+    """Return a decay scale equal to one quarter of the freshness window."""
+    scale_minutes = max_age_hours * 15
+    if scale_minutes % 60 == 0:
+        return f"{scale_minutes // 60}h"
+    return f"{scale_minutes}m"
 
 
 # ---------------------------------------------------------------------------
@@ -58,11 +58,15 @@ async def popularity_search(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
     """Run a function_score query combining recency and like_count."""
 
+    # Freshness applies to candidate post created_at. Scaling the Gaussian with
+    # the hard window keeps wider presets meaningful rather than scoring their
+    # oldest eligible posts effectively at zero.
     filters: list[dict] = [
-        {"range": {"created_at": {"gte": f"now-{RECENCY_WINDOW}"}}},
+        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
     ]
     if video_only:
         filters.append({"term": {"contains_video": True}})
@@ -79,7 +83,7 @@ async def popularity_search(
                     "gauss": {
                         "created_at": {
                             "origin": "now",
-                            "scale": DECAY_SCALE,
+                            "scale": recency_decay_scale(max_age_hours),
                             "offset": DECAY_OFFSET,
                             "decay": DECAY_FACTOR,
                         }
@@ -146,9 +150,10 @@ class PopularityCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         candidates = await popularity_search(
             es, num_candidates, generator_name=self.name, video_only=video_only,
-            exclude_uris=exclude_uris,
+            exclude_uris=exclude_uris, max_age_hours=max_age_hours,
         )
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -5,6 +5,7 @@ import pytest
 from ..candidates.popularity import (
     PopularityCandidateGenerator,
     popularity_search,
+    recency_decay_scale,
 )
 from ..embeddings import MINILM_L12_EMBEDDING_KEY
 
@@ -98,6 +99,21 @@ class TestPopularitySearch:
         assert "Math.log1p(likes)" in script_source
         assert query["function_score"]["score_mode"] == "multiply"
         assert query["function_score"]["boost_mode"] == "replace"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("hours", "scale"),
+        [(6, "90m"), (24, "6h"), (168, "42h")],
+    )
+    async def test_selected_window_sets_cutoff_and_decay(self, hours, scale):
+        es = FakeEs()
+        await popularity_search(es, num_candidates=10, max_age_hours=hours)
+        function_score = es.calls[0]["query"]["function_score"]
+        filters = function_score["query"]["bool"]["filter"]
+        assert {"range": {"created_at": {"gte": f"now-{hours}h"}}} in filters
+        gauss = next(f["gauss"] for f in function_score["functions"] if "gauss" in f)
+        assert gauss["created_at"]["scale"] == scale
+        assert recency_decay_scale(hours) == scale
 
     @pytest.mark.asyncio
     async def test_video_only_true_includes_filter(self):

--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -10,6 +10,7 @@ Generates candidates by finding posts similar to a user's recent likes:
 
 import logging
 
+from ...models import MaxAgeHours
 from .base import CandidateGenerator, CandidateResult
 from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings
 from ..feed_debug import current_recorder
@@ -51,6 +52,7 @@ class PostSimilarityCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         rec = current_recorder()
 
@@ -81,10 +83,12 @@ class PostSimilarityCandidateGenerator(CandidateGenerator):
         vectors = [embedding for _, embedding in embedding_pairs]
         avg_vector = average_vectors(vectors)
 
-        # 4. kNN search for similar posts
+        # Freshness filters returned candidates, not the liked posts above that
+        # are used to construct this query vector.
         candidates = await knn_search_posts(
             es, avg_vector, num_candidates, search_field=MINILM_L12_EMBEDDING_FIELD,
             generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         )
 
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -4,7 +4,7 @@ Returns random recent posts from Elasticsearch using ``random_score``.
 Useful as a simple baseline generator and as a low-correlation fallback.
 """
 
-from ...models import CandidatePost
+from ...models import CandidatePost, MaxAgeHours
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
@@ -15,10 +15,15 @@ async def random_posts_search(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
+    max_age_hours: MaxAgeHours = 168,
 ) -> list[CandidatePost]:
     """Fetch random posts from the ``posts_recent`` index."""
 
-    filters: list[dict] = []
+    # Freshness is a strict candidate-post created_at bound. Random infill uses
+    # the same bound as primary generation and cannot widen the search.
+    filters: list[dict] = [
+        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
+    ]
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
@@ -64,6 +69,7 @@ class RandomPostsCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         candidates = await random_posts_search(
             es,
@@ -71,5 +77,6 @@ class RandomPostsCandidateGenerator(CandidateGenerator):
             generator_name=self.name,
             video_only=video_only,
             exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         )
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -82,6 +82,9 @@ class TestRandomPostsSearch:
         function_score = query["function_score"]
         assert "random_score" in function_score
         assert function_score["boost_mode"] == "replace"
+        assert {"range": {"created_at": {"gte": "now-168h"}}} in (
+            function_score["query"]["bool"]["filter"]
+        )
 
     @pytest.mark.asyncio
     async def test_video_only_true_includes_filter(self):

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -6,6 +6,7 @@ for the most relevant posts via the pre-calculated post embeddings.
 
 import logging
 
+from ...models import MaxAgeHours
 from .base import CandidateGenerator, CandidateResult
 from ..inference import get_inference_settings, compute_user_embedding, get_cached_post_tower_uuid
 from .es_candidates import knn_search_posts
@@ -36,6 +37,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
+        max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         inference_base_url, inference_api_key = (
             get_inference_settings()
@@ -64,11 +66,13 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
             TWO_TOWER_GENERATOR_NAME,
         )
 
-        # kNN search for the most relevant posts given the user embedding
+        # Freshness filters returned candidates, not the interaction history
+        # used above to compute the user embedding.
         candidates = await knn_search_posts(
             es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
             generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
             ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=MIN_LIKE_COUNT,
+            max_age_hours=max_age_hours,
         )
 
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -98,6 +98,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=["at://old/1", "at://old/2"],
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age_hours=168,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == candidates
@@ -137,6 +138,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age_hours=168,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == []
@@ -176,6 +178,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age_hours=168,
         )
         assert result.candidates == []
 

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -30,6 +30,7 @@ def _request() -> CandidateGenerateRequest:
         user_did="did:plc:user",
         num_candidates=10,
         video_only=False,
+        max_age_hours=168,
         infill="popularity",
     )
 
@@ -182,7 +183,7 @@ class TestBuildDocument:
         assert rec.author_dids() == {"did:plc:a", "did:plc:b"}
 
 
-def test_snapshot_diagnostics_keep_friend_fallback_modes_separate():
+def test_snapshot_diagnostics_use_one_followed_users_source():
     rec = FeedDebugRecorder(feed_name="your-feed", regenerated=False)
     rec.set_generate_request(
         CandidateGenerateRequest(
@@ -190,18 +191,14 @@ def test_snapshot_diagnostics_keep_friend_fallback_modes_separate():
             user_did="did:plc:user",
             num_candidates=3,
             video_only=False,
+            max_age_hours=168,
             infill=None,
         )
     )
     recent = _candidate("at://p/recent")
     older = _candidate("at://p/older")
     rec.record_generator_output(CandidateResult(
-        generator_name="followed_users", candidates=[recent],
-        mode="direct_friends_recent",
-    ))
-    rec.record_generator_output(CandidateResult(
-        generator_name="followed_users", candidates=[older],
-        mode="direct_friends_7d",
+        generator_name="followed_users", candidates=[recent, older],
     ))
     rec.record_final_candidates([recent, older])
     rec.record_final_order(["at://p/recent", "at://p/older"])
@@ -211,11 +208,9 @@ def test_snapshot_diagnostics_keep_friend_fallback_modes_separate():
         request_id="req", generated_at=now, expires_at=now + timedelta(minutes=15)
     )
 
-    assert [diagnostic.mode for diagnostic in snapshot.generator_diagnostics] == [
-        "direct_friends_recent", "direct_friends_7d"
-    ]
-    assert [diagnostic.requested_count for diagnostic in snapshot.generator_diagnostics] == [3, 2]
-    assert [diagnostic.contributed_count for diagnostic in snapshot.generator_diagnostics] == [1, 1]
+    assert [diagnostic.mode for diagnostic in snapshot.generator_diagnostics] == ["primary"]
+    assert [diagnostic.requested_count for diagnostic in snapshot.generator_diagnostics] == [3]
+    assert [diagnostic.contributed_count for diagnostic in snapshot.generator_diagnostics] == [2]
 
 
 class TestModelScoreCapture:
@@ -320,6 +315,7 @@ class TestBuildPipelineMetadata:
                 user_did="did:plc:user",
                 num_candidates=30,
                 video_only=False,
+                max_age_hours=168,
                 infill=None,
             )
         )
@@ -346,6 +342,7 @@ class TestBuildPipelineMetadata:
                 user_did="did:plc:user",
                 num_candidates=30,
                 video_only=False,
+                max_age_hours=168,
                 infill=None,
             )
         )
@@ -382,6 +379,7 @@ class TestBuildPipelineMetadata:
                 user_did="did:plc:user",
                 num_candidates=30,
                 video_only=False,
+                max_age_hours=168,
                 infill=None,
             )
         )
@@ -418,6 +416,7 @@ class TestBuildPipelineMetadata:
                 user_did="did:plc:user",
                 num_candidates=30,
                 video_only=False,
+                max_age_hours=168,
                 infill=None,
             )
         )
@@ -447,6 +446,7 @@ class TestBuildPipelineMetadata:
                 user_did="did:plc:user",
                 num_candidates=30,
                 video_only=False,
+                max_age_hours=168,
                 infill=None,
             )
         )

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -627,6 +627,7 @@ def _feed_debug_doc() -> FeedDebugDocument:
             user_did=USER_DID,
             num_candidates=10,
             video_only=False,
+            max_age_hours=168,
             infill=None,
         ),
         final_order=["at://p/1", "at://p/2"],

--- a/src/app/lib/freshness.py
+++ b/src/app/lib/freshness.py
@@ -1,0 +1,20 @@
+"""Shared freshness presets for feed preferences and candidate generation."""
+
+from ..models import MaxAgeHours
+
+DEFAULT_FRESHNESS_INDEX = 5
+DEFAULT_MAX_AGE_HOURS: MaxAgeHours = 168
+
+FRESHNESS_HOURS_BY_INDEX: dict[int, MaxAgeHours] = {
+    0: 6,
+    1: 12,
+    2: 24,
+    3: 48,
+    4: 72,
+    5: 168,
+}
+
+
+def max_age_hours_for_freshness(freshness: int) -> MaxAgeHours:
+    """Resolve a stored freshness index, falling back to the seven-day default."""
+    return FRESHNESS_HOURS_BY_INDEX.get(freshness, DEFAULT_MAX_AGE_HOURS)

--- a/src/app/lib/freshness_test.py
+++ b/src/app/lib/freshness_test.py
@@ -1,0 +1,19 @@
+import pytest
+
+from .freshness import (
+    DEFAULT_MAX_AGE_HOURS,
+    FRESHNESS_HOURS_BY_INDEX,
+    max_age_hours_for_freshness,
+)
+
+
+@pytest.mark.parametrize(
+    ("index", "hours"),
+    sorted(FRESHNESS_HOURS_BY_INDEX.items()),
+)
+def test_maps_freshness_index_to_hours(index, hours):
+    assert max_age_hours_for_freshness(index) == hours
+
+
+def test_unknown_index_falls_back_to_seven_days():
+    assert max_age_hours_for_freshness(99) == DEFAULT_MAX_AGE_HOURS == 168

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -87,6 +87,9 @@ class GeneratorSpec(BaseModel):
     )
 
 
+MaxAgeHours = Literal[6, 12, 24, 48, 72, 168]
+
+
 class CandidateGenerateRequest(BaseModel):
     """Describes a candidate-generation job.
 
@@ -102,6 +105,13 @@ class CandidateGenerateRequest(BaseModel):
     user_did: str = Field(..., description="AT Protocol DID of the user")
     num_candidates: int = Field(100, ge=1, le=1000, description="Total candidates to return")
     video_only: bool = Field(False, description="When true, only return posts containing video")
+    # Freshness always means the candidate post's created_at timestamp. Actual
+    # availability may be shorter than this upper bound when an environment's
+    # backing index retention is shorter (notably stage).
+    max_age_hours: MaxAgeHours = Field(
+        168,
+        description="Maximum candidate-post age in hours (6h through 7d).",
+    )
     exclude_uris: list[str] = Field(
         default_factory=list,
         description=(

--- a/src/app/models_feed_transparency.py
+++ b/src/app/models_feed_transparency.py
@@ -113,6 +113,6 @@ class Preferences(BaseModel):
     model_config = {"extra": "forbid"}
 
     social_radius: int = Field(default=3, ge=0, le=4)
-    freshness: int = Field(default=2, ge=0, le=5)
+    freshness: int = Field(default=5, ge=0, le=5)
     politics: float = Field(default=1.0, ge=0.5, le=1.5)
     purpose: float = Field(default=0.5, ge=0.2, le=0.8)

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -64,3 +64,40 @@ class TestFeedConfig:
     def test_avatar_can_be_set(self):
         cfg = _minimal_feed_cfg(avatar="assets/icons/test.png")
         assert cfg.avatar == "assets/icons/test.png"
+
+
+class TestCandidateGenerateRequest:
+    def test_defaults_to_seven_days(self):
+        request = CandidateGenerateRequest(
+            generators=[GeneratorSpec(name="test", weight=1.0)],
+            user_did="did:plc:test",
+            num_candidates=100,
+            video_only=False,
+            max_age_hours=168,
+            infill=None,
+        )
+        assert request.max_age_hours == 168
+
+    @pytest.mark.parametrize("hours", [6, 12, 24, 48, 72, 168])
+    def test_accepts_supported_freshness_windows(self, hours):
+        request = CandidateGenerateRequest(
+            generators=[GeneratorSpec(name="test", weight=1.0)],
+            user_did="did:plc:test",
+            num_candidates=100,
+            video_only=False,
+            max_age_hours=hours,
+            infill=None,
+        )
+        assert request.max_age_hours == hours
+
+    @pytest.mark.parametrize("hours", [0, 10, 169])
+    def test_rejects_unsupported_freshness_windows(self, hours):
+        with pytest.raises(ValidationError):
+            CandidateGenerateRequest(
+                generators=[GeneratorSpec(name="test", weight=1.0)],
+                user_did="did:plc:test",
+                num_candidates=100,
+                video_only=False,
+                max_age_hours=hours,
+                infill=None,
+            )

--- a/src/app/routers/feed_transparency.py
+++ b/src/app/routers/feed_transparency.py
@@ -174,7 +174,16 @@ async def list_feeds(
     )
 
     summaries: list[FeedSummary] = []
+    seen_snapshots: set[tuple[str, tuple[str, ...]]] = set()
     for doc in docs:
+        # Treat the complete ordered post sequence as the snapshot identity.
+        # Documents are newest-first, so skipping a repeated key retains the
+        # newest load while preserving snapshots with different posts or order.
+        snapshot_key = (doc.feed_name, tuple(doc.items))
+        if snapshot_key in seen_snapshots:
+            continue
+        seen_snapshots.add(snapshot_key)
+
         summaries.append(
             FeedSummary(
                 request_id=doc.request_id,

--- a/src/app/routers/feed_transparency_test.py
+++ b/src/app/routers/feed_transparency_test.py
@@ -161,7 +161,7 @@ def test_list_feeds_returns_401_without_auth():
 
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
-def test_list_feeds_preserves_overlapping_snapshots(mock_query, client):
+def test_list_feeds_collapses_identical_snapshots_and_keeps_newest(mock_query, client):
     now = datetime.now(timezone.utc)
     newer = _snapshot_doc(
         request_id="req-1",
@@ -185,9 +185,57 @@ def test_list_feeds_preserves_overlapping_snapshots(mock_query, client):
 
     response = client.get("/api/feeds")
     data = response.json()
-    assert len(data["feeds"]) == 2
-    assert data["feeds"][0]["request_id"] == "req-1"
-    assert data["feeds"][1]["request_id"] == "req-2"
+    assert [feed["request_id"] for feed in data["feeds"]] == ["req-1"]
+
+
+@patch("app.routers.feed_transparency.get_recent_feed_snapshots")
+def test_list_feeds_preserves_same_posts_in_different_order(mock_query, client):
+    now = datetime.now(timezone.utc)
+    mock_query.return_value = [
+        _snapshot_doc(
+            request_id="req-1",
+            generated_at=now,
+            items=["at://a", "at://b"],
+        ),
+        _snapshot_doc(
+            request_id="req-2",
+            generated_at=now - timedelta(minutes=5),
+            items=["at://b", "at://a"],
+        ),
+    ]
+
+    response = client.get("/api/feeds")
+
+    assert [feed["request_id"] for feed in response.json()["feeds"]] == [
+        "req-1",
+        "req-2",
+    ]
+
+
+@patch("app.routers.feed_transparency.get_recent_feed_snapshots")
+def test_list_feeds_preserves_identical_posts_from_different_feeds(mock_query, client):
+    now = datetime.now(timezone.utc)
+    mock_query.return_value = [
+        _snapshot_doc(
+            request_id="req-1",
+            generated_at=now,
+            feed_name="your-feed",
+            items=["at://a", "at://b"],
+        ),
+        _snapshot_doc(
+            request_id="req-2",
+            generated_at=now - timedelta(minutes=5),
+            feed_name="best-of-friends",
+            items=["at://a", "at://b"],
+        ),
+    ]
+
+    response = client.get("/api/feeds")
+
+    assert [feed["request_id"] for feed in response.json()["feeds"]] == [
+        "req-1",
+        "req-2",
+    ]
 
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
@@ -481,7 +529,7 @@ def test_get_preferences_returns_default_for_new_user(mock_get_user, client):
     assert response.status_code == 200
     data = response.json()
     assert data["social_radius"] == 3  # default
-    assert data["freshness"] == 2  # default
+    assert data["freshness"] == 5  # seven-day default
     assert data["politics"] == 1.0  # default
     assert data["purpose"] == 0.5  # default
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -48,6 +48,7 @@ from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import DEFAULT_TTL_SECONDS, FeedCache
 from ..lib.feed_context import FeedContextPayload, decode_feed_context, encode_feed_context
 from ..lib.feed_debug import FeedDebugRecorder, current_recorder, feed_debug_scope
+from ..lib.freshness import DEFAULT_FRESHNESS_INDEX, max_age_hours_for_freshness
 from ..lib.firestore import (
     FEED_DEBUG_RETENTION_DAYS,
     get_recent_discarded_uris,
@@ -1150,7 +1151,9 @@ async def get_feed_skeleton(
     except Exception:
         logger.exception("Failed to read debug flag for user '%s'", user_did)
 
-    # Apply social-radius preference override to your-feed generator weights.
+    # Social Radius only reallocates the fixed candidate batch among sources;
+    # it never increases the total candidate count or per-request batch cap.
+    # Apply its preference override to your-feed generator weights.
     # The override is computed once and threaded through model_copy in both
     # generation paths so the shared module-level template is never mutated.
     generators_override: dict = {}
@@ -1160,6 +1163,11 @@ async def get_feed_skeleton(
         preset = SOCIAL_RADIUS_PRESETS.get(applied_social_radius)
         if preset is not None:
             generators_override = {"generators": preset}
+
+    freshness_index = (
+        user_doc.freshness if user_doc is not None else DEFAULT_FRESHNESS_INDEX
+    )
+    max_age_hours = max_age_hours_for_freshness(freshness_index)
 
     feed_cache = _get_feed_cache(request)
 
@@ -1227,6 +1235,7 @@ async def get_feed_skeleton(
                         "user_did": user_did,
                         "num_candidates": batch,
                         "exclude_uris": exclude_uris,
+                        "max_age_hours": max_age_hours,
                         **generators_override,
                     }
                 )
@@ -1296,6 +1305,7 @@ async def get_feed_skeleton(
                     "user_did": user_did,
                     "num_candidates": batch,
                     "exclude_uris": exclude_uris,
+                    "max_age_hours": max_age_hours,
                     **generators_override,
                 }
             )

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -2422,6 +2422,7 @@ class TestSocialRadiusOverride:
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
             social_radius=0,
+            freshness=1,
         )
         mock_pipeline.return_value = PipelineResult(["at://dummy/1", "at://dummy/2"], [])
 
@@ -2433,6 +2434,7 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS[0]
+        assert gen_request.max_age_hours == 12
 
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -2476,6 +2478,7 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS[3]
+        assert gen_request.max_age_hours == 168
 
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)


### PR DESCRIPTION
- All candidate generators should be controlled by the same time window parameter from the frontend
- Remove extended time window fallback in followed_users