### PR TITLE
Fix slow ES serving-path queries behind feed timeouts

### DIFF
--- a/src/app/lib/candidates/es_candidates.py
+++ b/src/app/lib/candidates/es_candidates.py
@@ -21,16 +21,27 @@ async def knn_search_posts(
     exclude_uris: list[str] | None = None,
     ge_post_embedding_model_uuid: str | None = None,
     min_like_count: int | None = None,
+    max_age: str | None = None,
 ) -> list[CandidatePost]:
     """Run a kNN search against the ``posts_recent`` index and return candidate posts.
 
     Filters are passed inside the kNN clause so ES applies them during HNSW
     traversal. The ``posts_recent`` index contains only top-level posts (no
     replies), so no reply-exclusion filter is needed.
+
+    ``max_age`` (an ES date-math duration like ``"48h"``) bounds candidates to
+    recently created posts. When a selective filter such as ``min_like_count``
+    is present, Lucene abandons the HNSW graph and brute-force scans every
+    vector matching the filter — bounding the scan set by recency is what keeps
+    that affordable (and keeps the scanned pages hot across requests, since the
+    set is the same for every user).
     """
     filters: list[dict] = []
     if video_only:
         filters.append({"term": {"contains_video": True}})
+
+    if max_age:
+        filters.append({"range": {"created_at": {"gte": f"now-{max_age}"}}})
 
     if ge_post_embedding_model_uuid:
         filters.append({"term": {"ge_post_embedding_model_uuid": ge_post_embedding_model_uuid}})
@@ -67,7 +78,11 @@ async def knn_search_posts(
             knn=knn_clause,
             size=num_candidates,
             _source=CANDIDATE_SOURCE_FIELDS,
-            request_timeout=60,
+            # Callers abandon this search after a few seconds (the candidate
+            # generator timeout), but ES keeps executing abandoned queries to
+            # completion — a long client timeout here lets a pathological query
+            # burn cluster resources long after anyone is waiting for it.
+            request_timeout=10,
         )
 
     return candidate_posts_from_es_response(resp, generator_name=generator_name)

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -106,8 +106,10 @@ async def _followed_users_search_details(
             ],
         }
     }
-
-    fetch_size = num_candidates + len(exclude_uris or [])
+    # Exclusions in the query (not client-side after an overfetch) keep the
+    # fetch size at num_candidates even when a user's seen list is large.
+    if exclude_uris:
+        query["bool"]["must_not"] = [{"terms": {"at_uri": exclude_uris}}]
 
     async with timed(
         logger,
@@ -118,13 +120,14 @@ async def _followed_users_search_details(
         resp = await es.search(
             index="posts_recent",
             query=query,
-            size=fetch_size,
+            size=num_candidates,
             sort=[{"created_at": "desc"}],
             _source=CANDIDATE_SOURCE_FIELDS,
         )
 
     candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
     if exclude_uris:
+        # ES already excluded these; kept as a cheap safety net.
         exclude_set = set(exclude_uris)
         candidates = [c for c in candidates if c.at_uri not in exclude_set]
     candidates = candidates[:num_candidates]

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -146,7 +146,7 @@ class TestFollowedUsersSearch:
         assert {"term": {"contains_video": True}} not in filters
 
     @pytest.mark.asyncio
-    async def test_exclude_uris_overfetches_and_filters_in_python(self, monkeypatch):
+    async def test_exclude_uris_pushed_into_query(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(responses={
             "posts_recent": {
@@ -155,10 +155,6 @@ class TestFollowedUsersSearch:
                         {
                             "_score": 1.0,
                             "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.9,
-                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
                         },
                         {
                             "_score": 0.8,
@@ -176,8 +172,10 @@ class TestFollowedUsersSearch:
             exclude_uris=["at://post/excluded"],
         )
 
-        assert "must_not" not in es.calls[0]["query"]["bool"]
-        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert es.calls[0]["query"]["bool"]["must_not"] == [
+            {"terms": {"at_uri": ["at://post/excluded"]}}
+        ]
+        assert es.calls[0]["size"] == 2  # no overfetch; ES handles exclusions
         assert [c.at_uri for c in candidates] == ["at://post/1", "at://post/2"]
 
     @pytest.mark.asyncio
@@ -316,7 +314,12 @@ class TestFollowedUsersCandidateGenerator:
         assert {
             "range": {"created_at": {"gte": "now-7d", "lt": "now-24h"}}
         } in older_filters
-        assert es.calls[1]["size"] == 2  # one needed + recent URI exclusion overfetch
+        # The second stage asks only for the shortfall (1); the recent stage's
+        # URI is excluded inside the query rather than via overfetch.
+        assert es.calls[1]["size"] == 1
+        assert es.calls[1]["query"]["bool"]["must_not"] == [
+            {"terms": {"at_uri": ["at://recent/1"]}}
+        ]
 
     @pytest.mark.asyncio
     async def test_generate_empty_when_no_followed_users(self, generator, monkeypatch):

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -67,13 +67,18 @@ async def popularity_search(
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
+    # Exclusions go into the query as must_not so we can fetch exactly
+    # num_candidates docs. The previous approach — overfetching
+    # num_candidates + len(exclude_uris) and filtering client-side — made
+    # fetch sizes balloon to ~2000 as a user's seen-post list grew, which
+    # dominated query cost (fetch phase + response payload).
+    bool_query: dict = {"filter": filters}
+    if exclude_uris:
+        bool_query["must_not"] = [{"terms": {"at_uri": exclude_uris}}]
+
     query = {
         "function_score": {
-            "query": {
-                "bool": {
-                    "filter": filters,
-                }
-            },
+            "query": {"bool": bool_query},
             "functions": [
                 {
                     "gauss": {
@@ -107,18 +112,17 @@ async def popularity_search(
         }
     }
 
-    fetch_size = num_candidates + len(exclude_uris or [])
-
     async with timed(logger, "es_popularity", num_candidates=num_candidates):
         resp = await es.search(
             index="posts_recent",
             query=query,
-            size=fetch_size,
+            size=num_candidates,
             _source=CANDIDATE_SOURCE_FIELDS,
         )
 
     candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
     if exclude_uris:
+        # ES already excluded these; kept as a cheap safety net.
         exclude_set = set(exclude_uris)
         candidates = [c for c in candidates if c.at_uri not in exclude_set]
     return candidates[:num_candidates]

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -116,7 +116,7 @@ class TestPopularitySearch:
         assert any("range" in f for f in filters)
 
     @pytest.mark.asyncio
-    async def test_exclude_uris_overfetches_and_filters_in_python(self):
+    async def test_exclude_uris_pushed_into_query(self):
         es = FakeEs(responses={
             "posts_recent": {
                 "hits": {
@@ -124,10 +124,6 @@ class TestPopularitySearch:
                         {
                             "_score": 10.0,
                             "_source": {"at_uri": "at://popular/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 9.0,
-                            "_source": {"at_uri": "at://popular/excluded", "content": "x", "embeddings": {}},
                         },
                         {
                             "_score": 8.0,
@@ -145,8 +141,10 @@ class TestPopularitySearch:
         )
 
         inner_bool = es.calls[0]["query"]["function_score"]["query"]["bool"]
-        assert "must_not" not in inner_bool
-        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert inner_bool["must_not"] == [
+            {"terms": {"at_uri": ["at://popular/excluded"]}}
+        ]
+        assert es.calls[0]["size"] == 2  # no overfetch; ES handles exclusions
         assert [c.at_uri for c in candidates] == ["at://popular/1", "at://popular/2"]
 
     @pytest.mark.asyncio

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -8,9 +8,6 @@ from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
-# How far back to sample posts from (ES date-math expression).
-RECENCY_WINDOW = "24h"
-
 
 async def random_posts_search(
     es,
@@ -19,12 +16,12 @@ async def random_posts_search(
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
 ) -> list[CandidatePost]:
-    """Fetch random posts from the ``posts_recent`` index."""
+    """Fetch random posts from the ``posts_recent`` index.
 
-    # Without a recency bound, random_score scores every doc in the alias
-    # (~2 weeks of posts); a 24h window halves the query cost and better
-    # matches the "recent posts" intent.
-    filters: list[dict] = [{"range": {"created_at": {"gte": f"now-{RECENCY_WINDOW}"}}}]
+    Deliberately samples the full alias (~2 weeks) — downstream features
+    depend on random draws from the whole window, so no recency filter here.
+    """
+    filters: list[dict] = []
     if video_only:
         filters.append({"term": {"contains_video": True}})
 

--- a/src/app/lib/candidates/random_posts.py
+++ b/src/app/lib/candidates/random_posts.py
@@ -8,6 +8,9 @@ from ...models import CandidatePost
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
+# How far back to sample posts from (ES date-math expression).
+RECENCY_WINDOW = "24h"
+
 
 async def random_posts_search(
     es,
@@ -18,33 +21,37 @@ async def random_posts_search(
 ) -> list[CandidatePost]:
     """Fetch random posts from the ``posts_recent`` index."""
 
-    filters: list[dict] = []
+    # Without a recency bound, random_score scores every doc in the alias
+    # (~2 weeks of posts); a 24h window halves the query cost and better
+    # matches the "recent posts" intent.
+    filters: list[dict] = [{"range": {"created_at": {"gte": f"now-{RECENCY_WINDOW}"}}}]
     if video_only:
         filters.append({"term": {"contains_video": True}})
 
+    # Exclusions in the query (not client-side after an overfetch) keep the
+    # fetch size at num_candidates even when a user's seen list is large.
+    bool_query: dict = {"filter": filters}
+    if exclude_uris:
+        bool_query["must_not"] = [{"terms": {"at_uri": exclude_uris}}]
+
     query = {
         "function_score": {
-            "query": {
-                "bool": {
-                    "filter": filters,
-                }
-            },
+            "query": {"bool": bool_query},
             "random_score": {},
             "boost_mode": "replace",
         }
     }
 
-    fetch_size = num_candidates + len(exclude_uris or [])
-
     resp = await es.search(
         index="posts_recent",
         query=query,
-        size=fetch_size,
+        size=num_candidates,
         _source=CANDIDATE_SOURCE_FIELDS,
     )
 
     candidates = candidate_posts_from_es_response(resp, generator_name=generator_name)
     if exclude_uris:
+        # ES already excluded these; kept as a cheap safety net.
         exclude_set = set(exclude_uris)
         candidates = [c for c in candidates if c.at_uri not in exclude_set]
     return candidates[:num_candidates]

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -98,7 +98,7 @@ class TestRandomPostsSearch:
         assert {"term": {"contains_video": True}} not in filters
 
     @pytest.mark.asyncio
-    async def test_exclude_uris_overfetches_and_filters_in_python(self):
+    async def test_exclude_uris_pushed_into_query(self):
         es = FakeEs(responses={
             "posts_recent": {
                 "hits": {
@@ -106,10 +106,6 @@ class TestRandomPostsSearch:
                         {
                             "_score": 1.0,
                             "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.9,
-                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
                         },
                         {
                             "_score": 0.8,
@@ -127,8 +123,8 @@ class TestRandomPostsSearch:
         )
 
         inner_bool = es.calls[0]["query"]["function_score"]["query"]["bool"]
-        assert "must_not" not in inner_bool
-        assert es.calls[0]["size"] == 3  # num_candidates + len(exclude_uris)
+        assert inner_bool["must_not"] == [{"terms": {"at_uri": ["at://post/excluded"]}}]
+        assert es.calls[0]["size"] == 2  # no overfetch; ES handles exclusions
         assert [c.at_uri for c in candidates] == ["at://post/1", "at://post/2"]
 
     @pytest.mark.asyncio

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -19,9 +19,12 @@ MIN_LIKE_COUNT = 20
 # Only consider posts created within this window. Besides freshness, this
 # bounds the brute-force vector scan that the selective MIN_LIKE_COUNT filter
 # forces on ES: like_count>=20 alone matches ~1M posts in posts_recent (a
-# multi-second cold scan per query), while the ~48h slice is ~135k and stays
-# hot in the page cache because it is identical for every user.
-MAX_POST_AGE = "48h"
+# multi-second cold scan per query), while the 96h slice is ~320k (~95k/day)
+# and stays hot in the page cache because it is identical for every user.
+# Warm-scan cost measured on prod: 100-350ms; a fully cold scan re-warms the
+# shared set in one query, so longer windows mainly cost re-warm time after
+# cache-eviction events.
+MAX_POST_AGE = "96h"
 
 
 class TwoTowerCandidateGenerator(CandidateGenerator):

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -16,6 +16,12 @@ logger = logging.getLogger(__name__)
 
 TWO_TOWER_GENERATOR_NAME = "two_tower"
 MIN_LIKE_COUNT = 20
+# Only consider posts created within this window. Besides freshness, this
+# bounds the brute-force vector scan that the selective MIN_LIKE_COUNT filter
+# forces on ES: like_count>=20 alone matches ~1M posts in posts_recent (a
+# multi-second cold scan per query), while the ~48h slice is ~135k and stays
+# hot in the page cache because it is identical for every user.
+MAX_POST_AGE = "48h"
 
 
 class TwoTowerCandidateGenerator(CandidateGenerator):
@@ -69,6 +75,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
             es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
             generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
             ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=MIN_LIKE_COUNT,
+            max_age=MAX_POST_AGE,
         )
 
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -7,6 +7,7 @@ import pytest
 from ...models import CandidatePost
 from ..candidates import get_generator, list_generators
 from ..candidates.two_tower import (
+    MAX_POST_AGE,
     MIN_LIKE_COUNT,
     TWO_TOWER_GENERATOR_NAME,
     TwoTowerCandidateGenerator,
@@ -98,6 +99,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=["at://old/1", "at://old/2"],
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age=MAX_POST_AGE,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == candidates
@@ -137,6 +139,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age=MAX_POST_AGE,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == []
@@ -176,6 +179,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=MIN_LIKE_COUNT,
+            max_age=MAX_POST_AGE,
         )
         assert result.candidates == []
 

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -173,7 +173,10 @@ class TestTwoTowerCandidateGenerator:
         ):
             await generator.generate(es, "did:plc:user1", max_age_hours=fresh_hours)
 
-        assert knn_search.await_args.kwargs["max_age_hours"] == fresh_hours
+        knn_search.assert_awaited_once()
+        await_args = knn_search.await_args
+        assert await_args is not None
+        assert await_args.kwargs["max_age_hours"] == fresh_hours
 
     @pytest.mark.asyncio
     async def test_generate_allows_zero_candidates_passthrough(self, generator):

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -87,6 +87,10 @@ async def fetch_recent_liked_post_uris(
                 size=limit,
                 sort=[{"created_at": "desc"}],
                 _source=["subject_uri"],
+                # Likes are indexed with routing=author_did (see ingex), so
+                # routing on the same DIDs searches one shard per weekly index
+                # instead of fanning out to every shard of every index.
+                routing=",".join(user_dids),
             )
 
             data = unwrap_es_response(resp)
@@ -147,6 +151,8 @@ async def fetch_recent_liked_post_uris_and_times(
                 size=limit,
                 sort=[{"created_at": "desc"}],
                 _source=["subject_uri", "created_at"],
+                # Same routing rationale as fetch_recent_liked_post_uris.
+                routing=",".join(user_dids),
             )
 
             data = unwrap_es_response(resp)


### PR DESCRIPTION
Closes #310 (the quick-fix portion — follow-up tasks filed separately).

## Motivation

Since feed timeouts were tightened below the Bluesky client timeout, **~8-10% of your-feed loads serve degraded** — ~666 of 7.9k over the last 72h (8.4%), and 8-13% on individual days once the `feed.render.degraded_count` metric began emitting on 2026-07-24. (An earlier revision of this description said ~2%; that was wrong — it divided a partial first-day count of the just-deployed metric by a fuller-window success denominator. See the thread below.) Prod metrics show the rankers, inference, and Perspective all comfortably inside their budgets (p99 < 1s); the degradation is almost entirely ES-side candidate generation — dominated by `two_tower` generator timeouts (686 in 72h), which map ~1:1 onto degraded renders. Component timeouts (4s generator, 2.5s ranker, 1.5s hydration) cap each render, so degradation surfaces as reduced-quality 200s rather than 504s (your-feed render p95≈4.5s, p99≈5s; ~0 hard 504 timeouts).

## What was slow (measured against prod ES)

- **two_tower kNN**: the `like_count >= 20` filter matches ~928k of 20.2M docs in `posts_recent`. A filter that selective makes Lucene abandon the HNSW graph and brute-force scan every matching vector (confirmed via `profile: true` — ~460k vector ops/query). Cold, that's a ~30s query; prod abandons it at the 4s generator timeout while ES keeps grinding.
- **likes lookups**: `likes` docs are indexed with `routing=author_did`, but reads never passed routing — every recent-likes lookup fanned out to all 56 primary shards of the 1B-doc alias.
- **popularity / random_posts / followed_users**: exclusions were handled by overfetching `num_candidates + len(exclude_uris)` (≈2000 docs as seen-lists grow) and filtering client-side.

## Changes

- two_tower kNN: add a 96h `created_at` bound to the kNN filter. The scan set drops to ~320k docs (~95k/day pass the like filter) and is identical for every user, so it stays page-cache hot: 100–350ms warm measured on prod (vs 30s cold before); a fully cold scan re-warms the shared set in one query. Also drop kNN `request_timeout` 60s → 10s so abandoned queries stop burning cluster resources.
- likes fetchers: pass `routing` on the queried DIDs (1 shard per weekly index instead of 7).
- popularity / random_posts / followed_users: push exclusions into the query as `must_not` terms, fetch exactly `num_candidates` (followed_users at prod sizes: **407ms → 29ms**). random_posts keeps sampling the full 2-week alias — downstream features depend on whole-window draws.

## Testing

- Unit suite: 863 passed.
- End-to-end against prod ES (read-only key) + stage inference + live Perspective, for three users including a heavy real user: your-feed first page, cursor paging, past-end regeneration with exclusions, and random feed — all fully populated, kNN at 200–800ms, zero ES timeouts or errors.
- kNN window sizing measured at 48/72/96/120h on prod: counts 136k/230k/322k/411k; warm scans 90–350ms at every size, so 96h buys a 4× candidate pool for ~2× the cold-scan work vs 48h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
