### PR TITLE
Cold Start Debug Feed

### DIFF
--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -55,7 +55,10 @@ from app.lib.firestore import (
 )
 
 console = Console()
-HEAVY_RANKER_MODEL_NAME = "heavy_ranker"
+HEAVY_RANKER_MODEL_NAMES = (
+    "heavy_ranker",
+    "heavy_ranker_empty_history",
+)
 
 # GCP project + Firestore database per environment. Both environments live in
 # the same project and are separated by database (see scripts/gcp_setup.sh).
@@ -148,6 +151,13 @@ def _generator_candidate_groups(doc: FeedDebugDocument) -> dict[str, list]:
     return groups
 
 
+def _active_heavy_ranker_model_name(doc: FeedDebugDocument) -> str:
+    for entry in doc.model_scores:
+        if entry.model_name in HEAVY_RANKER_MODEL_NAMES:
+            return entry.model_name
+    return HEAVY_RANKER_MODEL_NAMES[0]
+
+
 def _candidate_stats_rows(doc: FeedDebugDocument) -> list[tuple[str, str, str, str, str]]:
     """Candidate stats by generator.
 
@@ -157,8 +167,9 @@ def _candidate_stats_rows(doc: FeedDebugDocument) -> list[tuple[str, str, str, s
     final_ranks = {uri: i + 1 for i, uri in enumerate(doc.final_order)}
     author_penalties = {entry.at_uri: entry.author_penalty for entry in doc.diversification}
     heavy_scores: dict[str, float] = {}
+    heavy_ranker_model_name = _active_heavy_ranker_model_name(doc)
     for entry in doc.model_scores:
-        if entry.model_name == HEAVY_RANKER_MODEL_NAME:
+        if entry.model_name == heavy_ranker_model_name:
             heavy_scores = {score.at_uri: score.score for score in entry.scores}
             break
 
@@ -341,7 +352,11 @@ def _candidate_stats_table(doc: FeedDebugDocument) -> Table:
     table.add_column("generator", style="cyan")
     table.add_column("count", justify="right", style="green")
     table.add_column("placement", justify="right", style="yellow")
-    table.add_column("heavy_ranker", justify="right", style="white")
+    table.add_column(
+        _active_heavy_ranker_model_name(doc),
+        justify="right",
+        style="white",
+    )
     table.add_column("author_penalty", justify="right", style="magenta")
     for (
         label,

--- a/scripts/feed_debug_test.py
+++ b/scripts/feed_debug_test.py
@@ -113,6 +113,16 @@ def test_generator_output_stats_labels_primary_and_infill_with_average_rank():
         ("popularity", "1", "2.0", "0.80", "0.200"),
         ("infill popularity", "2", "4.0", "0.10", "0.000"),
     ]
+    assert [
+        column.header
+        for column in feed_debug._candidate_stats_table(doc).columns
+    ] == [
+        "generator",
+        "count",
+        "placement",
+        "heavy_ranker",
+        "author_penalty",
+    ]
 
 
 def test_generator_output_stats_includes_missing_primary_as_zero():
@@ -182,4 +192,41 @@ def test_generator_output_stats_counts_duplicate_candidates_in_average():
 
     assert feed_debug._candidate_stats_rows(doc) == [
         ("two_tower", "3", "1.7", "0.60", "0.400"),
+    ]
+
+
+def test_candidate_stats_uses_single_empty_history_heavy_ranker_column():
+    doc = _doc(
+        generators=["two_tower_empty_history"],
+        infill=None,
+        outputs=[
+            _result(
+                "two_tower_empty_history",
+                ["at://p/1", "at://p/2"],
+            )
+        ],
+        final_order=["at://p/2", "at://p/1"],
+        model_scores=[
+            _model_score(
+                "heavy_ranker_empty_history",
+                {"at://p/1": 0.2, "at://p/2": 0.8},
+            ),
+            _model_score(
+                "perspective",
+                {"at://p/1": -1.0, "at://p/2": -1.0},
+            ),
+        ],
+    )
+
+    assert feed_debug._candidate_stats_rows(doc) == [
+        ("two_tower_empty_history", "2", "1.5", "0.50", "—"),
+    ]
+
+    table = feed_debug._candidate_stats_table(doc)
+    assert [column.header for column in table.columns] == [
+        "generator",
+        "count",
+        "placement",
+        "heavy_ranker_empty_history",
+        "author_penalty",
     ]

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -293,4 +293,32 @@ FEEDS: dict[str, FeedConfig] = {
             exclude_uris=[],
         ),
     ),
+    "cold-start": FeedConfig(
+        display_name="Cold Start",
+        description="Main Green Earth feed for a user with no like history.",
+        public=False,
+        internal_rkey="mf-cs",
+        internal_display_name="mf CS",
+        avatar="assets/icons/green-earth.png",
+        max_render_share=0.5,
+        min_rank_score=0.425,
+        min_mmr_score=-0.05,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="followed_users", weight=0.40),
+                GeneratorSpec(name="two_tower_empty_history", weight=0.30),
+                GeneratorSpec(name="popularity", weight=0.30),
+            ],
+            infill=None,
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
+        ),
+        rank_request_template=RankPredictRequest.model_construct(
+            models=[
+                RankModelSpec(name="heavy_ranker_empty_history", weight=1.0),
+                RankModelSpec(name="perspective", weight=1.0),
+            ],
+        ),
+    ),
 }

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -66,6 +66,17 @@ class TestFeedsRegistry:
             assert cfg.min_rank_score == pytest.approx(0.425)
             assert cfg.min_mmr_score is not None
 
+    def test_cold_start_feed_uses_empty_history_two_tower_generator(self):
+        cfg = FEEDS["cold-start"]
+        assert cfg.public is False
+        assert [
+            spec.name for spec in cfg.gen_request_template.generators
+        ] == [
+            "followed_users",
+            "two_tower_empty_history",
+            "popularity",
+        ]
+
     def test_unranked_feeds_have_no_slate_cutoffs(self):
         for feed_name, cfg in FEEDS.items():
             if cfg.rank_request_template is not None:

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -66,16 +66,29 @@ class TestFeedsRegistry:
             assert cfg.min_rank_score == pytest.approx(0.425)
             assert cfg.min_mmr_score is not None
 
-    def test_cold_start_feed_uses_empty_history_two_tower_generator(self):
+    def test_cold_start_feed_uses_empty_history_models(self):
         cfg = FEEDS["cold-start"]
         assert cfg.public is False
         assert [
-            spec.name for spec in cfg.gen_request_template.generators
+            (spec.name, spec.weight)
+            for spec in cfg.gen_request_template.generators
         ] == [
-            "followed_users",
-            "two_tower_empty_history",
-            "popularity",
+            ("followed_users", 0.40),
+            ("two_tower_empty_history", 0.30),
+            ("popularity", 0.30),
         ]
+        assert cfg.rank_request_template is not None
+        assert [
+            (spec.name, spec.weight)
+            for spec in cfg.rank_request_template.models
+        ] == [
+            ("heavy_ranker_empty_history", 1.0),
+            ("perspective", 1.0),
+        ]
+        assert cfg.diversify is True
+        assert cfg.max_render_share == pytest.approx(0.5)
+        assert cfg.min_rank_score == pytest.approx(0.425)
+        assert cfg.min_mmr_score == pytest.approx(-0.05)
 
     def test_unranked_feeds_have_no_slate_cutoffs(self):
         for feed_name, cfg in FEEDS.items():

--- a/src/app/lib/candidates/__init__.py
+++ b/src/app/lib/candidates/__init__.py
@@ -44,8 +44,17 @@ register_generator(_followed_users)
 _network_likes = NetworkLikesCandidateGenerator()
 register_generator(_network_likes)
 
-_two_tower = TwoTowerCandidateGenerator()
+_two_tower = TwoTowerCandidateGenerator(
+    name="two_tower",
+    history_mode="actual",
+)
 register_generator(_two_tower)
+
+_two_tower_empty_history = TwoTowerCandidateGenerator(
+    name="two_tower_empty_history",
+    history_mode="empty",
+)
+register_generator(_two_tower_empty_history)
 
 __all__ = [
     "CandidateGenerator",

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -8,14 +8,18 @@ import logging
 
 from ...models import MaxAgeHours
 from .base import CandidateGenerator, CandidateResult
-from ..inference import get_inference_settings, compute_user_embedding, get_cached_post_tower_uuid
+from ..inference import (
+    get_inference_settings,
+    compute_user_embedding,
+    get_cached_post_tower_uuid,
+    HistoryMode,
+)
 from .es_candidates import knn_search_posts
 from ..embeddings import GE_POST_EMBEDDING_FIELD
 
 logger = logging.getLogger(__name__)
 
 
-TWO_TOWER_GENERATOR_NAME = "two_tower"
 MIN_LIKE_COUNT = 20
 # Hard cap on the freshness window for two-tower, independent of the user's
 # freshness preference. The selective MIN_LIKE_COUNT filter makes Lucene
@@ -36,9 +40,13 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         user_did → recent likes → post embeddings → user tower → kNN search
     """
 
+    def __init__(self, name: str, history_mode: HistoryMode):
+        self._name = name
+        self.history_mode: HistoryMode = history_mode
+
     @property
     def name(self) -> str:
-        return "two_tower"
+        return self._name
 
     async def generate(
         self,
@@ -73,7 +81,8 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
             es,
             inference_base_url,
             inference_api_key,
-            TWO_TOWER_GENERATOR_NAME,
+            self.name,
+            self.history_mode,
         )
 
         # Freshness filters returned candidates, not the interaction history

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -152,6 +152,7 @@ class TestTwoTowerCandidateGenerator:
             TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME,
             "empty",
         )
+        assert knn_search.await_args is not None
         assert knn_search.await_args.kwargs["generator_name"] == (
             TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME
         )

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -8,12 +8,13 @@ from ...models import CandidatePost
 from ..candidates import get_generator, list_generators
 from ..candidates.two_tower import (
     MIN_LIKE_COUNT,
-    TWO_TOWER_GENERATOR_NAME,
     TWO_TOWER_MAX_AGE_CAP_HOURS,
     TwoTowerCandidateGenerator,
 )
 from ..embeddings import GE_POST_EMBEDDING_FIELD
 
+TWO_TOWER_GENERATOR_NAME = "two_tower"
+TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME = "two_tower_empty_history"
 GET_INFERENCE_SETTINGS = "app.lib.candidates.two_tower.get_inference_settings"
 COMPUTE_USER_EMBEDDING = "app.lib.candidates.two_tower.compute_user_embedding"
 GET_CACHED_POST_TOWER_UUID = "app.lib.candidates.two_tower.get_cached_post_tower_uuid"
@@ -23,7 +24,10 @@ INFERENCE_SETTINGS = ("https://inference", "api-key")
 
 @pytest.fixture
 def generator():
-    return TwoTowerCandidateGenerator()
+    return TwoTowerCandidateGenerator(
+        name=TWO_TOWER_GENERATOR_NAME,
+        history_mode="actual",
+    )
 
 
 class TestTwoTowerCandidateGenerator:
@@ -34,6 +38,12 @@ class TestTwoTowerCandidateGenerator:
         registered = get_generator(TWO_TOWER_GENERATOR_NAME)
         assert isinstance(registered, TwoTowerCandidateGenerator)
         assert TWO_TOWER_GENERATOR_NAME in list_generators()
+
+    def test_empty_history_variant_registered_as_builtin_generator(self):
+        registered = get_generator(TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME)
+        assert isinstance(registered, TwoTowerCandidateGenerator)
+        assert registered.history_mode == "empty"
+        assert TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME in list_generators()
 
     @pytest.mark.asyncio
     async def test_generate_runs_user_tower_then_ge_post_knn(self, generator):
@@ -88,6 +98,7 @@ class TestTwoTowerCandidateGenerator:
             "https://inference",
             "api-key",
             TWO_TOWER_GENERATOR_NAME,
+            "actual",
         )
         knn_search.assert_awaited_once_with(
             es,
@@ -103,6 +114,48 @@ class TestTwoTowerCandidateGenerator:
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == candidates
+
+    @pytest.mark.asyncio
+    async def test_generate_forwards_empty_history_mode(self):
+        generator = TwoTowerCandidateGenerator(
+            name=TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME,
+            history_mode="empty",
+        )
+        es = object()
+        user_embedding = [0.1, 0.2, 0.3]
+
+        with (
+            patch(GET_INFERENCE_SETTINGS, return_value=INFERENCE_SETTINGS),
+            patch(
+                GET_CACHED_POST_TOWER_UUID,
+                new_callable=AsyncMock,
+                return_value="post-tower-uuid",
+            ),
+            patch(
+                COMPUTE_USER_EMBEDDING,
+                new_callable=AsyncMock,
+                return_value=user_embedding,
+            ) as compute_user_embedding,
+            patch(
+                KNN_SEARCH_POSTS,
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as knn_search,
+        ):
+            result = await generator.generate(es, "did:plc:user1")
+
+        compute_user_embedding.assert_awaited_once_with(
+            "did:plc:user1",
+            es,
+            "https://inference",
+            "api-key",
+            TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME,
+            "empty",
+        )
+        assert knn_search.await_args.kwargs["generator_name"] == (
+            TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME
+        )
+        assert result.generator_name == TWO_TOWER_EMPTY_HISTORY_GENERATOR_NAME
 
     @pytest.mark.asyncio
     async def test_generate_uses_default_options(self, generator):

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -253,7 +253,7 @@ async def fetch_post_embeddings_and_metadata(
         return []
 
     async def _fetch() -> list[tuple[str, list[float], str, int]]:
-        async with timed(logger, "es_post_embeddings", n_uris=len(at_uris)):
+        async with timed(logger, "es_post_embeddings_and_metadata", n_uris=len(at_uris)):
             query = {"terms": {"at_uri": at_uris}}
 
             resp = await es.search(

--- a/src/app/lib/inference.py
+++ b/src/app/lib/inference.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import time
+from typing import Literal, assert_never
 
 from .elasticsearch import (
     fetch_recent_liked_post_uris_and_times,
@@ -27,6 +28,7 @@ _POST_TOWER_UUID_STALE_GRACE_SEC = 3600
 _post_tower_uuid_cache: dict[tuple[str, str], tuple[str, float]] = {}
 _post_tower_uuid_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
+HistoryMode = Literal["actual", "empty"]
 
 class InferenceResponseFormatError(RuntimeError):
     """Raised when inference-service returns a successful but malformed response."""
@@ -207,35 +209,45 @@ async def compute_user_embedding(
     inference_base_url: str,
     inference_api_key: str,
     source: str,
+    history_mode: HistoryMode,
 ) -> list[float]:
     async with timed(logger, "two_tower_user_side", user_did=user_did):
-        user_history_vectors: list[list[float]] = []
-        history_author_dids: list[str] = []
-        user_history_liked_uris, _ = await fetch_recent_liked_post_uris_and_times(es, user_did)
-
         rec = current_recorder()
 
-        if not user_history_liked_uris:
-            logger.info("No likes found for user %s", user_did)
-            if rec is not None:
-                rec.record_user_features(source, [], 0)
-        else:
-            user_history_embedding_pairs: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
-                es, user_history_liked_uris,
-            )
-            if rec is not None:
-                rec.record_user_features(
-                    source, user_history_liked_uris, len(user_history_embedding_pairs)
-                )
-            if not user_history_embedding_pairs:
-                logger.info(
-                    "No embeddings found for %d liked posts of user %s",
-                    len(user_history_liked_uris),
-                    user_did,
-                )
-            else:
-                user_history_vectors = [embedding for _, embedding, _, _ in user_history_embedding_pairs]
-                history_author_dids = [author_did for _, _, author_did, _ in user_history_embedding_pairs]
+        match history_mode:
+            case "actual":
+                user_history_vectors: list[list[float]] = []
+                history_author_dids: list[str] = []
+                user_history_liked_uris, _ = await fetch_recent_liked_post_uris_and_times(es, user_did)
+
+                if not user_history_liked_uris:
+                    logger.info("No likes found for user %s", user_did)
+                    if rec is not None:
+                        rec.record_user_features(source, [], 0)
+                else:
+                    user_history_embedding_pairs: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
+                        es, user_history_liked_uris,
+                    )
+                    if rec is not None:
+                        rec.record_user_features(
+                            source, user_history_liked_uris, len(user_history_embedding_pairs)
+                        )
+                    if not user_history_embedding_pairs:
+                        logger.info(
+                            "No embeddings found for %d liked posts of user %s",
+                            len(user_history_liked_uris),
+                            user_did,
+                        )
+                    else:
+                        user_history_vectors = [embedding for _, embedding, _, _ in user_history_embedding_pairs]
+                        history_author_dids = [author_did for _, _, author_did, _ in user_history_embedding_pairs]
+            case "empty":
+                user_history_vectors = []
+                history_author_dids = []
+                if rec is not None:
+                    rec.record_user_features(source, [], 0)
+            case _:
+                assert_never(history_mode)
 
         output_user_embedding_list = await predict_user_tower_single(
             user_history_vectors,

--- a/src/app/lib/inference_test.py
+++ b/src/app/lib/inference_test.py
@@ -1,6 +1,7 @@
 """Tests for shared inference helpers."""
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -153,6 +154,49 @@ async def test_predict_heavy_ranker_single_user_raises_for_http_error(monkeypatc
             base_url="https://inference.example",
             api_key="secret",
         )
+
+
+@pytest.mark.asyncio
+async def test_compute_user_embedding_with_empty_history_skips_elasticsearch(
+    monkeypatch,
+):
+    fetch_recent_likes = AsyncMock()
+    fetch_history_embeddings = AsyncMock()
+    predict_user_tower = AsyncMock(return_value=[[0.1, 0.2]])
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fetch_recent_likes,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_post_embeddings_and_metadata",
+        fetch_history_embeddings,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "predict_user_tower_single",
+        predict_user_tower,
+    )
+
+    result = await inference_module.compute_user_embedding(
+        "did:plc:user1",
+        es=object(),
+        inference_base_url="https://inference.example",
+        inference_api_key="secret",
+        source="two_tower_empty_history",
+        history_mode="empty",
+    )
+
+    assert result == [0.1, 0.2]
+    fetch_recent_likes.assert_not_awaited()
+    fetch_history_embeddings.assert_not_awaited()
+    predict_user_tower.assert_awaited_once_with(
+        [],
+        [],
+        base_url="https://inference.example",
+        api_key="secret",
+    )
 
 
 @pytest.mark.asyncio

--- a/src/app/lib/rankers/__init__.py
+++ b/src/app/lib/rankers/__init__.py
@@ -32,8 +32,18 @@ register_ranker(_two_tower)
 _perspective = PerspectiveRanker()
 register_ranker(_perspective)
 
-_heavy_ranker = HeavyRanker()
+_heavy_ranker = HeavyRanker(
+    name="heavy_ranker",
+    history_mode="actual",
+)
 register_ranker(_heavy_ranker)
+
+_heavy_ranker_empty_history = HeavyRanker(
+    name="heavy_ranker_empty_history",
+    history_mode="empty",
+)
+register_ranker(_heavy_ranker_empty_history)
+
 
 __all__ = [
     "CandidateScoreRanker",

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+from typing import assert_never
 
 from ...models import RankedCandidate, CandidatePost, RankPredictResult
 from .base import Ranker, RankerResult
@@ -15,20 +16,24 @@ from ..telemetry import timed
 from ..inference import (
     get_inference_settings,
     predict_heavy_ranker_single_user,
+    HistoryMode
 )
 from ..feed_debug import current_recorder
 from .utils import get_rank_predict_results_from_candidates_and_scores
 
 logger = logging.getLogger(__name__)
-HEAVY_RANKER_MODEL_NAME = "heavy_ranker"
 
 
 class HeavyRanker(Ranker):
     """Rank candidate posts relative to a user using an ML model."""
 
+    def __init__(self, name: str, history_mode: HistoryMode):
+        self._name = name
+        self.history_mode: HistoryMode = history_mode
+
     @property
     def name(self) -> str:
-        return HEAVY_RANKER_MODEL_NAME
+        return self._name
 
     @property
     def score_bounds(self) -> tuple[float, float]:
@@ -45,45 +50,53 @@ class HeavyRanker(Ranker):
         )
 
         async def _get_user_features() -> tuple[list[list[float]], list[str], list[str], list[int]]:
-            async with timed(logger, "ranker_get_user_features", user_did=user_did):
-                user_history_vectors: list[list[float]] = []
-                history_author_dids: list[str] = []
-                filtered_history_liked_at_times: list[str] = []
-                history_like_counts: list[int] = []
-                user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
+            rec = current_recorder()
 
-                rec = current_recorder()
+            match self.history_mode:    
+                case "actual": 
+                    async with timed(logger, "ranker_get_user_features", user_did=user_did):
+                        user_history_vectors: list[list[float]] = []
+                        history_author_dids: list[str] = []
+                        filtered_history_liked_at_times: list[str] = []
+                        history_like_counts: list[int] = []
+                        user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
 
-                if not user_history_liked_uris:
-                    logger.info("No likes found for user %s", user_did)
+                        if not user_history_liked_uris:
+                            logger.info("No likes found for user %s", user_did)
+                            if rec is not None:
+                                rec.record_user_features(self._name, [], 0)
+                        else:
+                            user_history_hydrated_posts: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
+                                es, user_history_liked_uris,
+                            )
+                            if rec is not None:
+                                rec.record_user_features(
+                                    self._name, user_history_liked_uris, len(user_history_hydrated_posts)
+                                )
+                            if not user_history_hydrated_posts:
+                                logger.info(
+                                    "No embeddings found for %d liked posts of user %s",
+                                    len(user_history_liked_uris),
+                                    user_did,
+                                )
+                            else:
+                                user_history_vectors = [embedding for _, embedding, _, _ in user_history_hydrated_posts]
+                                history_author_dids = [author_did for _, _, author_did, _ in user_history_hydrated_posts]
+                                history_like_counts = [like_count for _, _, _, like_count in user_history_hydrated_posts]
+                                filtered_history_uris = [uri for uri, _, _, _ in user_history_hydrated_posts]
+                                filtered_history_liked_at_times = [
+                                    liked_at_time
+                                    for uri, liked_at_time in zip(user_history_liked_uris, history_liked_at_times)
+                                    if uri in filtered_history_uris
+                                ]
+
+                        return user_history_vectors, history_author_dids, filtered_history_liked_at_times, history_like_counts
+                case "empty":
                     if rec is not None:
-                        rec.record_user_features(HEAVY_RANKER_MODEL_NAME, [], 0)
-                else:
-                    user_history_hydrated_posts: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
-                        es, user_history_liked_uris,
-                    )
-                    if rec is not None:
-                        rec.record_user_features(
-                            HEAVY_RANKER_MODEL_NAME, user_history_liked_uris, len(user_history_hydrated_posts)
-                        )
-                    if not user_history_hydrated_posts:
-                        logger.info(
-                            "No embeddings found for %d liked posts of user %s",
-                            len(user_history_liked_uris),
-                            user_did,
-                        )
-                    else:
-                        user_history_vectors = [embedding for _, embedding, _, _ in user_history_hydrated_posts]
-                        history_author_dids = [author_did for _, _, author_did, _ in user_history_hydrated_posts]
-                        history_like_counts = [like_count for _, _, _, like_count in user_history_hydrated_posts]
-                        filtered_history_uris = [uri for uri, _, _, _ in user_history_hydrated_posts]
-                        filtered_history_liked_at_times = [
-                            liked_at_time
-                            for uri, liked_at_time in zip(user_history_liked_uris, history_liked_at_times)
-                            if uri in filtered_history_uris
-                        ]
-
-                return user_history_vectors, history_author_dids, filtered_history_liked_at_times, history_like_counts
+                        rec.record_user_features(self._name, [], 0)
+                    return [], [], [], []
+                case _:
+                    assert_never(self.history_mode)
         # end _get_user_features()
 
 

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -52,8 +52,8 @@ class HeavyRanker(Ranker):
         async def _get_user_features() -> tuple[list[list[float]], list[str], list[str], list[int]]:
             rec = current_recorder()
 
-            match self.history_mode:    
-                case "actual": 
+            match self.history_mode:
+                case "actual":
                     async with timed(logger, "ranker_get_user_features", user_did=user_did):
                         user_history_vectors: list[list[float]] = []
                         history_author_dids: list[str] = []

--- a/src/app/lib/rankers/heavy_ranker_test.py
+++ b/src/app/lib/rankers/heavy_ranker_test.py
@@ -16,7 +16,7 @@ def _time(hour: int) -> datetime:
 
 
 def test_score_bounds_match_inference_service_output_range():
-    assert HeavyRanker().score_bounds == (0.0, 1.0)
+    assert HeavyRanker(name="heavy_ranker", history_mode="actual").score_bounds == (0.0, 1.0)
 
 
 def test_predict_requires_inference_env_vars(monkeypatch):
@@ -25,7 +25,7 @@ def test_predict_requires_inference_env_vars(monkeypatch):
 
     with pytest.raises(RuntimeError, match="GE_INFERENCE_BASE_URL"):
         asyncio.run(
-            HeavyRanker().predict(
+            HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
                 es=None,
                 user_did="did:plc:user1",
                 candidates=[CandidatePost(at_uri="at://post/1")],
@@ -102,7 +102,7 @@ def test_predict_filters_history_times_to_embeddable_likes_and_ranks_candidates(
     )
 
     result = asyncio.run(
-        HeavyRanker().predict(
+        HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
             es=None,
             user_did="did:plc:user1",
             candidates=[
@@ -191,7 +191,7 @@ def test_predict_uses_embedded_candidate_features_and_fetches_missing_candidates
     )
 
     result = asyncio.run(
-        HeavyRanker().predict(
+        HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
             es=None,
             user_did="did:plc:user1",
             candidates=[
@@ -274,7 +274,7 @@ def test_predict_calls_ranker_with_empty_history_when_likes_have_no_embeddings(m
     )
 
     result = asyncio.run(
-        HeavyRanker().predict(
+        HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
             es=None,
             user_did="did:plc:user1",
             candidates=[CandidatePost(at_uri="at://post/a")],
@@ -325,7 +325,7 @@ def test_predict_returns_unscored_candidates_when_candidate_features_are_missing
     )
 
     result = asyncio.run(
-        HeavyRanker().predict(
+        HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
             es=None,
             user_did="did:plc:user1",
             candidates=[
@@ -377,7 +377,7 @@ def test_predict_returns_unscored_candidates_when_output_count_mismatches(monkey
     )
 
     result = asyncio.run(
-        HeavyRanker().predict(
+        HeavyRanker(name="heavy_ranker", history_mode="actual").predict(
             es=None,
             user_did="did:plc:user1",
             candidates=[

--- a/src/app/lib/rankers/heavy_ranker_test.py
+++ b/src/app/lib/rankers/heavy_ranker_test.py
@@ -2,11 +2,13 @@
 
 import asyncio
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ...models import CandidatePost
 from ..embeddings import encode_float32_b64
+from . import get_ranker
 from . import heavy_ranker as heavy_ranker_module
 from .heavy_ranker import HeavyRanker
 
@@ -17,6 +19,14 @@ def _time(hour: int) -> datetime:
 
 def test_score_bounds_match_inference_service_output_range():
     assert HeavyRanker(name="heavy_ranker", history_mode="actual").score_bounds == (0.0, 1.0)
+
+
+def test_empty_history_variant_is_registered_with_empty_history_mode():
+    ranker = get_ranker("heavy_ranker_empty_history")
+
+    assert isinstance(ranker, HeavyRanker)
+    assert ranker.name == "heavy_ranker_empty_history"
+    assert ranker.history_mode == "empty"
 
 
 def test_predict_requires_inference_env_vars(monkeypatch):
@@ -217,6 +227,112 @@ def test_predict_uses_embedded_candidate_features_and_fetches_missing_candidates
         "candidate_author_dids": ["did:plc:embedded", "did:plc:fetched"],
         "candidate_like_counts": [6, 8],
     }
+    assert [ranking.model_dump() for ranking in result.result.rankings] == [
+        {"at_uri": "at://post/fetched", "rank": 1, "rank_score": 0.7},
+        {"at_uri": "at://post/embedded", "rank": 2, "rank_score": 0.4},
+    ]
+
+
+def test_empty_history_mode_skips_like_history_and_ranks_candidates(monkeypatch):
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "get_inference_settings",
+        lambda: ("https://example.com", "secret"),
+    )
+    fetch_recent_likes = AsyncMock()
+    recorder = MagicMock()
+    seen = {}
+
+    async def fake_fetch_post_embeddings_and_metadata(es, at_uris, index="posts"):
+        seen["fetch_calls"] = [(list(at_uris), index)]
+        return [("at://post/fetched", [0.0, 1.0], "did:plc:fetched", 8)]
+
+    async def fake_predict_heavy_ranker_single_user(
+        history_embeddings,
+        history_author_dids,
+        history_liked_at_times,
+        history_like_counts,
+        candidate_post_embeddings,
+        candidate_author_dids,
+        candidate_like_counts,
+        *,
+        base_url,
+        api_key,
+    ):
+        seen["ranker_call"] = {
+            "history_embeddings": history_embeddings,
+            "history_author_dids": history_author_dids,
+            "history_liked_at_times": history_liked_at_times,
+            "history_like_counts": history_like_counts,
+            "candidate_post_embeddings": candidate_post_embeddings,
+            "candidate_author_dids": candidate_author_dids,
+            "candidate_like_counts": candidate_like_counts,
+            "base_url": base_url,
+            "api_key": api_key,
+        }
+        return [0.4, 0.7]
+
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_recent_liked_post_uris_and_times",
+        fetch_recent_likes,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "predict_heavy_ranker_single_user",
+        fake_predict_heavy_ranker_single_user,
+    )
+    monkeypatch.setattr(
+        heavy_ranker_module,
+        "current_recorder",
+        lambda: recorder,
+    )
+
+    result = asyncio.run(
+        HeavyRanker(
+            name="heavy_ranker_empty_history",
+            history_mode="empty",
+        ).predict(
+            es=None,
+            user_did="did:plc:user1",
+            candidates=[
+                CandidatePost(
+                    at_uri="at://post/embedded",
+                    minilm_l12_embedding=encode_float32_b64([1.0, 0.0]),
+                    author_did="did:plc:embedded",
+                    like_count=6,
+                ),
+                CandidatePost(at_uri="at://post/fetched"),
+            ],
+        )
+    )
+
+    fetch_recent_likes.assert_not_awaited()
+    recorder.record_user_features.assert_called_once_with(
+        "heavy_ranker_empty_history",
+        [],
+        0,
+    )
+    assert seen["fetch_calls"] == [
+        (["at://post/fetched"], "posts_recent"),
+    ]
+    assert seen["ranker_call"] == {
+        "history_embeddings": [],
+        "history_author_dids": [],
+        "history_liked_at_times": [],
+        "history_like_counts": [],
+        "candidate_post_embeddings": [[1.0, 0.0], [0.0, 1.0]],
+        "candidate_author_dids": ["did:plc:embedded", "did:plc:fetched"],
+        "candidate_like_counts": [6, 8],
+        "base_url": "https://example.com",
+        "api_key": "secret",
+    }
+    assert result.model == "heavy_ranker_empty_history"
     assert [ranking.model_dump() for ranking in result.result.rankings] == [
         {"at_uri": "at://post/fetched", "rank": 1, "rank_score": 0.7},
         {"at_uri": "at://post/embedded", "rank": 2, "rank_score": 0.4},

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -163,7 +163,8 @@ class TwoTowerRanker(Ranker):
                 es,
                 inference_base_url,
                 inference_api_key,
-                TWO_TOWER_MODEL_NAME
+                TWO_TOWER_MODEL_NAME,
+                "actual",
             ),
             _compute_candidate_post_embeddings(),
         )

--- a/src/app/routers/rank_test.py
+++ b/src/app/routers/rank_test.py
@@ -52,6 +52,7 @@ def test_list_models(app):
             "two_tower",
             "perspective",
             "heavy_ranker",
+            "heavy_ranker_empty_history",
         ]
     }
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1251,15 +1251,24 @@ async def get_feed_skeleton(
 
     # Social Radius only reallocates the fixed candidate batch among sources;
     # it never increases the total candidate count or per-request batch cap.
-    # Apply its preference override to your-feed generator weights.
+    # Apply its preference override to personalized-feed generator weights.
+    # Cold-start uses the same source mix as your-feed, but forces the
+    # empty-history two-tower variant.
     # The override is computed once and threaded through model_copy in both
     # generation paths so the shared module-level template is never mutated.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if feed_name == "your-feed":
+    if feed_name in ("your-feed", "cold-start"):
         applied_social_radius = user_doc.social_radius if user_doc is not None else 3
         preset = SOCIAL_RADIUS_PRESETS.get(applied_social_radius)
         if preset is not None:
+            if feed_name == "cold-start":
+                preset = [
+                    spec.model_copy(update={"name": "two_tower_empty_history"})
+                    if spec.name == "two_tower"
+                    else spec
+                    for spec in preset
+                ]
             generators_override = {"generators": preset}
 
     freshness_index = (

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -36,6 +36,10 @@ RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
 RANKED_FEED_RKEY = "your-feed"
 RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
+COLD_START_FEED_RKEY = "cold-start"
+COLD_START_FEED_URI = (
+    f"at://{SERVICE_DID}/app.bsky.feed.generator/{COLD_START_FEED_RKEY}"
+)
 BEST_OF_FRIENDS_FEED_RKEY = "best-of-friends"
 BEST_OF_FRIENDS_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{BEST_OF_FRIENDS_FEED_RKEY}"
 # The AppView sends the publisher DID in the feed URI, not the service DID.
@@ -2524,6 +2528,35 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS[4]
+
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_applies_social_radius_to_cold_start(self, mock_pipeline, mock_get_user):
+        """Cold-start keeps the radius mix but uses empty-history two-tower."""
+        from ..documents import UserDocument
+        from .xrpc import PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            social_radius=4,
+        )
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": COLD_START_FEED_URI, "limit": 30},
+        )
+
+        assert resp.status_code == 200
+        gen_request = mock_pipeline.call_args.args[1]
+        assert [
+            (generator.name, generator.weight)
+            for generator in gen_request.generators
+        ] == [
+            ("followed_users", 0.20),
+            ("two_tower_empty_history", 0.40),
+            ("popularity", 0.40),
+        ]
 
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)


### PR DESCRIPTION
Closes #267 

## Summary

Adds a private `cold-start` debug feed that mirrors the main Green Earth feed while forcing the personalized models to behave as though the user has no like history.

## Changes

- Registers `two_tower_empty_history` and `heavy_ranker_empty_history` variants.
- Skips like-history and history-embedding lookups for those variants.
- Sends empty, correctly aligned history inputs to the inference service.
- Preserves the user’s follows, seen/discarded exclusions, freshness, and social-radius preferences.
- Uses the normal generator mix, ranking, perspective scoring, diversification, and slate cutoffs.
- Updates feed-debug output to display scores from the active heavy-ranker variant.
- Improves Elasticsearch timing labels to distinguish embedding-only and metadata hydration.
- Adds coverage for registration, inference payloads, history skipping, feed configuration, social-radius behavior, and feed-debug rendering.

## Validation

- `pipenv run pytest -q` — 899 passed
- `pipenv run pyright` — 0 errors
- `git diff --check origin/main` — passed