### PR TITLE
Enforce ruff in CI and fix all lint/format violations

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
@@ -25,6 +25,12 @@ jobs:
 
     - name: Install dependencies
       run: pipenv install --dev
+
+    - name: Lint (ruff)
+      run: pipenv run ruff check .
+
+    - name: Format check (ruff)
+      run: pipenv run ruff format --check .
 
     - name: Type check (pyright)
       run: pipenv run pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ select = [
 ]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+# main.py configures the root logger before importing app modules on purpose,
+# so those local imports intentionally sit below module-level statements.
+"src/app/main.py" = ["E402"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"

--- a/scripts/apikeys.py
+++ b/scripts/apikeys.py
@@ -10,6 +10,7 @@ Run from the api/ directory:
 Reads Firestore connection from the same env vars as the API server:
     GE_FIRESTORE_PROJECT, GE_FIRESTORE_DATABASE, GE_FIRESTORE_EMULATOR_HOST
 """
+
 from __future__ import annotations
 
 import argparse
@@ -43,7 +44,10 @@ async def cmd_list() -> None:
     print("-" * 80)
     for k in keys:
         last_used = k.last_used_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-        print(f"{k.key_id:<10} {k.email:<30} {str(k.is_active):<8} {k.monthly_call_count:<10} {last_used}")
+        print(
+            f"{k.key_id:<10} {k.email:<30} {str(k.is_active):<8} "
+            f"{k.monthly_call_count:<10} {last_used}"
+        )
 
 
 async def cmd_revoke(key_id: str) -> None:

--- a/scripts/feed_debug.py
+++ b/scripts/feed_debug.py
@@ -28,7 +28,6 @@ import argparse
 import asyncio
 import os
 import sys
-from datetime import datetime
 from typing import NoReturn
 
 from rich import box
@@ -169,20 +168,10 @@ def _candidate_stats_rows(doc: FeedDebugDocument) -> list[tuple[str, str, str, s
 
     rows = []
     for label, candidates in groups.items():
-        placements = [
-            final_ranks[c.at_uri]
-            for c in candidates
-            if c.at_uri in final_ranks
-        ]
-        ranker_scores = [
-            heavy_scores[c.at_uri]
-            for c in candidates
-            if c.at_uri in heavy_scores
-        ]
+        placements = [final_ranks[c.at_uri] for c in candidates if c.at_uri in final_ranks]
+        ranker_scores = [heavy_scores[c.at_uri] for c in candidates if c.at_uri in heavy_scores]
         author_penalty_scores = [
-            author_penalties[c.at_uri]
-            for c in candidates
-            if c.at_uri in author_penalties
+            author_penalties[c.at_uri] for c in candidates if c.at_uri in author_penalties
         ]
         rows.append(
             (

--- a/scripts/feed_debug_test.py
+++ b/scripts/feed_debug_test.py
@@ -2,7 +2,6 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
-
 MODULE_PATH = Path(__file__).with_name("feed_debug.py")
 spec = importlib.util.spec_from_file_location("feed_debug_cli", MODULE_PATH)
 assert spec and spec.loader
@@ -25,17 +24,13 @@ def _result(name: str, uris: list[str]):
 def _model_score(name: str, scores: dict[str, float]):
     return SimpleNamespace(
         model_name=name,
-        scores=[
-            SimpleNamespace(at_uri=uri, score=score)
-            for uri, score in scores.items()
-        ],
+        scores=[SimpleNamespace(at_uri=uri, score=score) for uri, score in scores.items()],
     )
 
 
 def _diversification(penalties: dict[str, float]):
     return [
-        SimpleNamespace(at_uri=uri, author_penalty=penalty)
-        for uri, penalty in penalties.items()
+        SimpleNamespace(at_uri=uri, author_penalty=penalty) for uri, penalty in penalties.items()
     ]
 
 
@@ -135,7 +130,9 @@ def test_discarded_table_labels_cutoff_reasons():
     doc = _doc(
         generators=["two_tower"],
         infill=None,
-        outputs=[_result("two_tower", ["at://p/1", "at://p/cut", "at://p/capped", "at://p/unranked"])],
+        outputs=[
+            _result("two_tower", ["at://p/1", "at://p/cut", "at://p/capped", "at://p/unranked"])
+        ],
         final_order=["at://p/1"],
         ranking=SimpleNamespace(
             rankings=[
@@ -147,9 +144,7 @@ def test_discarded_table_labels_cutoff_reasons():
         cutoff_uris={"rank_score": ["at://p/cut"], "share": ["at://p/capped"]},
     )
 
-    table = feed_debug._discarded_table(
-        doc, ["at://p/cut", "at://p/capped", "at://p/unranked"], {}
-    )
+    table = feed_debug._discarded_table(doc, ["at://p/cut", "at://p/capped", "at://p/unranked"], {})
 
     reasons = list(table.columns[1]._cells)
     assert reasons == ["rank floor", "share cap", "not ranked"]

--- a/scripts/feed_format.py
+++ b/scripts/feed_format.py
@@ -7,7 +7,7 @@ they render them identically from here rather than drifting apart.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from rich.text import Text
 
@@ -15,7 +15,7 @@ from rich.text import Text
 def relative_time(dt: datetime) -> str:
     """Compact relative-time string for a tz-aware datetime."""
     try:
-        delta = datetime.now(timezone.utc) - dt
+        delta = datetime.now(UTC) - dt
         secs = delta.total_seconds()
         if secs < 60:
             return "just now"

--- a/scripts/feed_format_test.py
+++ b/scripts/feed_format_test.py
@@ -1,5 +1,5 @@
 import importlib.util
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).with_name("feed_format.py")
@@ -14,7 +14,7 @@ media_badges = feed_format.media_badges
 
 
 def _ago(**kwargs) -> datetime:
-    return datetime.now(timezone.utc) - timedelta(**kwargs)
+    return datetime.now(UTC) - timedelta(**kwargs)
 
 
 class TestRelativeTime:
@@ -31,7 +31,7 @@ class TestRelativeTime:
         assert relative_time(_ago(days=4)) == "4d ago"
 
     def test_old_dates_fall_back_to_absolute(self):
-        old = datetime(2020, 1, 15, tzinfo=timezone.utc)
+        old = datetime(2020, 1, 15, tzinfo=UTC)
         assert relative_time(old) == "Jan 15, 2020"
 
     def test_bad_input_does_not_raise(self):

--- a/scripts/feed_view_test.py
+++ b/scripts/feed_view_test.py
@@ -1,7 +1,7 @@
 import base64
 import importlib.util
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -60,7 +60,7 @@ class TestRequestIdFromFeedContext:
 class TestParseCreatedAt:
     def test_parses_z_suffix(self):
         dt = feed_view._parse_created_at("2026-07-21T16:18:15Z")
-        assert dt == datetime(2026, 7, 21, 16, 18, 15, tzinfo=timezone.utc)
+        assert dt == datetime(2026, 7, 21, 16, 18, 15, tzinfo=UTC)
 
     def test_none_returns_none(self):
         assert feed_view._parse_created_at(None) is None

--- a/scripts/get_firebase_token.py
+++ b/scripts/get_firebase_token.py
@@ -10,7 +10,6 @@ REST API — no service account key file needed.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import urllib.request
@@ -85,9 +84,7 @@ def main() -> None:
     print(f"Custom token created for {did}", file=sys.stderr)
 
     # 2. Exchange custom token for an ID token.
-    signin_body = json.dumps(
-        {"token": custom_token, "returnSecureToken": True}
-    ).encode()
+    signin_body = json.dumps({"token": custom_token, "returnSecureToken": True}).encode()
     signin_url = (
         "https://identitytoolkit.googleapis.com/v1/"
         f"accounts:signInWithCustomToken?key={FIREBASE_API_KEY}"

--- a/scripts/manage_post.py
+++ b/scripts/manage_post.py
@@ -28,7 +28,7 @@ import sys
 from atproto import Client, client_utils
 from dotenv import load_dotenv
 
-LINK_RE = re.compile(r'\[(\[[^\]]+\]|[^\]]+)\]\((https?://[^)]+)\)')
+LINK_RE = re.compile(r"\[(\[[^\]]+\]|[^\]]+)\]\((https?://[^)]+)\)")
 
 
 def parse_content(text: str) -> list[dict]:
@@ -37,7 +37,7 @@ def parse_content(text: str) -> list[dict]:
     last = 0
     for m in LINK_RE.finditer(text):
         if m.start() > last:
-            segments.append({"type": "text", "text": text[last:m.start()]})
+            segments.append({"type": "text", "text": text[last : m.start()]})
         segments.append({"type": "link", "text": m.group(1), "url": m.group(2)})
         last = m.end()
     if last < len(text):

--- a/scripts/manage_post_test.py
+++ b/scripts/manage_post_test.py
@@ -1,5 +1,5 @@
-import pytest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
+
 from manage_post import parse_content
 
 
@@ -50,6 +50,7 @@ def test_no_trailing_empty_text():
 
 def test_build_text_builder_plain():
     from manage_post import build_text_builder
+
     segments = [{"type": "text", "text": "hello world"}]
     tb = MagicMock()
     with patch("manage_post.client_utils.TextBuilder", return_value=tb):
@@ -60,6 +61,7 @@ def test_build_text_builder_plain():
 
 def test_build_text_builder_with_link():
     from manage_post import build_text_builder
+
     segments = [
         {"type": "text", "text": "visit "},
         {"type": "link", "text": "site", "url": "https://example.com"},
@@ -69,5 +71,3 @@ def test_build_text_builder_with_link():
         build_text_builder(segments)
     tb.text.assert_called_once_with("visit ")
     tb.link.assert_called_once_with("site", "https://example.com")
-
-

--- a/scripts/profile_es_queries.py
+++ b/scripts/profile_es_queries.py
@@ -34,10 +34,10 @@ import os
 import re
 import sys
 
+from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from rich import box
 
 console = Console()
 
@@ -82,6 +82,7 @@ def inject_profile(body: dict) -> dict:
 
 # ──────────────────────────── profile analysis ───────────────────────────────
 
+
 def summarise_profile(profile: dict) -> dict:
     """Reduce the raw ES profile response to the numbers we care about.
 
@@ -102,17 +103,17 @@ def summarise_profile(profile: dict) -> dict:
             for q in search.get("query", [])
         )
         fetch_ns = shard.get("fetch", {}).get("time_in_nanos", 0)
-        shard_details.append({
-            "id": sid,
-            "query_ms": query_ns / 1_000_000,
-            "fetch_ms": fetch_ns / 1_000_000,
-        })
+        shard_details.append(
+            {
+                "id": sid,
+                "query_ms": query_ns / 1_000_000,
+                "fetch_ms": fetch_ns / 1_000_000,
+            }
+        )
 
     max_query_ms = max((s["query_ms"] for s in shard_details), default=0.0)
     max_fetch_ms = max((s["fetch_ms"] for s in shard_details), default=0.0)
-    slowest_shard = next(
-        (s["id"] for s in shard_details if s["query_ms"] == max_query_ms), "?"
-    )
+    slowest_shard = next((s["id"] for s in shard_details if s["query_ms"] == max_query_ms), "?")
 
     return {
         "num_shards": len(shards),
@@ -171,6 +172,7 @@ def _breakdown_table(profile: dict) -> Table | None:
 
 # ──────────────────────────── ES replay ──────────────────────────────────────
 
+
 async def replay_with_profile(entry: dict) -> dict | None:
     """Replay one slow-query entry against ES with profile: true, return response."""
     from elasticsearch import AsyncElasticsearch
@@ -197,6 +199,7 @@ async def replay_with_profile(entry: dict) -> dict | None:
 
 
 # ──────────────────────────── rendering ──────────────────────────────────────
+
 
 def _render_entry(entry: dict, profile_resp: dict | None, pos: int, total: int) -> None:
     """Print one slow-query entry with its profile summary."""
@@ -241,6 +244,7 @@ def _render_entry(entry: dict, profile_resp: dict | None, pos: int, total: int) 
 
 # ──────────────────────────── main ───────────────────────────────────────────
 
+
 def _load_entries(source) -> list[dict]:
     """Parse NDJSON log entries from *source*. Returns list of parsed entries."""
     entries = []
@@ -272,8 +276,7 @@ async def _main_async(args) -> None:
         entries = entries[: args.top]
 
     console.print(
-        f"[bold]Profiling {len(entries)} slow queries[/bold]  "
-        f"(sorted by elapsed_ms desc)"
+        f"[bold]Profiling {len(entries)} slow queries[/bold]  (sorted by elapsed_ms desc)"
     )
     console.print()
 

--- a/scripts/profile_es_queries_test.py
+++ b/scripts/profile_es_queries_test.py
@@ -1,6 +1,7 @@
 """Tests for profile_es_queries helper functions."""
-import json
+
 import importlib.util
+import json
 import pathlib
 
 import pytest
@@ -21,7 +22,7 @@ def mod():
 
 
 SAMPLE_PAYLOAD = (
-    'slow_es_query rid=abc123 elapsed_ms=2654.3 index=posts_recent '
+    "slow_es_query rid=abc123 elapsed_ms=2654.3 index=posts_recent "
     'body={"knn":{"field":"embeddings.minilm_l12_v1","query_vector":[0.1,0.2],"k":300},"size":300}'
 )
 
@@ -76,9 +77,7 @@ def test_summarise_profile_extracts_max_shard_time(mod):
 
 def test_summarise_profile_handles_missing_fetch(mod):
     profile = {
-        "shards": [
-            {"id": "[shard0]", "searches": [{"query": [{"time_in_nanos": 500_000_000}]}]}
-        ]
+        "shards": [{"id": "[shard0]", "searches": [{"query": [{"time_in_nanos": 500_000_000}]}]}]
     }
     summary = mod.summarise_profile(profile)
     assert summary["max_fetch_ms"] == 0.0

--- a/scripts/profile_perspective.py
+++ b/scripts/profile_perspective.py
@@ -133,11 +133,15 @@ async def _main_async(n_candidates: int, profile_dir: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--candidates", type=int, default=500,
+        "--candidates",
+        type=int,
+        default=500,
         help="Number of synthetic candidates to score concurrently (default: 500)",
     )
     parser.add_argument(
-        "--profile-dir", type=Path, default=Path("profiles"),
+        "--profile-dir",
+        type=Path,
+        default=Path("profiles"),
         help="Directory to write the pyinstrument HTML report to (default: ./profiles)",
     )
     args = parser.parse_args()

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -55,6 +55,8 @@ from dotenv import load_dotenv
 
 # Add the repo's src/ directory to the path so we can import app.*
 sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "src"))  # type: ignore
+from datetime import UTC
+
 from app.feeds import FEEDS  # type: ignore
 
 DEFAULT_PDS = "https://bsky.social"
@@ -278,7 +280,7 @@ def publish_feed(
         access_jwt = session["accessJwt"]
         repo_did = session["did"]
 
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         avatar_blob = _upload_blob(client, pds, access_jwt, feed_cfg.avatar if feed_cfg else None)
         record: dict = {
@@ -287,17 +289,15 @@ def publish_feed(
             "displayName": display_name,
             "description": description,
             "acceptsInteractions": True,
-            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "createdAt": datetime.now(UTC).isoformat(),
         }
         if avatar_blob is not None:
             record["avatar"] = avatar_blob
 
-        result = _put_record(
-            client, pds, access_jwt, repo_did, feed_name, record
-        )
+        result = _put_record(client, pds, access_jwt, repo_did, feed_name, record)
 
     feed_uri = f"at://{repo_did}/app.bsky.feed.generator/{feed_name}"
-    print(f"Published feed record:")
+    print("Published feed record:")
     print(f"  URI:  {feed_uri}")
     print(f"  CID:  {result.get('cid', '?')}")
     print(f"  DID:  {generator_did}")
@@ -328,7 +328,7 @@ def delete_feed(
         _delete_record(client, pds, access_jwt, repo_did, feed_name)
 
     feed_uri = f"at://{repo_did}/app.bsky.feed.generator/{feed_name}"
-    print(f"Deleted feed record:")
+    print("Deleted feed record:")
     print(f"  URI:  {feed_uri}")
     print(f"  Name: {feed_name}")
 
@@ -415,7 +415,11 @@ def _resolve_feed_publish_params(
     """Return (published_rkey, display_name, description) for a feed based on routing rules."""
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
-        return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
+        return (
+            rkey,
+            feed_cfg.display_name,
+            f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social).",
+        )
     published_rkey = feed_cfg.internal_rkey
     base_display_name = feed_cfg.internal_display_name
     if normalized_env in ("dev", "stage"):
@@ -461,7 +465,7 @@ def sync_feeds(
         existing_records = _list_records(client, pds, access_jwt, repo_did)
         existing_rkeys = {r["uri"].split("/")[-1] for r in existing_records}
 
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         desired_rkeys: set[str] = set()
         for rkey, feed_cfg in feed_items:
@@ -476,7 +480,7 @@ def sync_feeds(
                 "displayName": display_name,
                 "description": description,
                 "acceptsInteractions": True,
-                "createdAt": datetime.now(timezone.utc).isoformat(),
+                "createdAt": datetime.now(UTC).isoformat(),
             }
             if avatar_blob is not None:
                 record["avatar"] = avatar_blob
@@ -489,7 +493,9 @@ def sync_feeds(
             # When syncing a visibility subset, restrict cleanup to rkeys owned
             # by feeds in this class. Without this, an --internal-only prod pass
             # would delete public feeds' Caterpie records left by a stage deploy.
-            class_rkeys = {cfg.internal_rkey for _, cfg in feed_items} | {rkey for rkey, _ in feed_items}
+            class_rkeys = {cfg.internal_rkey for _, cfg in feed_items} | {
+                rkey for rkey, _ in feed_items
+            }
             stale = (existing_rkeys & class_rkeys) - desired_rkeys
         for rkey in sorted(stale):
             _delete_record(client, pds, access_jwt, repo_did, rkey)
@@ -609,7 +615,9 @@ def main() -> None:
     # Validate mutually exclusive flags
     mode_flags = sum([args.publish_all, args.delete, args.delete_all, args.list, args.sync])
     if mode_flags > 1:
-        parser.error("Only one of --all, --delete, --delete-all, --list, or --sync can be used at a time.")
+        parser.error(
+            "Only one of --all, --delete, --delete-all, --list, or --sync can be used at a time."
+        )
 
     if args.public_only and args.internal_only:
         parser.error("--public-only and --internal-only are mutually exclusive.")
@@ -631,9 +639,7 @@ def main() -> None:
             parser.error("--environment is required for --sync.")
         generator_did = args.generator_did or os.environ.get("GE_FEED_GENERATOR_DID")
         if not generator_did:
-            parser.error(
-                "--generator-did is required for --sync (or set GE_FEED_GENERATOR_DID)"
-            )
+            parser.error("--generator-did is required for --sync (or set GE_FEED_GENERATOR_DID)")
         visibility: Literal["public", "internal"] | None = (
             "public" if args.public_only else ("internal" if args.internal_only else None)
         )

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -6,9 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-
 from publish_feed import (
-    ENV_DISPLAY_PREFIX,
     FEEDS,
     _create_session,
     _delete_record,
@@ -25,7 +23,6 @@ from publish_feed import (
     publish_feed,
     sync_feeds,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -85,7 +82,10 @@ class TestCreateSession:
 class TestPutRecord:
     def test_success(self):
         client = MagicMock(spec=httpx.Client)
-        put_response = {"uri": f"at://{REPO_DID}/app.bsky.feed.generator/{FEED_NAME}", "cid": "bafyabc"}
+        put_response = {
+            "uri": f"at://{REPO_DID}/app.bsky.feed.generator/{FEED_NAME}",
+            "cid": "bafyabc",
+        }
         client.post.return_value = _mock_response(200, put_response)
 
         result = _put_record(client, PDS, ACCESS_JWT, REPO_DID, FEED_NAME, {"test": "record"})
@@ -218,7 +218,12 @@ class TestUploadBlob:
     def test_uploads_jpg_with_correct_mime_type(self, tmp_path):
         img = tmp_path / "icon.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 8)
-        blob_ref = {"$type": "blob", "ref": {"$link": "bafyjpg"}, "mimeType": "image/jpeg", "size": 12}
+        blob_ref = {
+            "$type": "blob",
+            "ref": {"$link": "bafyjpg"},
+            "mimeType": "image/jpeg",
+            "size": 12,
+        }
         client = MagicMock(spec=httpx.Client)
         client.post.return_value = _mock_response(200, {"blob": blob_ref})
 
@@ -281,7 +286,11 @@ class TestPublishFeed:
 
         # Verify putRecord was called with the right record shape
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert record["$type"] == "app.bsky.feed.generator"
         assert record["did"] == GENERATOR_DID
         assert record["displayName"] == "Unranked YF"  # from FEEDS config
@@ -291,7 +300,9 @@ class TestPublishFeed:
 
     @patch("publish_feed._upload_blob", return_value=None)
     @patch("publish_feed.httpx.Client")
-    def test_publishes_unknown_feed_uses_name_as_display(self, MockClient, mock_upload_blob, capsys):
+    def test_publishes_unknown_feed_uses_name_as_display(
+        self, MockClient, mock_upload_blob, capsys
+    ):
         """Publishing a feed not in FEEDS falls back to feed_name."""
         client = MagicMock()
         MockClient.return_value.__enter__ = MagicMock(return_value=client)
@@ -302,7 +313,7 @@ class TestPublishFeed:
             _mock_response(200, {"cid": "bafyxyz"}),
         ]
 
-        result = publish_feed(
+        publish_feed(
             handle=HANDLE,
             password=PASSWORD,
             feed_name="unknown-feed",
@@ -311,7 +322,11 @@ class TestPublishFeed:
         )
 
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert record["displayName"] == "unknown-feed"
         assert record["description"] == ""
 
@@ -339,7 +354,11 @@ class TestPublishFeed:
         )
 
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert record["displayName"] == "Custom Name"
         assert record["description"] == "Custom desc"
 
@@ -366,7 +385,11 @@ class TestPublishFeed:
         )
 
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert record["displayName"] == "GE Stg Unranked YF"
 
 
@@ -391,7 +414,9 @@ class TestDeleteFeed:
 
         # Verify deleteRecord was called
         delete_call = client.post.call_args_list[1]
-        body = delete_call.kwargs["json"] if "json" in delete_call.kwargs else delete_call[1]["json"]
+        body = (
+            delete_call.kwargs["json"] if "json" in delete_call.kwargs else delete_call[1]["json"]
+        )
         assert body["rkey"] == FEED_NAME
         assert body["collection"] == "app.bsky.feed.generator"
 
@@ -519,6 +544,7 @@ class TestMainCLI:
         with pytest.raises(SystemExit):
             with patch("sys.argv", ["publish_feed.py", "--handle", HANDLE, "--all", "--delete"]):
                 from publish_feed import main
+
                 main()
 
     def test_delete_requires_feed_name(self, monkeypatch):
@@ -526,6 +552,7 @@ class TestMainCLI:
         with pytest.raises(SystemExit):
             with patch("sys.argv", ["publish_feed.py", "--handle", HANDLE, "--delete"]):
                 from publish_feed import main
+
                 main()
 
     def test_publish_requires_feed_name_or_all(self, monkeypatch):
@@ -534,6 +561,7 @@ class TestMainCLI:
         with pytest.raises(SystemExit):
             with patch("sys.argv", ["publish_feed.py", "--handle", HANDLE, "--environment", "dev"]):
                 from publish_feed import main
+
                 main()
 
     def test_app_password_arg_takes_precedence_over_env(self, monkeypatch):
@@ -554,7 +582,9 @@ class TestMainCLI:
 
                 main()
 
-        mock_list.assert_called_once_with(handle=HANDLE, password=PASSWORD, pds="https://bsky.social")
+        mock_list.assert_called_once_with(
+            handle=HANDLE, password=PASSWORD, pds="https://bsky.social"
+        )
 
     def test_prompts_when_no_password_in_arg_or_env(self, monkeypatch):
         monkeypatch.delenv("GE_BSKY_APP_PASSWORD", raising=False)
@@ -567,7 +597,9 @@ class TestMainCLI:
                         main()
 
         mock_getpass.assert_called_once_with("App password: ")
-        mock_list.assert_called_once_with(handle=HANDLE, password=PASSWORD, pds="https://bsky.social")
+        mock_list.assert_called_once_with(
+            handle=HANDLE, password=PASSWORD, pds="https://bsky.social"
+        )
 
     def test_publish_all_requires_environment(self, monkeypatch):
         monkeypatch.setenv("GE_BSKY_APP_PASSWORD", PASSWORD)
@@ -732,7 +764,9 @@ class TestSyncFeeds:
 
     @patch("publish_feed._upload_blob", return_value=None)
     @patch("publish_feed.httpx.Client")
-    def test_internal_only_does_not_delete_public_feed_caterpie_records(self, MockClient, mock_upload_blob, capsys):
+    def test_internal_only_does_not_delete_public_feed_caterpie_records(
+        self, MockClient, mock_upload_blob, capsys
+    ):
         """A prod --internal-only sync must not delete public feeds' Caterpie
         records that were published by an earlier stage (unfiltered) deployment."""
         client = MagicMock()
@@ -740,12 +774,8 @@ class TestSyncFeeds:
         MockClient.return_value.__exit__ = MagicMock(return_value=False)
 
         # Simulate stage having already published all four feeds to Caterpie.
-        public_feed_rkeys = [
-            cfg.internal_rkey for cfg in FEEDS.values() if cfg.public
-        ]
-        internal_feed_rkeys = [
-            cfg.internal_rkey for cfg in FEEDS.values() if not cfg.public
-        ]
+        public_feed_rkeys = [cfg.internal_rkey for cfg in FEEDS.values() if cfg.public]
+        internal_feed_rkeys = [cfg.internal_rkey for cfg in FEEDS.values() if not cfg.public]
         stage_records = [
             {"uri": f"at://{REPO_DID}/app.bsky.feed.generator/{rkey}", "value": {}}
             for rkey in public_feed_rkeys + internal_feed_rkeys
@@ -863,10 +893,19 @@ class TestPublicInternalOnlyCLI:
             with pytest.raises(SystemExit):
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE, "--sync",
-                     "--environment", "prod", "--public-only", "--internal-only"],
+                    [
+                        "publish_feed.py",
+                        "--handle",
+                        HANDLE,
+                        "--sync",
+                        "--environment",
+                        "prod",
+                        "--public-only",
+                        "--internal-only",
+                    ],
                 ):
                     from publish_feed import main
+
                     main()
 
     def test_public_only_requires_sync(self, monkeypatch):
@@ -876,10 +915,18 @@ class TestPublicInternalOnlyCLI:
             with pytest.raises(SystemExit):
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE,
-                     "--all", "--environment", "prod", "--public-only"],
+                    [
+                        "publish_feed.py",
+                        "--handle",
+                        HANDLE,
+                        "--all",
+                        "--environment",
+                        "prod",
+                        "--public-only",
+                    ],
                 ):
                     from publish_feed import main
+
                     main()
 
     def test_internal_only_requires_sync(self, monkeypatch):
@@ -889,10 +936,10 @@ class TestPublicInternalOnlyCLI:
             with pytest.raises(SystemExit):
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE,
-                     "--list", "--internal-only"],
+                    ["publish_feed.py", "--handle", HANDLE, "--list", "--internal-only"],
                 ):
                     from publish_feed import main
+
                     main()
 
     def test_public_only_passes_visibility_public(self, monkeypatch):
@@ -902,10 +949,18 @@ class TestPublicInternalOnlyCLI:
             with patch("publish_feed.sync_feeds") as mock_sync:
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE, "--sync",
-                     "--environment", "prod", "--public-only"],
+                    [
+                        "publish_feed.py",
+                        "--handle",
+                        HANDLE,
+                        "--sync",
+                        "--environment",
+                        "prod",
+                        "--public-only",
+                    ],
                 ):
                     from publish_feed import main
+
                     main()
         mock_sync.assert_called_once()
         assert mock_sync.call_args.kwargs["visibility"] == "public"
@@ -917,10 +972,18 @@ class TestPublicInternalOnlyCLI:
             with patch("publish_feed.sync_feeds") as mock_sync:
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE, "--sync",
-                     "--environment", "prod", "--internal-only"],
+                    [
+                        "publish_feed.py",
+                        "--handle",
+                        HANDLE,
+                        "--sync",
+                        "--environment",
+                        "prod",
+                        "--internal-only",
+                    ],
                 ):
                     from publish_feed import main
+
                     main()
         mock_sync.assert_called_once()
         assert mock_sync.call_args.kwargs["visibility"] == "internal"
@@ -932,10 +995,10 @@ class TestPublicInternalOnlyCLI:
             with patch("publish_feed.sync_feeds") as mock_sync:
                 with patch(
                     "sys.argv",
-                    ["publish_feed.py", "--handle", HANDLE, "--sync",
-                     "--environment", "prod"],
+                    ["publish_feed.py", "--handle", HANDLE, "--sync", "--environment", "prod"],
                 ):
                     from publish_feed import main
+
                     main()
         mock_sync.assert_called_once()
         assert mock_sync.call_args.kwargs["visibility"] is None
@@ -976,7 +1039,11 @@ class TestPublishFeedAvatar:
         )
 
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert record["avatar"] == BLOB_REF
 
     @patch("publish_feed._upload_blob")
@@ -1000,7 +1067,11 @@ class TestPublishFeedAvatar:
         )
 
         put_call = client.post.call_args_list[1]
-        record = put_call.kwargs["json"]["record"] if "json" in put_call.kwargs else put_call[1]["json"]["record"]
+        record = (
+            put_call.kwargs["json"]["record"]
+            if "json" in put_call.kwargs
+            else put_call[1]["json"]["record"]
+        )
         assert "avatar" not in record
 
     @patch("publish_feed._upload_blob")
@@ -1056,12 +1127,13 @@ class TestSyncFeedsAvatar:
             pds=PDS,
         )
 
-        put_calls = [
-            c for c in client.post.call_args_list
-            if "putRecord" in str(c)
-        ]
+        put_calls = [c for c in client.post.call_args_list if "putRecord" in str(c)]
         for call in put_calls:
-            record = call.kwargs["json"]["record"] if "json" in call.kwargs else call[1]["json"]["record"]
+            record = (
+                call.kwargs["json"]["record"]
+                if "json" in call.kwargs
+                else call[1]["json"]["record"]
+            )
             assert record["avatar"] == BLOB_REF
 
     @patch("publish_feed._upload_blob")

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,4 +1,3 @@
-
 import os
 
 from dotenv import load_dotenv
@@ -9,4 +8,4 @@ from dotenv import load_dotenv
 # On Cloud Run, avoid loading local .env so emulator settings do not override
 # deployed environment configuration.
 if not os.environ.get("K_SERVICE"):
-	load_dotenv()
+    load_dotenv()

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -12,7 +12,7 @@ Convention:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, Field
 
@@ -21,7 +21,7 @@ from .models import CandidateGenerateRequest, CandidatePost, RankPredictResult
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 class UserDocument(BaseModel):
@@ -67,8 +67,7 @@ class UserDocument(BaseModel):
         default=1.0,
         ge=0.5,
         le=1.5,
-        description="Politics multiplier: 0.5-1.5.  "
-        "Applied to political content scores.",
+        description="Politics multiplier: 0.5-1.5.  Applied to political content scores.",
     )
     purpose: float = Field(
         default=0.5,
@@ -87,8 +86,8 @@ class FeedCacheDocument(BaseModel):
 
     items: list[str] = Field(default_factory=list, description="Cached AT URI list")
     expires_at: datetime = Field(..., description="UTC expiration timestamp for this cache entry")
-    items_meta: list["PipelineItemMeta"] = Field(default_factory=list)
-    generator_diagnostics: list["GeneratorDiagnostic"] = Field(default_factory=list)
+    items_meta: list[PipelineItemMeta] = Field(default_factory=list)
+    generator_diagnostics: list[GeneratorDiagnostic] = Field(default_factory=list)
     applied_social_radius: int | None = None
     feed_name: str | None = None
     generated_at: datetime | None = None
@@ -271,7 +270,9 @@ class FeedDebugDocument(BaseModel):
     feed_name: str = Field(..., description="Feed rkey that was loaded")
     regenerated: bool = Field(
         default=False,
-        description="True when this capture came from the cursor-regeneration path rather than a fresh load",
+        description=(
+            "True when this capture came from the cursor-regeneration path rather than a fresh load"
+        ),
     )
 
     # Inputs
@@ -309,7 +310,9 @@ class FeedDebugDocument(BaseModel):
     )
     diversification: list[FeedDebugDiversificationEntry] = Field(
         default_factory=list,
-        description="Per-item diversification breakdown in final order (empty when diversify was off)",
+        description=(
+            "Per-item diversification breakdown in final order (empty when diversify was off)"
+        ),
     )
     n_retrieved: int = Field(
         default=0,
@@ -396,7 +399,9 @@ class FeedSnapshotDocument(BaseModel):
     debug tool and is only written for debug-flagged users.
     """
 
-    request_id: str = Field(..., description="Feed-cache key / feedContext id (also the document ID)")
+    request_id: str = Field(
+        ..., description="Feed-cache key / feedContext id (also the document ID)"
+    )
     items: list[str] = Field(default_factory=list, description="AT URIs in final served order")
     feed_name: str
     generated_at: datetime

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -206,7 +206,6 @@ FEEDS: dict[str, FeedConfig] = {
         min_rank_score=0.425,
         min_mmr_score=-0.05,
     ),
-
     ### (Private) Pure Candidate Generator Feeds, mostly for testing and debugging ###
     "post-similarity": FeedConfig(
         display_name="Post Similarity",

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -15,9 +15,7 @@ class TestFeedsRegistry:
     def test_social_radius_splits_everyone_weight_evenly(self):
         for generators in SOCIAL_RADIUS_PRESETS.values():
             weights = {generator.name: generator.weight for generator in generators}
-            assert weights.get("two_tower", 0.0) == pytest.approx(
-                weights.get("popularity", 0.0)
-            )
+            assert weights.get("two_tower", 0.0) == pytest.approx(weights.get("popularity", 0.0))
             assert sum(weights.values()) == pytest.approx(1.0)
 
     def test_friends_social_radius_has_no_everyone_generators(self):
@@ -26,17 +24,12 @@ class TestFeedsRegistry:
         ]
 
     def test_balanced_social_radius_matches_your_feed_defaults(self):
-        assert (
-            FEEDS["your-feed"].gen_request_template.generators
-            == SOCIAL_RADIUS_PRESETS[3]
-        )
+        assert FEEDS["your-feed"].gen_request_template.generators == SOCIAL_RADIUS_PRESETS[3]
 
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
         primary_rkeys = set(FEEDS.keys())
         internal_rkeys = {
-            cfg.internal_rkey
-            for cfg in FEEDS.values()
-            if cfg.internal_rkey is not None
+            cfg.internal_rkey for cfg in FEEDS.values() if cfg.internal_rkey is not None
         }
         overlap = primary_rkeys & internal_rkeys
         assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"
@@ -55,9 +48,10 @@ class TestFeedsRegistry:
         for feed_name in ("your-feed", "best-of-friends"):
             cfg = FEEDS[feed_name]
             assert cfg.rank_request_template is not None
-            assert [
-                spec.name for spec in cfg.rank_request_template.models
-            ] == ["heavy_ranker", "perspective"]
+            assert [spec.name for spec in cfg.rank_request_template.models] == [
+                "heavy_ranker",
+                "perspective",
+            ]
 
     def test_ranked_feeds_have_slate_cutoffs(self):
         for feed_name in ("your-feed", "best-of-friends"):
@@ -81,9 +75,10 @@ class TestFeedsRegistry:
         cfg = FEEDS["cutoff-preview"]
         assert cfg.public is False
         assert cfg.rank_request_template is not None
-        assert [
-            spec.name for spec in cfg.rank_request_template.models
-        ] == ["heavy_ranker", "perspective"]
+        assert [spec.name for spec in cfg.rank_request_template.models] == [
+            "heavy_ranker",
+            "perspective",
+        ]
         assert cfg.diversify is True
         assert (
             cfg.gen_request_template.generators

--- a/src/app/lib/api_keys.py
+++ b/src/app/lib/api_keys.py
@@ -7,16 +7,19 @@ Key format: gea_<8-char key_id><48-char secret>
 
 Storage: only the SHA-256 hash is written to Firestore.
 """
+
 from __future__ import annotations
 
 import hashlib
 import hmac
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from google.cloud.firestore import AsyncClient  # type: ignore[import-untyped]
-from google.cloud.firestore import Increment  # type: ignore[import-untyped]
+from google.cloud.firestore import (
+    AsyncClient,  # type: ignore[import-untyped]
+    Increment,  # type: ignore[import-untyped]
+)
 
 from ..documents import ApiKeyDocument
 
@@ -56,7 +59,7 @@ def parse_key_id(full_key: str | None) -> str | None:
         return None
     if len(full_key) != FULL_KEY_LEN:
         return None
-    return full_key[len(KEY_PREFIX): len(KEY_PREFIX) + KEY_ID_LEN]
+    return full_key[len(KEY_PREFIX) : len(KEY_PREFIX) + KEY_ID_LEN]
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +84,7 @@ async def create_api_key(db: AsyncClient, email: str) -> tuple[ApiKeyDocument, s
     The plaintext key is returned exactly once and never stored.
     """
     key_id, full_key, key_hash = generate_key()
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     doc = ApiKeyDocument(
         key_id=key_id,
         key_hash=key_hash,
@@ -117,21 +120,25 @@ async def authenticate_api_key(db: AsyncClient, full_key: str | None) -> ApiKeyD
     if not hmac.compare_digest(expected_hash, doc.key_hash):
         return None
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     current_period = now.strftime("%Y-%m")
     ref = db.collection(API_KEYS_COLLECTION).document(key_id)
 
     if doc.monthly_period != current_period:
-        await ref.update({
-            "last_used_at": now,
-            "monthly_call_count": 1,
-            "monthly_period": current_period,
-        })
+        await ref.update(
+            {
+                "last_used_at": now,
+                "monthly_call_count": 1,
+                "monthly_period": current_period,
+            }
+        )
     else:
-        await ref.update({
-            "last_used_at": now,
-            "monthly_call_count": Increment(1),
-        })
+        await ref.update(
+            {
+                "last_used_at": now,
+                "monthly_call_count": Increment(1),
+            }
+        )
 
     return doc
 

--- a/src/app/lib/api_keys_test.py
+++ b/src/app/lib/api_keys_test.py
@@ -1,16 +1,26 @@
 """Tests for api_keys module."""
+
 from __future__ import annotations
 
 import hmac
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ..documents import ApiKeyDocument
 from ..lib.api_keys import (
+    API_KEYS_COLLECTION,
     FULL_KEY_LEN,
     KEY_PREFIX,
     _hash_key,
+    authenticate_api_key,
+    create_api_key,
     generate_key,
+    get_api_key_doc,
+    list_api_keys,
     parse_key_id,
+    revoke_api_key,
 )
 
 
@@ -69,20 +79,6 @@ class TestParseKeyId:
         assert parse_key_id("") is None
 
 
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
-
-from ..documents import ApiKeyDocument
-from ..lib.api_keys import (
-    API_KEYS_COLLECTION,
-    authenticate_api_key,
-    create_api_key,
-    get_api_key_doc,
-    list_api_keys,
-    revoke_api_key,
-)
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -94,7 +90,7 @@ def _make_doc_data(
     monthly_period: str = "2026-05",
     monthly_call_count: int = 0,
 ) -> dict:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     _, _, key_hash = generate_key()
     return {
         "key_id": key_id,
@@ -181,7 +177,7 @@ class TestCreateApiKey:
 
         doc, _ = await create_api_key(db, "alice@example.com")
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         assert doc.monthly_period == now.strftime("%Y-%m")
 
 
@@ -242,7 +238,7 @@ class TestAuthenticateApiKey:
     @pytest.mark.asyncio
     async def test_increments_call_count_same_month(self):
         key_id, full_key, key_hash = generate_key()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         data = _make_doc_data(key_id=key_id, monthly_period=now.strftime("%Y-%m"))
         data["key_hash"] = key_hash
         db, doc_ref = _mock_firestore(data, exists=True)

--- a/src/app/lib/atproto_auth.py
+++ b/src/app/lib/atproto_auth.py
@@ -15,7 +15,6 @@ DID resolution (``atproto_server``, ``atproto_identity``).
 """
 
 import logging
-from typing import Optional
 
 from atproto_identity.cache.in_memory_cache import AsyncDidInMemoryCache
 from atproto_identity.resolver import AsyncIdResolver
@@ -41,6 +40,7 @@ BEARER_PREFIX = "Bearer "
 # and attached to ``app.state.id_resolver``.  Using an in-memory cache
 # avoids redundant DID document fetches for the same user across requests.
 
+
 def init_id_resolver() -> AsyncIdResolver:
     """Create an ``AsyncIdResolver`` with an in-memory DID cache."""
     cache = AsyncDidInMemoryCache()
@@ -51,9 +51,10 @@ def init_id_resolver() -> AsyncIdResolver:
 # Auth helpers
 # ---------------------------------------------------------------------------
 
+
 async def verify_auth_header(
     request: Request,
-    service_did: Optional[str] = None,
+    service_did: str | None = None,
 ) -> str:
     """Extract and verify the AT Protocol JWT from the request.
 
@@ -80,13 +81,11 @@ async def verify_auth_header(
         logger.warning("Authorization header present but not Bearer scheme")
         return ""
 
-    token = auth_header[len(BEARER_PREFIX):].strip()
+    token = auth_header[len(BEARER_PREFIX) :].strip()
     if not token:
         return ""
 
-    resolver: AsyncIdResolver | None = getattr(
-        request.app.state, "id_resolver", None
-    )
+    resolver: AsyncIdResolver | None = getattr(request.app.state, "id_resolver", None)
     if resolver is None:
         logger.error("id_resolver not initialised on app.state")
         return ""

--- a/src/app/lib/atproto_auth_test.py
+++ b/src/app/lib/atproto_auth_test.py
@@ -7,11 +7,9 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from ..lib.atproto_auth import (
-    BEARER_PREFIX,
     init_id_resolver,
     verify_auth_header,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,6 +39,7 @@ def _build_app_with_auth_endpoint(*, attach_resolver: bool = True) -> FastAPI:
 # init_id_resolver
 # ---------------------------------------------------------------------------
 
+
 class TestInitIdResolver:
     def test_returns_async_id_resolver(self):
         resolver = init_id_resolver()
@@ -61,6 +60,7 @@ class TestInitIdResolver:
 # ---------------------------------------------------------------------------
 # verify_auth_header
 # ---------------------------------------------------------------------------
+
 
 class TestVerifyAuthHeader:
     """Tests for verify_auth_header using mocked JWT verification."""
@@ -100,9 +100,7 @@ class TestVerifyAuthHeader:
     def test_missing_resolver_returns_empty(self):
         app_no_resolver = _build_app_with_auth_endpoint(attach_resolver=False)
         client = TestClient(app_no_resolver)
-        resp = client.get(
-            "/auth-test", headers={"Authorization": "Bearer some.jwt.token"}
-        )
+        resp = client.get("/auth-test", headers={"Authorization": "Bearer some.jwt.token"})
         assert resp.json()["user_did"] == ""
 
     # --- successful verification ---

--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -31,6 +31,7 @@ FOLLOWS_RETRY_BACKOFF_SECONDS = 0.1
 # Followed users API query
 # ---------------------------------------------------------------------------
 
+
 class FollowedUsersLookupError(Exception):
     """Raised when followed-user lookup fails."""
 
@@ -55,10 +56,7 @@ async def _get_follows_page(
             resp.raise_for_status()
             return resp.json()
         except httpx.HTTPError as exc:
-            if (
-                attempt >= FOLLOWS_MAX_RETRIES
-                or not _is_retryable_follow_lookup_error(exc)
-            ):
+            if attempt >= FOLLOWS_MAX_RETRIES or not _is_retryable_follow_lookup_error(exc):
                 raise
             await asyncio.sleep(FOLLOWS_RETRY_BACKOFF_SECONDS)
 
@@ -114,8 +112,7 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                 followed_dids.extend(
                     follow["did"]
                     for follow in follows
-                    if isinstance(follow, dict)
-                    and isinstance(follow.get("did"), str)
+                    if isinstance(follow, dict) and isinstance(follow.get("did"), str)
                 )
 
                 cursor = data.get("cursor")
@@ -124,21 +121,16 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
     except TimeoutError as exc:
         if followed_dids:
             logger.warning(
-                "Returning %s partial followed users for %s after follow lookup "
-                "exceeded %.1fs",
+                "Returning %s partial followed users for %s after follow lookup exceeded %.1fs",
                 len(followed_dids),
                 user_did,
                 FOLLOWS_LOOKUP_TIMEOUT_SECONDS,
             )
             return followed_dids[:limit]
-        raise FollowedUsersLookupError(
-            f"Failed to fetch followed users for {user_did}"
-        ) from exc
+        raise FollowedUsersLookupError(f"Failed to fetch followed users for {user_did}") from exc
     except FollowedUsersLookupError:
         raise
     except (httpx.HTTPError, ValueError) as exc:
-        raise FollowedUsersLookupError(
-            f"Failed to fetch followed users for {user_did}"
-        ) from exc
+        raise FollowedUsersLookupError(f"Failed to fetch followed users for {user_did}") from exc
 
     return followed_dids[:limit]

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -49,21 +49,25 @@ def fake_http_client(monkeypatch):
 class TestGetFollowedUserDids:
     @pytest.mark.asyncio
     async def test_returns_followed_dids_and_uses_query_params(self, fake_http_client):
-        fake_http_client.response = FakeResponse({
-            "follows": [
-                {"did": "did:plc:follow1"},
-                {"did": "did:plc:follow2"},
-            ]
-        })
+        fake_http_client.response = FakeResponse(
+            {
+                "follows": [
+                    {"did": "did:plc:follow1"},
+                    {"did": "did:plc:follow2"},
+                ]
+            }
+        )
 
         dids = await get_followed_user_dids("did:plc:user1", limit=50)
 
         assert dids == ["did:plc:follow1", "did:plc:follow2"]
-        assert fake_http_client.get_calls == [{
-            "url": "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows",
-            "params": {"actor": "did:plc:user1", "limit": 50},
-            "kwargs": {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT},
-        }]
+        assert fake_http_client.get_calls == [
+            {
+                "url": "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows",
+                "params": {"actor": "did:plc:user1", "limit": 50},
+                "kwargs": {"timeout": bsky_module.FOLLOWS_HTTP_TIMEOUT},
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_paginates_follows_with_api_page_limit(self, fake_http_client):
@@ -101,13 +105,15 @@ class TestGetFollowedUserDids:
     @pytest.mark.asyncio
     async def test_caps_returned_dids_at_requested_total_limit(self, fake_http_client):
         fake_http_client.responses = [
-            FakeResponse({
-                "follows": [
-                    {"did": "did:plc:follow1"},
-                    {"did": "did:plc:follow2"},
-                ],
-                "cursor": "next-page",
-            }),
+            FakeResponse(
+                {
+                    "follows": [
+                        {"did": "did:plc:follow1"},
+                        {"did": "did:plc:follow2"},
+                    ],
+                    "cursor": "next-page",
+                }
+            ),
         ]
 
         dids = await get_followed_user_dids("did:plc:user1", limit=1)
@@ -124,16 +130,18 @@ class TestGetFollowedUserDids:
 
     @pytest.mark.asyncio
     async def test_skips_malformed_follow_entries(self, fake_http_client):
-        fake_http_client.response = FakeResponse({
-            "follows": [
-                {"did": "did:plc:follow1"},
-                {"handle": "missing.did"},
-                {"did": 123},
-                None,
-                "not-a-dict",
-                {"did": "did:plc:follow2"},
-            ]
-        })
+        fake_http_client.response = FakeResponse(
+            {
+                "follows": [
+                    {"did": "did:plc:follow1"},
+                    {"handle": "missing.did"},
+                    {"did": 123},
+                    None,
+                    "not-a-dict",
+                    {"did": "did:plc:follow2"},
+                ]
+            }
+        )
 
         dids = await get_followed_user_dids("did:plc:user1", limit=100)
 
@@ -246,9 +254,11 @@ class TestGetFollowedUserDids:
                 raise TimeoutError
 
         monkeypatch.setattr(bsky_module.asyncio, "timeout", ExpiringTimeout)
-        fake_http_client.response = FakeResponse({
-            "follows": [{"did": "did:plc:follow1"}],
-        })
+        fake_http_client.response = FakeResponse(
+            {
+                "follows": [{"did": "did:plc:follow1"}],
+            }
+        )
 
         dids = await get_followed_user_dids("did:plc:user1", limit=100)
 

--- a/src/app/lib/candidates/__init__.py
+++ b/src/app/lib/candidates/__init__.py
@@ -4,6 +4,11 @@ Provides an abstraction for named candidate generators that can be called
 internally (as a pipeline step) or via an API endpoint.
 """
 
+from ...models import (
+    CandidateGenerateRequest,
+    CandidateGenerateResult,
+    GeneratorSpec,
+)
 from .base import (
     CandidateGenerator,
     CandidateResult,
@@ -11,21 +16,16 @@ from .base import (
     list_generators,
     register_generator,
 )
-from ...models import (
-    CandidateGenerateRequest,
-    CandidateGenerateResult,
-    GeneratorSpec,
-)
+from .followed_users import FollowedUsersCandidateGenerator
 from .generate import (
     GeneratorError,
     GeneratorNotFoundError,
     run_generate,
 )
+from .network_likes import NetworkLikesCandidateGenerator
 from .popularity import PopularityCandidateGenerator
 from .post_similarity import PostSimilarityCandidateGenerator
 from .random_posts import RandomPostsCandidateGenerator
-from .followed_users import FollowedUsersCandidateGenerator
-from .network_likes import NetworkLikesCandidateGenerator
 from .two_tower import TwoTowerCandidateGenerator
 
 # Register built-in generators

--- a/src/app/lib/candidates/base.py
+++ b/src/app/lib/candidates/base.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, Field
 
 from ...models import CandidatePost, MaxAgeHours
 
-
 # ---------------------------------------------------------------------------
 # Models
 # ---------------------------------------------------------------------------
@@ -21,7 +20,9 @@ from ...models import CandidatePost, MaxAgeHours
 class CandidateResult(BaseModel):
     """The output of a candidate generator invocation."""
 
-    generator_name: str = Field(..., description="Name of the generator that produced these candidates")
+    generator_name: str = Field(
+        ..., description="Name of the generator that produced these candidates"
+    )
     candidates: list[CandidatePost] = Field(default_factory=list)
     status: str = Field(default="success")
     reason: str | None = None
@@ -31,6 +32,7 @@ class CandidateResult(BaseModel):
 # ---------------------------------------------------------------------------
 # Abstract base
 # ---------------------------------------------------------------------------
+
 
 class CandidateGenerator(ABC):
     """Abstract base class for named candidate generators.

--- a/src/app/lib/candidates/es_candidates.py
+++ b/src/app/lib/candidates/es_candidates.py
@@ -1,12 +1,11 @@
-"""Helpers for elasticsearch related to candidate generation
-"""
+"""Helpers for elasticsearch related to candidate generation"""
 
 import logging
 
 from ...models import CandidatePost, MaxAgeHours
 from ..elasticsearch import POSTS_KNN_INDEX
-from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 from ..telemetry import timed
+from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
 logger = logging.getLogger(__name__)
 

--- a/src/app/lib/candidates/es_candidates_test.py
+++ b/src/app/lib/candidates/es_candidates_test.py
@@ -18,36 +18,40 @@ class FakeEs:
     async def search(
         self, *, index=None, query=None, knn=None, size=None, sort=None, _source=None, **kwargs
     ):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "knn": knn,
-            "size": size,
-            "sort": sort,
-            "_source": _source,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "knn": knn,
+                "size": size,
+                "sort": sort,
+                "_source": _source,
+            }
+        )
         return self._responses.get(index, self._default)
 
 
 class TestKnnSearchPosts:
     @pytest.mark.asyncio
     async def test_returns_candidates_with_scores(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.95,
-                            "_source": {
-                                "at_uri": "at://post/1",
-                                "content": "hello",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.95,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "hello",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await knn_search_posts(
             es, [0.1, 0.2], num_candidates=10, search_field=MINILM_L12_EMBEDDING_FIELD
         )
@@ -60,29 +64,31 @@ class TestKnnSearchPosts:
 
     @pytest.mark.asyncio
     async def test_keeps_candidates_without_embeddings_for_later_hydration(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.95,
-                            "_source": {
-                                "at_uri": "at://post/1",
-                                "content": "hello",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.95,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "hello",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://post/2",
-                                "content": "missing embedding",
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/2",
+                                    "content": "missing embedding",
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await knn_search_posts(
             es, [0.1, 0.2], num_candidates=10, search_field=MINILM_L12_EMBEDDING_FIELD
         )
@@ -93,25 +99,30 @@ class TestKnnSearchPosts:
 
     @pytest.mark.asyncio
     async def test_passes_generator_name(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://post/1",
-                                "content": "hi",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "hi",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            generator_name="post_similarity"
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            generator_name="post_similarity",
         )
         assert candidates[0].generator_name == "post_similarity"
 
@@ -123,17 +134,18 @@ class TestKnnSearchPosts:
         )
         knn = es.calls[0]["knn"]
         assert es.calls[0]["query"] is None
-        assert {"range": {"created_at": {"gte": "now-168h"}}} in (
-            knn["filter"]["bool"]["filter"]
-        )
+        assert {"range": {"created_at": {"gte": "now-168h"}}} in (knn["filter"]["bool"]["filter"])
 
     @pytest.mark.asyncio
     async def test_video_only_true_sends_es_filter(self):
         """video_only is applied on the ES side inside knn.filter."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            video_only=True
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            video_only=True,
         )
         knn = es.calls[0]["knn"]
         assert {"term": {"contains_video": True}} in knn["filter"]["bool"]["filter"]
@@ -142,21 +154,25 @@ class TestKnnSearchPosts:
     async def test_video_only_false_keeps_only_freshness_filter(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            video_only=False
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            video_only=False,
         )
         knn = es.calls[0]["knn"]
-        assert knn["filter"]["bool"]["filter"] == [
-            {"range": {"created_at": {"gte": "now-168h"}}}
-        ]
+        assert knn["filter"]["bool"]["filter"] == [{"range": {"created_at": {"gte": "now-168h"}}}]
 
     @pytest.mark.asyncio
     async def test_exclude_uris_is_an_es_filter(self):
         """exclude_uris is bitmap-friendly and stays in ES knn.filter."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            exclude_uris=["at://a", "at://b"]
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            exclude_uris=["at://a", "at://b"],
         )
         knn = es.calls[0]["knn"]
         assert {"terms": {"at_uri": ["at://a", "at://b"]}} in knn["filter"]["bool"]["must_not"]
@@ -165,21 +181,26 @@ class TestKnnSearchPosts:
     async def test_ge_post_embedding_model_uuid_is_an_es_filter(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            ge_post_embedding_model_uuid="model-uuid-123"
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            ge_post_embedding_model_uuid="model-uuid-123",
         )
         knn = es.calls[0]["knn"]
-        assert (
-            {"term": {"ge_post_embedding_model_uuid": "model-uuid-123"}}
-            in knn["filter"]["bool"]["filter"]
-        )
+        assert {"term": {"ge_post_embedding_model_uuid": "model-uuid-123"}} in knn["filter"][
+            "bool"
+        ]["filter"]
 
     @pytest.mark.asyncio
     async def test_min_like_count_is_an_es_filter(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
-            min_like_count=20
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            min_like_count=20,
         )
         knn = es.calls[0]["knn"]
         assert {"range": {"like_count": {"gte": 20}}} in knn["filter"]["bool"]["filter"]
@@ -188,15 +209,17 @@ class TestKnnSearchPosts:
     async def test_ge_post_embedding_model_uuid_filter_combines_with_exclude_uris(self):
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=5, search_field=MINILM_L12_EMBEDDING_FIELD,
+            es,
+            [0.1, 0.2],
+            num_candidates=5,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
             exclude_uris=["at://a", "at://b"],
             ge_post_embedding_model_uuid="model-uuid-123",
         )
         knn = es.calls[0]["knn"]
-        assert (
-            {"term": {"ge_post_embedding_model_uuid": "model-uuid-123"}}
-            in knn["filter"]["bool"]["filter"]
-        )
+        assert {"term": {"ge_post_embedding_model_uuid": "model-uuid-123"}} in knn["filter"][
+            "bool"
+        ]["filter"]
         assert {"terms": {"at_uri": ["at://a", "at://b"]}} in knn["filter"]["bool"]["must_not"]
 
     @pytest.mark.asyncio
@@ -204,8 +227,7 @@ class TestKnnSearchPosts:
         """No overfetch: k == num_candidates since replies are gone from the index."""
         es = FakeEs(responses={"posts_recent": {"hits": {"hits": []}}})
         await knn_search_posts(
-            es, [0.1, 0.2], num_candidates=10,
-            search_field=MINILM_L12_EMBEDDING_FIELD
+            es, [0.1, 0.2], num_candidates=10, search_field=MINILM_L12_EMBEDDING_FIELD
         )
         call = es.calls[0]
         assert call["size"] == 10

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -40,8 +40,7 @@ async def followed_users_search(
             )
     except FollowedUsersLookupError as exc:
         logger.warning(
-            "Skipping followed_users candidate generation for %s after follow "
-            "lookup failed: %s",
+            "Skipping followed_users candidate generation for %s after follow lookup failed: %s",
             user_did,
             exc,
         )
@@ -54,9 +53,7 @@ async def followed_users_search(
 
     # Freshness applies to the candidate post's creation time. The query does
     # not expand beyond this bound when the requested allocation cannot be filled.
-    filters.append(
-        {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}}
-    )
+    filters.append({"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}})
     query = {
         "bool": {
             "filter": [

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -26,12 +26,14 @@ class FakeEs:
         self.calls: list[dict] = []
 
     async def search(self, *, index=None, query=None, size=None, sort=None, **kwargs):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "size": size,
-            "sort": sort,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "size": size,
+                "sort": sort,
+            }
+        )
         return self._responses.get(index, self._default)
 
 
@@ -59,30 +61,32 @@ class TestFollowedUsersSearch:
             "get_followed_user_dids",
             fake_get_followed_user_dids,
         )
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.91,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "followed post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.91,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "followed post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 0.72,
-                            "_source": {
-                                "at_uri": "at://followed/2",
-                                "content": "another followed post",
-                                "embeddings": {},
+                            {
+                                "_score": 0.72,
+                                "_source": {
+                                    "at_uri": "at://followed/2",
+                                    "content": "another followed post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(
             es,
@@ -149,26 +153,40 @@ class TestFollowedUsersSearch:
     @pytest.mark.asyncio
     async def test_exclude_uris_overfetches_and_filters_in_python(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.9,
-                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.9,
+                                "_source": {
+                                    "at_uri": "at://post/excluded",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(
             es,
@@ -225,22 +243,24 @@ class TestFollowedUsersSearch:
     @pytest.mark.asyncio
     async def test_generator_name_defaults_to_none(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "post",
-                                "embeddings": {},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(es, "did:plc:user1", num_candidates=1)
 
@@ -255,22 +275,24 @@ class TestFollowedUsersCandidateGenerator:
     @pytest.mark.asyncio
     async def test_generate(self, generator, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "followed post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "followed post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 
@@ -285,9 +307,7 @@ class TestFollowedUsersCandidateGenerator:
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs()
 
-        await generator.generate(
-            es, "did:plc:user1", num_candidates=2, max_age_hours=48
-        )
+        await generator.generate(es, "did:plc:user1", num_candidates=2, max_age_hours=48)
 
         assert len(es.calls) == 1
         filters = es.calls[0]["query"]["bool"]["filter"]

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -26,12 +26,14 @@ class FakeEs:
         self.calls: list[dict] = []
 
     async def search(self, *, index=None, query=None, size=None, sort=None, **kwargs):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "size": size,
-            "sort": sort,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "size": size,
+                "sort": sort,
+            }
+        )
         return self._responses.get(index, self._default)
 
 
@@ -59,30 +61,32 @@ class TestFollowedUsersSearch:
             "get_followed_user_dids",
             fake_get_followed_user_dids,
         )
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.91,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "followed post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.91,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "followed post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 0.72,
-                            "_source": {
-                                "at_uri": "at://followed/2",
-                                "content": "another followed post",
-                                "embeddings": {},
+                            {
+                                "_score": 0.72,
+                                "_source": {
+                                    "at_uri": "at://followed/2",
+                                    "content": "another followed post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(
             es,
@@ -149,22 +153,32 @@ class TestFollowedUsersSearch:
     @pytest.mark.asyncio
     async def test_exclude_uris_pushed_into_query(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(
             es,
@@ -223,22 +237,24 @@ class TestFollowedUsersSearch:
     @pytest.mark.asyncio
     async def test_generator_name_defaults_to_none(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "post",
-                                "embeddings": {},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await followed_users_search(es, "did:plc:user1", num_candidates=1)
 
@@ -253,22 +269,24 @@ class TestFollowedUsersCandidateGenerator:
     @pytest.mark.asyncio
     async def test_generate(self, generator, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://followed/1",
-                                "content": "followed post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://followed/1",
+                                    "content": "followed post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 
@@ -283,9 +301,7 @@ class TestFollowedUsersCandidateGenerator:
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs()
 
-        await generator.generate(
-            es, "did:plc:user1", num_candidates=2, max_age_hours=48
-        )
+        await generator.generate(es, "did:plc:user1", num_candidates=2, max_age_hours=48)
 
         assert len(es.calls) == 1
         filters = es.calls[0]["query"]["bool"]["filter"]

--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    _GENERATOR_TIMEOUT_SEC: float = float(
-        os.environ.get("GE_CANDIDATE_GENERATOR_TIMEOUT_SEC", "4")
-    )
+    _GENERATOR_TIMEOUT_SEC: float = float(os.environ.get("GE_CANDIDATE_GENERATOR_TIMEOUT_SEC", "4"))
 except ValueError:
     _GENERATOR_TIMEOUT_SEC = 4.0
 
@@ -37,6 +35,7 @@ except ValueError:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def allocate_counts(specs: list[GeneratorSpec], total: int) -> list[int]:
     """Distribute *total* candidates across specs proportionally to their weights.
@@ -46,7 +45,7 @@ def allocate_counts(specs: list[GeneratorSpec], total: int) -> list[int]:
     weight_sum = sum(s.weight for s in specs)
     raw = [(s.weight / weight_sum) * total for s in specs]
     floors = [math.floor(r) for r in raw]
-    remainders = [r - f for r, f in zip(raw, floors)]
+    remainders = [r - f for r, f in zip(raw, floors, strict=False)]
     leftover = total - sum(floors)
     # Award the leftover slots to the specs with the largest fractional part
     for idx in sorted(range(len(specs)), key=lambda i: -remainders[i]):
@@ -73,6 +72,7 @@ def dedup_candidates(candidates: list[CandidatePost]) -> list[CandidatePost]:
 # Errors
 # ---------------------------------------------------------------------------
 
+
 class GeneratorNotFoundError(Exception):
     """Raised when a requested generator name is not in the registry."""
 
@@ -96,6 +96,7 @@ class GeneratorError(Exception):
 # Pipeline
 # ---------------------------------------------------------------------------
 
+
 async def run_generate(
     request: CandidateGenerateRequest,
     es,
@@ -117,7 +118,7 @@ async def run_generate(
     # Resolve generators up front so missing-name errors raise deterministically
     # before any network work begins.
     active: list[tuple[GeneratorSpec, int, CandidateGenerator]] = []
-    for spec, count in zip(request.generators, counts):
+    for spec, count in zip(request.generators, counts, strict=False):
         if count <= 0:
             continue
         gen = get_generator(spec.name)
@@ -129,7 +130,13 @@ async def run_generate(
         spec: GeneratorSpec, count: int, gen: CandidateGenerator
     ) -> list[CandidateResult]:
         try:
-            async with timed(logger, "candidates.generate.duration_ms", record_metric=True, metric_attrs={"generator_name": spec.name}, count=count):
+            async with timed(
+                logger,
+                "candidates.generate.duration_ms",
+                record_metric=True,
+                metric_attrs={"generator_name": spec.name},
+                count=count,
+            ):
                 results = [
                     await asyncio.wait_for(
                         gen.generate(
@@ -179,17 +186,21 @@ async def run_generate(
                 )
             ctx = current_pipeline_context()
             if ctx is not None:
-                ctx.record(DegradationEvent(
-                    stage=DegradationStage.CANDIDATE_GEN,
-                    component=spec.name,
-                    cause=exc,
-                ))
-                return [CandidateResult(
-                    generator_name=spec.name,
-                    candidates=[],
-                    status=outcome,
-                    reason="generator_timeout" if outcome == "timeout" else "generator_error",
-                )]
+                ctx.record(
+                    DegradationEvent(
+                        stage=DegradationStage.CANDIDATE_GEN,
+                        component=spec.name,
+                        cause=exc,
+                    )
+                )
+                return [
+                    CandidateResult(
+                        generator_name=spec.name,
+                        candidates=[],
+                        status=outcome,
+                        reason="generator_timeout" if outcome == "timeout" else "generator_error",
+                    )
+                ]
             raise GeneratorError(spec.name, exc) from exc
 
     result_groups = await asyncio.gather(
@@ -264,11 +275,13 @@ async def run_generate(
                 )
             ctx = current_pipeline_context()
             if ctx is not None:
-                ctx.record(DegradationEvent(
-                    stage=DegradationStage.CANDIDATE_GEN,
-                    component=f"{request.infill}:infill",
-                    cause=exc,
-                ))
+                ctx.record(
+                    DegradationEvent(
+                        stage=DegradationStage.CANDIDATE_GEN,
+                        component=f"{request.infill}:infill",
+                        cause=exc,
+                    )
+                )
                 infill_result = CandidateResult(
                     generator_name=request.infill,
                     candidates=[],
@@ -283,7 +296,7 @@ async def run_generate(
             rec.record_generator_output(infill_result)
         deduped = dedup_candidates(deduped + infill_result.candidates)
 
-    final = deduped[:request.num_candidates]
+    final = deduped[: request.num_candidates]
     if rec is not None:
         rec.record_final_candidates(final)
     return CandidateGenerateResult(candidates=final)

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -20,7 +20,6 @@ from ..pipeline_context import (
     pipeline_context_scope,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
@@ -35,8 +34,13 @@ class _HangingGenerator(CandidateGenerator):
         return self._name
 
     async def generate(
-        self, es, user_did, num_candidates=100, video_only=False,
-        exclude_uris=None, max_age_hours=168,
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
     ):
         await asyncio.sleep(9999)
         raise AssertionError("unreachable")
@@ -52,8 +56,13 @@ class _FailingGenerator(CandidateGenerator):
         return self._name
 
     async def generate(
-        self, es, user_did, num_candidates=100, video_only=False,
-        exclude_uris=None, max_age_hours=168,
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
     ):
         raise self._exc
 
@@ -67,8 +76,13 @@ class _EmptyGenerator(CandidateGenerator):
         return self._name
 
     async def generate(
-        self, es, user_did, num_candidates=100, video_only=False,
-        exclude_uris=None, max_age_hours=168,
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
     ):
         return CandidateResult(generator_name=self.name, candidates=[])
 
@@ -84,8 +98,13 @@ class _StaticGenerator(CandidateGenerator):
         return self._name
 
     async def generate(
-        self, es, user_did, num_candidates=100, video_only=False,
-        exclude_uris=None, max_age_hours=168,
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
     ):
         self.calls.append(
             {
@@ -111,13 +130,20 @@ class _FailThenReturnGenerator(CandidateGenerator):
         return self._name
 
     async def generate(
-        self, es, user_did, num_candidates=100, video_only=False,
-        exclude_uris=None, max_age_hours=168,
+        self,
+        es,
+        user_did,
+        num_candidates=100,
+        video_only=False,
+        exclude_uris=None,
+        max_age_hours=168,
     ):
         self.calls += 1
         if self.calls == 1:
             raise RuntimeError("primary failed")
-        return CandidateResult(generator_name=self.name, candidates=self._candidates[:num_candidates])
+        return CandidateResult(
+            generator_name=self.name, candidates=self._candidates[:num_candidates]
+        )
 
 
 class FakeMetricCollector:
@@ -206,11 +232,11 @@ class TestGeneratorTimeout:
                 await run_generate(_make_request("post_similarity"), es=None)
 
         timeout_warnings = [
-            r for r in caplog.records
-            if "timed out" in r.message and r.levelno == logging.WARNING
+            r for r in caplog.records if "timed out" in r.message and r.levelno == logging.WARNING
         ]
         error_logs = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelno >= logging.ERROR and "post_similarity" in r.message
         ]
         assert len(timeout_warnings) == 1
@@ -318,10 +344,13 @@ class TestInfillGeneratorTimeout:
     @pytest.mark.asyncio
     async def test_infill_timeout_swallow_returns_empty_and_records_metric(self, monkeypatch):
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
-        _stub_generators(monkeypatch, {
-            "random": _EmptyGenerator("random"),
-            "popular": _HangingGenerator("popular"),
-        })
+        _stub_generators(
+            monkeypatch,
+            {
+                "random": _EmptyGenerator("random"),
+                "popular": _HangingGenerator("popular"),
+            },
+        )
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
@@ -343,13 +372,18 @@ class TestInfillGeneratorTimeout:
         }
 
     @pytest.mark.asyncio
-    async def test_infill_timeout_no_swallow_raises_generator_error_with_is_infill(self, monkeypatch):
+    async def test_infill_timeout_no_swallow_raises_generator_error_with_is_infill(
+        self, monkeypatch
+    ):
         # No PipelineContext → hard fail
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
-        _stub_generators(monkeypatch, {
-            "random": _EmptyGenerator("random"),
-            "popular": _HangingGenerator("popular"),
-        })
+        _stub_generators(
+            monkeypatch,
+            {
+                "random": _EmptyGenerator("random"),
+                "popular": _HangingGenerator("popular"),
+            },
+        )
 
         with pytest.raises(GeneratorError) as exc_info:
             await run_generate(
@@ -364,10 +398,13 @@ class TestInfillGeneratorTimeout:
     async def test_infill_timeout_no_swallow_records_metric(self, monkeypatch):
         # No PipelineContext → hard fail
         monkeypatch.setattr(generate_module, "_GENERATOR_TIMEOUT_SEC", 0.01)
-        _stub_generators(monkeypatch, {
-            "random": _EmptyGenerator("random"),
-            "popular": _HangingGenerator("popular"),
-        })
+        _stub_generators(
+            monkeypatch,
+            {
+                "random": _EmptyGenerator("random"),
+                "popular": _HangingGenerator("popular"),
+            },
+        )
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
@@ -385,10 +422,13 @@ class TestInfillGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_infill_exception_records_error_outcome(self, monkeypatch):
-        _stub_generators(monkeypatch, {
-            "random": _EmptyGenerator("random"),
-            "popular": _FailingGenerator(RuntimeError("db down"), name="popular"),
-        })
+        _stub_generators(
+            monkeypatch,
+            {
+                "random": _EmptyGenerator("random"),
+                "popular": _FailingGenerator(RuntimeError("db down"), name="popular"),
+            },
+        )
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
@@ -411,10 +451,13 @@ class TestInfillGeneratorTimeout:
 
     @pytest.mark.asyncio
     async def test_infill_success_records_success_count_metric(self, monkeypatch):
-        _stub_generators(monkeypatch, {
-            "random": _EmptyGenerator("random"),
-            "popular": _EmptyGenerator("popular"),
-        })
+        _stub_generators(
+            monkeypatch,
+            {
+                "random": _EmptyGenerator("random"),
+                "popular": _EmptyGenerator("popular"),
+            },
+        )
         mc = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, mc))
 
@@ -593,6 +636,7 @@ class TestWithPipelineContext:
     @pytest.mark.asyncio
     async def test_infill_failure_records_degradation(self, monkeypatch):
         """Infill generator failure should also be tracked."""
+
         def _get(name: str):
             if name == "followed_users":
                 return _make_success(name)

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -44,6 +44,7 @@ MAX_LIKES_SCANNED = 5_000
 # Query helper
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class LikedPostUriPage:
     uris: list[str]
@@ -141,11 +142,7 @@ async def fetch_posts_by_uris(
         if candidate.at_uri and candidate.at_uri not in exclude_set:
             candidates_by_uri[candidate.at_uri] = candidate
 
-    return [
-        candidates_by_uri[at_uri]
-        for at_uri in at_uris
-        if at_uri in candidates_by_uri
-    ]
+    return [candidates_by_uri[at_uri] for at_uri in at_uris if at_uri in candidates_by_uri]
 
 
 async def network_likes_search(
@@ -166,8 +163,7 @@ async def network_likes_search(
         )
     except FollowedUsersLookupError as exc:
         logger.warning(
-            "Skipping network_likes candidate generation for %s after follow "
-            "lookup failed: %s",
+            "Skipping network_likes candidate generation for %s after follow lookup failed: %s",
             user_did,
             exc,
         )

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -75,15 +75,17 @@ class FakeEs:
         search_after=None,
         **kwargs,
     ):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "size": size,
-            "sort": sort,
-            "_source": _source,
-            "search_after": search_after,
-            "kwargs": kwargs,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "size": size,
+                "sort": sort,
+                "_source": _source,
+                "search_after": search_after,
+                "kwargs": kwargs,
+            }
+        )
 
         if index == "likes":
             if self.likes_pages:
@@ -120,13 +122,17 @@ def stub_followed_dids(monkeypatch, dids: list[str]):
 class TestFetchRecentLikedPostUriPage:
     @pytest.mark.asyncio
     async def test_returns_uris_and_next_search_after(self):
-        es = FakeEs(likes_pages=[
-            likes_response([
-                like_hit("at://post/1", 3),
-                like_hit(None, 2),
-                like_hit("at://post/2", 1),
-            ])
-        ])
+        es = FakeEs(
+            likes_pages=[
+                likes_response(
+                    [
+                        like_hit("at://post/1", 3),
+                        like_hit(None, 2),
+                        like_hit("at://post/2", 1),
+                    ]
+                )
+            ]
+        )
 
         page = await fetch_recent_liked_post_uri_page(
             es,
@@ -232,17 +238,21 @@ class TestNetworkLikesSearch:
         monkeypatch.setattr(network_likes_module, "MAX_LIKES_SCANNED", 10)
         es = FakeEs(
             likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 60),
-                    like_hit("at://missing/1", 50),
-                    like_hit("at://missing/2", 40),
-                    like_hit("at://post/a", 30),
-                    like_hit("at://missing/3", 20),
-                    like_hit("at://missing/4", 10),
-                ]),
-                likes_response([
-                    like_hit("at://post/b", 1),
-                ]),
+                likes_response(
+                    [
+                        like_hit("at://post/a", 60),
+                        like_hit("at://missing/1", 50),
+                        like_hit("at://missing/2", 40),
+                        like_hit("at://post/a", 30),
+                        like_hit("at://missing/3", 20),
+                        like_hit("at://missing/4", 10),
+                    ]
+                ),
+                likes_response(
+                    [
+                        like_hit("at://post/b", 1),
+                    ]
+                ),
             ],
             posts_by_uri={
                 "at://post/a": post_hit("at://post/a"),
@@ -284,14 +294,18 @@ class TestNetworkLikesSearch:
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         monkeypatch.setattr(network_likes_module, "LIKED_POSTS_PAGE_SIZE", 1)
         monkeypatch.setattr(network_likes_module, "MAX_LIKES_SCANNED", 4)
-        es = FakeEs(likes_pages=[
-            likes_response([
-                like_hit("at://missing/1", 4),
-                like_hit("at://missing/2", 3),
-                like_hit("at://missing/3", 2),
-                like_hit("at://missing/4", 1),
-            ])
-        ])
+        es = FakeEs(
+            likes_pages=[
+                likes_response(
+                    [
+                        like_hit("at://missing/1", 4),
+                        like_hit("at://missing/2", 3),
+                        like_hit("at://missing/3", 2),
+                        like_hit("at://missing/4", 1),
+                    ]
+                )
+            ]
+        )
 
         candidates = await network_likes_search(es, "did:plc:user1", num_candidates=2)
 
@@ -305,12 +319,14 @@ class TestNetworkLikesSearch:
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
             likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 4),
-                    like_hit("at://post/b", 3),
-                    like_hit("at://post/b", 2),
-                    like_hit("at://post/a", 1),
-                ])
+                likes_response(
+                    [
+                        like_hit("at://post/a", 4),
+                        like_hit("at://post/b", 3),
+                        like_hit("at://post/b", 2),
+                        like_hit("at://post/a", 1),
+                    ]
+                )
             ],
             posts_by_uri={
                 "at://post/a": post_hit("at://post/a"),
@@ -363,10 +379,12 @@ class TestNetworkLikesCandidateGenerator:
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
             likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 2),
-                    like_hit("at://post/a", 1),
-                ])
+                likes_response(
+                    [
+                        like_hit("at://post/a", 2),
+                        like_hit("at://post/a", 1),
+                    ]
+                )
             ],
             posts_by_uri={"at://post/a": post_hit("at://post/a")},
         )

--- a/src/app/lib/candidates/popularity.py
+++ b/src/app/lib/candidates/popularity.py
@@ -19,9 +19,9 @@ via configuration.
 import logging
 
 from ...models import CandidatePost, MaxAgeHours
+from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
-from ..telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ def recency_decay_scale(max_age_hours: MaxAgeHours) -> str:
 # ---------------------------------------------------------------------------
 # Query helper
 # ---------------------------------------------------------------------------
+
 
 async def popularity_search(
     es,
@@ -94,7 +95,8 @@ async def popularity_search(
                         "script": {
                             "source": (
                                 "double likes = params.missing; "
-                                "if (!doc['like_count'].empty) { likes = doc['like_count'].value; } "
+                                "if (!doc['like_count'].empty) { "
+                                "likes = doc['like_count'].value; } "
                                 "likes = Math.max(likes, 0.0); "
                                 "return params.factor * Math.log1p(likes);"
                             ),
@@ -132,6 +134,7 @@ async def popularity_search(
 # Generator class
 # ---------------------------------------------------------------------------
 
+
 class PopularityCandidateGenerator(CandidateGenerator):
     """Returns recent popular posts.
 
@@ -153,7 +156,11 @@ class PopularityCandidateGenerator(CandidateGenerator):
         max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
         candidates = await popularity_search(
-            es, num_candidates, generator_name=self.name, video_only=video_only,
-            exclude_uris=exclude_uris, max_age_hours=max_age_hours,
+            es,
+            num_candidates,
+            generator_name=self.name,
+            video_only=video_only,
+            exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
         )
         return CandidateResult(generator_name=self.name, candidates=candidates)

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -9,10 +9,10 @@ from ..candidates.popularity import (
 )
 from ..embeddings import MINILM_L12_EMBEDDING_KEY
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def generator():
@@ -36,33 +36,36 @@ class FakeEs:
 # Unit tests – popularity_search
 # ---------------------------------------------------------------------------
 
+
 class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 12.5,
-                            "_source": {
-                                "at_uri": "at://popular/1",
-                                "content": "trending post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 12.5,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "trending post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 10.0,
-                            "_source": {
-                                "at_uri": "at://popular/2",
-                                "content": "another popular one",
-                                "embeddings": {},
+                            {
+                                "_score": 10.0,
+                                "_source": {
+                                    "at_uri": "at://popular/2",
+                                    "content": "another popular one",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await popularity_search(es, num_candidates=5, generator_name="popularity")
 
@@ -133,22 +136,32 @@ class TestPopularitySearch:
 
     @pytest.mark.asyncio
     async def test_exclude_uris_pushed_into_query(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 10.0,
-                            "_source": {"at_uri": "at://popular/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 8.0,
-                            "_source": {"at_uri": "at://popular/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 10.0,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 8.0,
+                                "_source": {
+                                    "at_uri": "at://popular/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await popularity_search(
             es,
@@ -157,9 +170,7 @@ class TestPopularitySearch:
         )
 
         inner_bool = es.calls[0]["query"]["function_score"]["query"]["bool"]
-        assert inner_bool["must_not"] == [
-            {"terms": {"at_uri": ["at://popular/excluded"]}}
-        ]
+        assert inner_bool["must_not"] == [{"terms": {"at_uri": ["at://popular/excluded"]}}]
         assert es.calls[0]["size"] == 2  # no overfetch; ES handles exclusions
         assert [c.at_uri for c in candidates] == ["at://popular/1", "at://popular/2"]
 
@@ -177,43 +188,47 @@ class TestPopularitySearch:
 
     @pytest.mark.asyncio
     async def test_handles_missing_embeddings(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 5.0,
-                            "_source": {
-                                "at_uri": "at://popular/3",
-                                "content": "no embeddings post",
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 5.0,
+                                "_source": {
+                                    "at_uri": "at://popular/3",
+                                    "content": "no embeddings post",
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await popularity_search(es, num_candidates=5)
         assert len(candidates) == 1
         assert candidates[0].minilm_l12_embedding is None
 
     @pytest.mark.asyncio
     async def test_generator_name_defaults_to_none(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {
-                                "at_uri": "at://popular/4",
-                                "content": "post",
-                                "embeddings": {},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://popular/4",
+                                    "content": "post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await popularity_search(es, num_candidates=1)
         assert candidates[0].generator_name is None
 
@@ -222,6 +237,7 @@ class TestPopularitySearch:
 # Integration-style tests – full generator
 # ---------------------------------------------------------------------------
 
+
 class TestPopularityCandidateGenerator:
     @pytest.mark.asyncio
     async def test_name(self, generator):
@@ -229,22 +245,24 @@ class TestPopularityCandidateGenerator:
 
     @pytest.mark.asyncio
     async def test_generate(self, generator):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 8.0,
-                            "_source": {
-                                "at_uri": "at://popular/1",
-                                "content": "popular post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 8.0,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "popular post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 

--- a/src/app/lib/candidates/popularity_test.py
+++ b/src/app/lib/candidates/popularity_test.py
@@ -9,10 +9,10 @@ from ..candidates.popularity import (
 )
 from ..embeddings import MINILM_L12_EMBEDDING_KEY
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def generator():
@@ -36,33 +36,36 @@ class FakeEs:
 # Unit tests – popularity_search
 # ---------------------------------------------------------------------------
 
+
 class TestPopularitySearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 12.5,
-                            "_source": {
-                                "at_uri": "at://popular/1",
-                                "content": "trending post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 12.5,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "trending post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 10.0,
-                            "_source": {
-                                "at_uri": "at://popular/2",
-                                "content": "another popular one",
-                                "embeddings": {},
+                            {
+                                "_score": 10.0,
+                                "_source": {
+                                    "at_uri": "at://popular/2",
+                                    "content": "another popular one",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await popularity_search(es, num_candidates=5, generator_name="popularity")
 
@@ -133,26 +136,40 @@ class TestPopularitySearch:
 
     @pytest.mark.asyncio
     async def test_exclude_uris_overfetches_and_filters_in_python(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 10.0,
-                            "_source": {"at_uri": "at://popular/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 9.0,
-                            "_source": {"at_uri": "at://popular/excluded", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 8.0,
-                            "_source": {"at_uri": "at://popular/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 10.0,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 9.0,
+                                "_source": {
+                                    "at_uri": "at://popular/excluded",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 8.0,
+                                "_source": {
+                                    "at_uri": "at://popular/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await popularity_search(
             es,
@@ -179,43 +196,47 @@ class TestPopularitySearch:
 
     @pytest.mark.asyncio
     async def test_handles_missing_embeddings(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 5.0,
-                            "_source": {
-                                "at_uri": "at://popular/3",
-                                "content": "no embeddings post",
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 5.0,
+                                "_source": {
+                                    "at_uri": "at://popular/3",
+                                    "content": "no embeddings post",
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await popularity_search(es, num_candidates=5)
         assert len(candidates) == 1
         assert candidates[0].minilm_l12_embedding is None
 
     @pytest.mark.asyncio
     async def test_generator_name_defaults_to_none(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {
-                                "at_uri": "at://popular/4",
-                                "content": "post",
-                                "embeddings": {},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://popular/4",
+                                    "content": "post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
         candidates = await popularity_search(es, num_candidates=1)
         assert candidates[0].generator_name is None
 
@@ -224,6 +245,7 @@ class TestPopularitySearch:
 # Integration-style tests – full generator
 # ---------------------------------------------------------------------------
 
+
 class TestPopularityCandidateGenerator:
     @pytest.mark.asyncio
     async def test_name(self, generator):
@@ -231,22 +253,24 @@ class TestPopularityCandidateGenerator:
 
     @pytest.mark.asyncio
     async def test_generate(self, generator):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 8.0,
-                            "_source": {
-                                "at_uri": "at://popular/1",
-                                "content": "popular post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 8.0,
+                                "_source": {
+                                    "at_uri": "at://popular/1",
+                                    "content": "popular post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 

--- a/src/app/lib/candidates/post_similarity.py
+++ b/src/app/lib/candidates/post_similarity.py
@@ -11,10 +11,10 @@ Generates candidates by finding posts similar to a user's recent likes:
 import logging
 
 from ...models import MaxAgeHours
-from .base import CandidateGenerator, CandidateResult
-from ..elasticsearch import fetch_recent_liked_post_uris, fetch_post_embeddings
-from ..feed_debug import current_recorder
+from ..elasticsearch import fetch_post_embeddings, fetch_recent_liked_post_uris
 from ..embeddings import MINILM_L12_EMBEDDING_FIELD
+from ..feed_debug import current_recorder
+from .base import CandidateGenerator, CandidateResult
 from .es_candidates import knn_search_posts
 
 logger = logging.getLogger(__name__)
@@ -86,8 +86,13 @@ class PostSimilarityCandidateGenerator(CandidateGenerator):
         # Freshness filters returned candidates, not the liked posts above that
         # are used to construct this query vector.
         candidates = await knn_search_posts(
-            es, avg_vector, num_candidates, search_field=MINILM_L12_EMBEDDING_FIELD,
-            generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
+            es,
+            avg_vector,
+            num_candidates,
+            search_field=MINILM_L12_EMBEDDING_FIELD,
+            generator_name=self.name,
+            video_only=video_only,
+            exclude_uris=exclude_uris,
             max_age_hours=max_age_hours,
         )
 

--- a/src/app/lib/candidates/post_similarity_test.py
+++ b/src/app/lib/candidates/post_similarity_test.py
@@ -12,6 +12,7 @@ from ..embeddings import MINILM_L12_EMBEDDING_KEY
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def generator():
     return PostSimilarityCandidateGenerator()
@@ -29,14 +30,16 @@ class FakeEs:
     async def search(
         self, *, index=None, query=None, knn=None, size=None, sort=None, _source=None, **kwargs
     ):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "knn": knn,
-            "size": size,
-            "sort": sort,
-            "_source": _source,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "knn": knn,
+                "size": size,
+                "sort": sort,
+                "_source": _source,
+            }
+        )
         return self._responses.get(index, self._default)
 
 
@@ -52,9 +55,11 @@ class TestAverageVectors:
         with pytest.raises(ValueError, match="No vectors"):
             average_vectors([])
 
+
 # ---------------------------------------------------------------------------
 # Integration-style tests – full generator
 # ---------------------------------------------------------------------------
+
 
 class TestPostSimilarityGenerator:
     @pytest.mark.asyncio

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -30,30 +30,32 @@ class FakeEs:
 class TestRandomPostsSearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.91,
-                            "_source": {
-                                "at_uri": "at://random/1",
-                                "content": "random post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.91,
+                                "_source": {
+                                    "at_uri": "at://random/1",
+                                    "content": "random post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 0.72,
-                            "_source": {
-                                "at_uri": "at://random/2",
-                                "content": "another random post",
-                                "embeddings": {},
+                            {
+                                "_score": 0.72,
+                                "_source": {
+                                    "at_uri": "at://random/2",
+                                    "content": "another random post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await random_posts_search(es, num_candidates=5, generator_name="random_posts")
 
@@ -102,26 +104,40 @@ class TestRandomPostsSearch:
 
     @pytest.mark.asyncio
     async def test_exclude_uris_overfetches_and_filters_in_python(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.9,
-                            "_source": {"at_uri": "at://post/excluded", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.9,
+                                "_source": {
+                                    "at_uri": "at://post/excluded",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await random_posts_search(
             es,
@@ -154,22 +170,24 @@ class TestRandomPostsCandidateGenerator:
 
     @pytest.mark.asyncio
     async def test_generate(self, generator):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://random/1",
-                                "content": "random post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://random/1",
+                                    "content": "random post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 

--- a/src/app/lib/candidates/random_posts_test.py
+++ b/src/app/lib/candidates/random_posts_test.py
@@ -30,30 +30,32 @@ class FakeEs:
 class TestRandomPostsSearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.91,
-                            "_source": {
-                                "at_uri": "at://random/1",
-                                "content": "random post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.91,
+                                "_source": {
+                                    "at_uri": "at://random/1",
+                                    "content": "random post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.5, 0.6]},
+                                },
                             },
-                        },
-                        {
-                            "_score": 0.72,
-                            "_source": {
-                                "at_uri": "at://random/2",
-                                "content": "another random post",
-                                "embeddings": {},
+                            {
+                                "_score": 0.72,
+                                "_source": {
+                                    "at_uri": "at://random/2",
+                                    "content": "another random post",
+                                    "embeddings": {},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await random_posts_search(es, num_candidates=5, generator_name="random_posts")
 
@@ -102,22 +104,32 @@ class TestRandomPostsSearch:
 
     @pytest.mark.asyncio
     async def test_exclude_uris_pushed_into_query(self):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 1.0,
-                            "_source": {"at_uri": "at://post/1", "content": "x", "embeddings": {}},
-                        },
-                        {
-                            "_score": 0.8,
-                            "_source": {"at_uri": "at://post/2", "content": "x", "embeddings": {}},
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 1.0,
+                                "_source": {
+                                    "at_uri": "at://post/1",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://post/2",
+                                    "content": "x",
+                                    "embeddings": {},
+                                },
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         candidates = await random_posts_search(
             es,
@@ -150,22 +162,24 @@ class TestRandomPostsCandidateGenerator:
 
     @pytest.mark.asyncio
     async def test_generate(self, generator):
-        es = FakeEs(responses={
-            "posts_recent": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_score": 0.8,
-                            "_source": {
-                                "at_uri": "at://random/1",
-                                "content": "random post",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+        es = FakeEs(
+            responses={
+                "posts_recent": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_score": 0.8,
+                                "_source": {
+                                    "at_uri": "at://random/1",
+                                    "content": "random post",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                },
                             },
-                        },
-                    ]
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         result = await generator.generate(es, "did:plc:user1", num_candidates=10)
 

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -7,10 +7,10 @@ for the most relevant posts via the pre-calculated post embeddings.
 import logging
 
 from ...models import MaxAgeHours
-from .base import CandidateGenerator, CandidateResult
-from ..inference import get_inference_settings, compute_user_embedding, get_cached_post_tower_uuid
-from .es_candidates import knn_search_posts
 from ..embeddings import GE_POST_EMBEDDING_FIELD
+from ..inference import compute_user_embedding, get_cached_post_tower_uuid, get_inference_settings
+from .base import CandidateGenerator, CandidateResult
+from .es_candidates import knn_search_posts
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +39,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         exclude_uris: list[str] | None = None,
         max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
-        inference_base_url, inference_api_key = (
-            get_inference_settings()
-        )
+        inference_base_url, inference_api_key = get_inference_settings()
 
         post_tower_uuid = await get_cached_post_tower_uuid(inference_base_url, inference_api_key)
         # None means /ready was valid but no post-tower model is configured.
@@ -69,9 +67,15 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         # Freshness filters returned candidates, not the interaction history
         # used above to compute the user embedding.
         candidates = await knn_search_posts(
-            es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
-            generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
-            ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=MIN_LIKE_COUNT,
+            es,
+            user_embedding,
+            num_candidates,
+            search_field=GE_POST_EMBEDDING_FIELD,
+            generator_name=self.name,
+            video_only=video_only,
+            exclude_uris=exclude_uris,
+            ge_post_embedding_model_uuid=post_tower_uuid,
+            min_like_count=MIN_LIKE_COUNT,
             max_age_hours=max_age_hours,
         )
 

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -7,10 +7,10 @@ for the most relevant posts via the pre-calculated post embeddings.
 import logging
 
 from ...models import MaxAgeHours
-from .base import CandidateGenerator, CandidateResult
-from ..inference import get_inference_settings, compute_user_embedding, get_cached_post_tower_uuid
-from .es_candidates import knn_search_posts
 from ..embeddings import GE_POST_EMBEDDING_FIELD
+from ..inference import compute_user_embedding, get_cached_post_tower_uuid, get_inference_settings
+from .base import CandidateGenerator, CandidateResult
+from .es_candidates import knn_search_posts
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         exclude_uris: list[str] | None = None,
         max_age_hours: MaxAgeHours = 168,
     ) -> CandidateResult:
-        inference_base_url, inference_api_key = (
-            get_inference_settings()
-        )
+        inference_base_url, inference_api_key = get_inference_settings()
 
         post_tower_uuid = await get_cached_post_tower_uuid(inference_base_url, inference_api_key)
         # None means /ready was valid but no post-tower model is configured.
@@ -81,9 +79,15 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
         # TWO_TOWER_MAX_AGE_CAP_HOURS to bound the brute-force vector scan.
         effective_max_age_hours = min(max_age_hours, TWO_TOWER_MAX_AGE_CAP_HOURS)
         candidates = await knn_search_posts(
-            es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
-            generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
-            ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=MIN_LIKE_COUNT,
+            es,
+            user_embedding,
+            num_candidates,
+            search_field=GE_POST_EMBEDDING_FIELD,
+            generator_name=self.name,
+            video_only=video_only,
+            exclude_uris=exclude_uris,
+            ge_post_embedding_model_uuid=post_tower_uuid,
+            min_like_count=MIN_LIKE_COUNT,
             max_age_hours=effective_max_age_hours,
         )
 

--- a/src/app/lib/candidates/utils.py
+++ b/src/app/lib/candidates/utils.py
@@ -2,7 +2,6 @@ from ...models import CandidatePost
 from ..elasticsearch import post_has_embedding_source, unwrap_es_response
 from ..embeddings import MINILM_L12_EMBEDDING_KEY, encode_float32_b64
 
-
 # Fields every candidate generator should pull from ES via `_source`.
 # Critically, this does NOT include the 384-dim embedding array, even
 # though MMR and the two-tower ranker need it downstream. A kNN search
@@ -14,11 +13,11 @@ CANDIDATE_SOURCE_FIELDS = [
     "at_uri",
     "author_did",
     "content",
-    "contains_video",       # used for video_only filtering
-    "contains_images",      # media metadata (feed debugging)
-    "image_count",          # media metadata (feed debugging)
-    "video_count",          # media metadata (feed debugging)
-    "external_embed",       # link embed metadata (feed debugging)
+    "contains_video",  # used for video_only filtering
+    "contains_images",  # media metadata (feed debugging)
+    "image_count",  # media metadata (feed debugging)
+    "video_count",  # media metadata (feed debugging)
+    "external_embed",  # link embed metadata (feed debugging)
     "like_count",
 ]
 
@@ -41,11 +40,7 @@ def candidate_post_from_hit(
     src = hit.get("_source") or {}
     embeddings_obj = src.get("embeddings") or {}
 
-    l12 = (
-        embeddings_obj.get(MINILM_L12_EMBEDDING_KEY)
-        if isinstance(embeddings_obj, dict)
-        else None
-    )
+    l12 = embeddings_obj.get(MINILM_L12_EMBEDDING_KEY) if isinstance(embeddings_obj, dict) else None
 
     encoded = None
     if l12 is not None and post_has_embedding_source(src):
@@ -55,9 +50,7 @@ def candidate_post_from_hit(
             encoded = None
 
     external_embed = src.get("external_embed")
-    external_uri = (
-        external_embed.get("uri") if isinstance(external_embed, dict) else None
-    )
+    external_uri = external_embed.get("uri") if isinstance(external_embed, dict) else None
 
     return CandidatePost(
         author_did=src.get("author_did"),

--- a/src/app/lib/candidates/utils_test.py
+++ b/src/app/lib/candidates/utils_test.py
@@ -46,26 +46,30 @@ def test_candidate_post_from_hit_handles_missing_media():
 
 
 def test_candidate_post_from_hit_keeps_embedding_with_content_source():
-    candidate = candidate_post_from_hit({
-        "_source": {
-            "at_uri": "at://post/1",
-            "content": "hello",
-            "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+    candidate = candidate_post_from_hit(
+        {
+            "_source": {
+                "at_uri": "at://post/1",
+                "content": "hello",
+                "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+            }
         }
-    })
+    )
     assert candidate.minilm_l12_embedding is not None
 
 
 def test_candidate_post_from_hit_strips_embedding_without_nonblank_source_text():
-    candidate = candidate_post_from_hit({
-        "_source": {
-            "at_uri": "at://post/1",
-            "content": "   ",
-            "media": [{"alt_text": ""}, {"alt_text": "  "}, "bad"],
-            "video_transcript": 123,
-            "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+    candidate = candidate_post_from_hit(
+        {
+            "_source": {
+                "at_uri": "at://post/1",
+                "content": "   ",
+                "media": [{"alt_text": ""}, {"alt_text": "  "}, "bad"],
+                "video_transcript": 123,
+                "embeddings": {MINILM_L12_EMBEDDING_KEY: SAMPLE_EMBEDDING},
+            }
         }
-    })
+    )
     assert candidate.minilm_l12_embedding is None
 
 

--- a/src/app/lib/diversify.py
+++ b/src/app/lib/diversify.py
@@ -2,9 +2,9 @@
 
 import math
 
+from ..models import CandidatePost
 from .embeddings import decode_float32_b64
 from .feed_debug import current_recorder
-from ..models import CandidatePost
 
 # Global diversity weight (relevance weight is 1-BETA)
 BETA = 0.7
@@ -134,7 +134,7 @@ def _calculate_content_sim(
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
     norm_a = math.sqrt(sum(x * x for x in a))
     norm_b = math.sqrt(sum(x * x for x in b))
     if norm_a == 0.0 or norm_b == 0.0:

--- a/src/app/lib/diversify_test.py
+++ b/src/app/lib/diversify_test.py
@@ -130,6 +130,7 @@ def test_equal_scores_diversity_drives_selection():
 # _cosine_similarity unit tests
 # ---------------------------------------------------------------------------
 
+
 def test_cosine_identical_vectors():
     assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
 
@@ -153,6 +154,7 @@ def test_cosine_zero_vector_b_returns_zero():
 # ---------------------------------------------------------------------------
 # mmr_rerank with cosine similarity active
 # ---------------------------------------------------------------------------
+
 
 def test_cosine_penalizes_topically_similar_cross_author_post():
     """A post from a different author but with an identical embedding is penalized
@@ -192,6 +194,7 @@ def test_content_penalty_decays_after_intervening_selection():
 # ---------------------------------------------------------------------------
 # per-pick scores
 # ---------------------------------------------------------------------------
+
 
 def test_first_pick_score_is_weighted_normalized_relevance():
     """The first pick carries no penalties: score = (1-BETA) * norm_relevance."""

--- a/src/app/lib/elasticsearch.py
+++ b/src/app/lib/elasticsearch.py
@@ -22,7 +22,7 @@ DEFAULT_LIKED_POSTS_LIMIT = 50
 POSTS_KNN_INDEX = "posts_recent"
 
 
-POST_EMBEDDING_SOURCE_FIELDS = [ "content" ]
+POST_EMBEDDING_SOURCE_FIELDS = ["content"]
 
 
 def _has_nonblank_string(value) -> bool:
@@ -72,9 +72,7 @@ async def fetch_recent_liked_post_uris(
         return []
 
     async def _fetch() -> list[str]:
-        async with timed(
-            logger, "es_recent_likes", n_users=len(user_dids), limit=limit
-        ):
+        async with timed(logger, "es_recent_likes", n_users=len(user_dids), limit=limit):
             query = {
                 "bool": {
                     "filter": [{"terms": {"author_did": user_dids}}],
@@ -129,9 +127,7 @@ async def fetch_recent_liked_post_uris_and_times(
         return [], []
 
     async def _fetch() -> tuple[list[str], list[str]]:
-        async with timed(
-            logger, "es_recent_likes_and_times", n_users=len(user_dids), limit=limit
-        ):
+        async with timed(logger, "es_recent_likes_and_times", n_users=len(user_dids), limit=limit):
             query = {
                 "bool": {
                     "filter": [

--- a/src/app/lib/elasticsearch_test.py
+++ b/src/app/lib/elasticsearch_test.py
@@ -22,30 +22,34 @@ class FakeEs:
     async def search(
         self, *, index=None, query=None, knn=None, size=None, sort=None, _source=None, **kwargs
     ):
-        self.calls.append({
-            "index": index,
-            "query": query,
-            "knn": knn,
-            "size": size,
-            "sort": sort,
-            "_source": _source,
-        })
+        self.calls.append(
+            {
+                "index": index,
+                "query": query,
+                "knn": knn,
+                "size": size,
+                "sort": sort,
+                "_source": _source,
+            }
+        )
         return self._responses.get(index, self._default)
 
 
 class TestFetchRecentLikedPostUris:
     @pytest.mark.asyncio
     async def test_returns_subject_uris(self):
-        es = FakeEs(responses={
-            "likes": {
-                "hits": {
-                    "hits": [
-                        {"_source": {"subject_uri": "at://post/1"}},
-                        {"_source": {"subject_uri": "at://post/2"}},
-                    ]
+        es = FakeEs(
+            responses={
+                "likes": {
+                    "hits": {
+                        "hits": [
+                            {"_source": {"subject_uri": "at://post/1"}},
+                            {"_source": {"subject_uri": "at://post/2"}},
+                        ]
+                    }
                 }
             }
-        })
+        )
         uris = await fetch_recent_liked_post_uris(es, "did:plc:user1", limit=10)
         assert uris == ["at://post/1", "at://post/2"]
 
@@ -62,17 +66,19 @@ class TestFetchRecentLikedPostUris:
 
     @pytest.mark.asyncio
     async def test_skips_hits_without_subject_uri(self):
-        es = FakeEs(responses={
-            "likes": {
-                "hits": {
-                    "hits": [
-                        {"_source": {"subject_uri": "at://post/1"}},
-                        {"_source": {}},
-                        {"_source": {"subject_uri": "at://post/3"}},
-                    ]
+        es = FakeEs(
+            responses={
+                "likes": {
+                    "hits": {
+                        "hits": [
+                            {"_source": {"subject_uri": "at://post/1"}},
+                            {"_source": {}},
+                            {"_source": {"subject_uri": "at://post/3"}},
+                        ]
+                    }
                 }
             }
-        })
+        )
         uris = await fetch_recent_liked_post_uris(es, "did:plc:user1")
         assert uris == ["at://post/1", "at://post/3"]
 
@@ -80,26 +86,28 @@ class TestFetchRecentLikedPostUris:
 class TestFetchRecentLikedPostUrisAndTimes:
     @pytest.mark.asyncio
     async def test_returns_subject_uris_and_times(self):
-        es = FakeEs(responses={
-            "likes": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "subject_uri": "at://post/1",
-                                "created_at": "2026-01-01T00:00:00+00:00",
-                            }
-                        },
-                        {
-                            "_source": {
-                                "subject_uri": "at://post/2",
-                                "created_at": "2026-01-02T00:00:00+00:00",
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "likes": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "subject_uri": "at://post/1",
+                                    "created_at": "2026-01-01T00:00:00+00:00",
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "subject_uri": "at://post/2",
+                                    "created_at": "2026-01-02T00:00:00+00:00",
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         uris, times = await fetch_recent_liked_post_uris_and_times(es, "did:plc:user1", limit=10)
 
         assert uris == ["at://post/1", "at://post/2"]
@@ -120,28 +128,30 @@ class TestFetchRecentLikedPostUrisAndTimes:
 
     @pytest.mark.asyncio
     async def test_skips_hits_missing_subject_uri_or_time_to_keep_lists_aligned(self):
-        es = FakeEs(responses={
-            "likes": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "subject_uri": "at://post/1",
-                                "created_at": "2026-01-01T00:00:00+00:00",
-                            }
-                        },
-                        {"_source": {"created_at": "2026-01-02T00:00:00+00:00"}},
-                        {"_source": {"subject_uri": "at://post/3"}},
-                        {
-                            "_source": {
-                                "subject_uri": "at://post/4",
-                                "created_at": "2026-01-04T00:00:00+00:00",
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "likes": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "subject_uri": "at://post/1",
+                                    "created_at": "2026-01-01T00:00:00+00:00",
+                                }
+                            },
+                            {"_source": {"created_at": "2026-01-02T00:00:00+00:00"}},
+                            {"_source": {"subject_uri": "at://post/3"}},
+                            {
+                                "_source": {
+                                    "subject_uri": "at://post/4",
+                                    "created_at": "2026-01-04T00:00:00+00:00",
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
 
         uris, times = await fetch_recent_liked_post_uris_and_times(
             es, ["did:plc:user1", "did:plc:user2"]
@@ -165,28 +175,30 @@ class TestFetchRecentLikedPostUrisAndTimes:
 class TestFetchPostEmbeddingsAndMetadata:
     @pytest.mark.asyncio
     async def test_returns_embeddings_in_requested_uri_order(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "content": "two",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "content": "one",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "content": "two",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "content": "one",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2"])
         assert vecs == [
             ("at://1", [0.1, 0.2], "", 0),
@@ -209,91 +221,96 @@ class TestFetchPostEmbeddingsAndMetadata:
 
     @pytest.mark.asyncio
     async def test_skips_posts_without_embeddings(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "content": "one",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "embeddings": {},
-                            }
-                        },
-                        {"_source": {"at_uri": "at://3"}},
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "content": "one",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "embeddings": {},
+                                }
+                            },
+                            {"_source": {"at_uri": "at://3"}},
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2", "at://3"])
         assert vecs == [("at://1", [0.1, 0.2], "", 0)]
 
     @pytest.mark.asyncio
     async def test_skips_embeddings_without_source_text(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "content": "one",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "content": "   ",
-                                "media": [{"alt_text": ""}],
-                                "video_transcript": None,
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "content": "one",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "content": "   ",
+                                    "media": [{"alt_text": ""}],
+                                    "video_transcript": None,
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2", "at://3"])
         assert vecs == [
             ("at://1", [0.1, 0.2], "", 0),
         ]
 
-
     @pytest.mark.asyncio
     async def test_returns_embeddings_authors_and_like_counts_in_requested_uri_order(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "author_did": "did:plc:two",
-                                "like_count": 22,
-                                "content": "two",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "author_did": "did:plc:one",
-                                "like_count": 11,
-                                "content": "one",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "author_did": "did:plc:two",
+                                    "like_count": 22,
+                                    "content": "two",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "author_did": "did:plc:one",
+                                    "like_count": 11,
+                                    "content": "one",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2"])
         assert vecs == [
             ("at://1", [0.1, 0.2], "did:plc:one", 11),
@@ -309,37 +326,39 @@ class TestFetchPostEmbeddingsAndMetadata:
 
     @pytest.mark.asyncio
     async def test_keeps_posts_with_missing_author_dids_and_like_counts(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "content": "one",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "author_did": 123,
-                                "like_count": "2",
-                                "content": "two",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://3",
-                                "author_did": "did:plc:three",
-                                "embeddings": {},
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "content": "one",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "author_did": 123,
+                                    "like_count": "2",
+                                    "content": "two",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://3",
+                                    "author_did": "did:plc:three",
+                                    "embeddings": {},
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2", "at://3"])
         assert vecs == [
             ("at://1", [0.1, 0.2], "", 0),
@@ -348,31 +367,33 @@ class TestFetchPostEmbeddingsAndMetadata:
 
     @pytest.mark.asyncio
     async def test_skips_embeddings_without_source_text_even_with_author_did(self):
-        es = FakeEs(responses={
-            "posts": {
-                "hits": {
-                    "hits": [
-                        {
-                            "_source": {
-                                "at_uri": "at://1",
-                                "author_did": "did:plc:one",
-                                "content": "some content",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
-                            }
-                        },
-                        {
-                            "_source": {
-                                "at_uri": "at://2",
-                                "author_did": "did:plc:two",
-                                "content": "",
-                                "media": [{"alt_text": "   "}],
-                                "video_transcript": "",
-                                "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
-                            }
-                        },
-                    ]
+        es = FakeEs(
+            responses={
+                "posts": {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    "at_uri": "at://1",
+                                    "author_did": "did:plc:one",
+                                    "content": "some content",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.1, 0.2]},
+                                }
+                            },
+                            {
+                                "_source": {
+                                    "at_uri": "at://2",
+                                    "author_did": "did:plc:two",
+                                    "content": "",
+                                    "media": [{"alt_text": "   "}],
+                                    "video_transcript": "",
+                                    "embeddings": {MINILM_L12_EMBEDDING_KEY: [0.3, 0.4]},
+                                }
+                            },
+                        ]
+                    }
                 }
             }
-        })
+        )
         vecs = await fetch_post_embeddings_and_metadata(es, ["at://1", "at://2"])
         assert vecs == [("at://1", [0.1, 0.2], "did:plc:one", 0)]

--- a/src/app/lib/embeddings.py
+++ b/src/app/lib/embeddings.py
@@ -6,12 +6,12 @@ These helpers are used by candidate generators and API routers.
 import base64
 import struct
 
-
 MINILM_L12_EMBEDDING_KEY = "all_MiniLM_L12_v2"
 MINILM_L12_EMBEDDING_FIELD = f"embeddings.{MINILM_L12_EMBEDDING_KEY}"
 
 GE_POST_EMBEDDING_KEY = "ge_post_embedding"
 GE_POST_EMBEDDING_FIELD = f"embeddings.{GE_POST_EMBEDDING_KEY}"
+
 
 def encode_float32_b64(vec: list[float]) -> str:
     """Encode a list of floats as little-endian float32 bytes, then base64.

--- a/src/app/lib/es_client_test.py
+++ b/src/app/lib/es_client_test.py
@@ -9,7 +9,7 @@ from elastic_transport import ConnectionTimeout
 
 from . import es_client as es_client_module
 from .es_client import SlowQueryLoggingES
-from .request_context import set_request_id, reset_request_id
+from .request_context import reset_request_id, set_request_id
 
 
 class FakeEs:

--- a/src/app/lib/feed_cache.py
+++ b/src/app/lib/feed_cache.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from google.cloud.firestore import AsyncClient  # type: ignore[import-untyped]
 
@@ -25,7 +25,9 @@ class FeedCache(ABC):
     """Backend-agnostic interface for storing and retrieving feed pages."""
 
     @abstractmethod
-    async def store(self, key: str, items: list[str], ttl_seconds: int = DEFAULT_TTL_SECONDS) -> None:
+    async def store(
+        self, key: str, items: list[str], ttl_seconds: int = DEFAULT_TTL_SECONDS
+    ) -> None:
         """Persist *items* (AT URIs) under *key* with the given TTL."""
         ...
 
@@ -48,7 +50,7 @@ class FeedCache(ABC):
             return None
         return FeedCacheDocument(
             items=items,
-            expires_at=datetime.now(timezone.utc) + timedelta(seconds=DEFAULT_TTL_SECONDS),
+            expires_at=datetime.now(UTC) + timedelta(seconds=DEFAULT_TTL_SECONDS),
         )
 
     async def store_document(self, key: str, document: FeedCacheDocument) -> None:
@@ -65,7 +67,7 @@ class FeedCache(ABC):
             return None
         return FeedCacheDocument(
             items=items,
-            expires_at=datetime.now(timezone.utc) + timedelta(seconds=DEFAULT_TTL_SECONDS),
+            expires_at=datetime.now(UTC) + timedelta(seconds=DEFAULT_TTL_SECONDS),
             items_meta=new_items_meta,
         )
 
@@ -82,14 +84,12 @@ class FirestoreFeedCache(FeedCache):
     def __init__(self, db: AsyncClient) -> None:
         self._db = db
 
-    async def store(self, key: str, items: list[str], ttl_seconds: int = DEFAULT_TTL_SECONDS) -> None:
-        expires_at = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+    async def store(
+        self, key: str, items: list[str], ttl_seconds: int = DEFAULT_TTL_SECONDS
+    ) -> None:
+        expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
         cache_doc = FeedCacheDocument(items=items, expires_at=expires_at)
-        await (
-            self._db.collection(FEED_CACHE_COLLECTION)
-            .document(key)
-            .set(cache_doc.model_dump())
-        )
+        await self._db.collection(FEED_CACHE_COLLECTION).document(key).set(cache_doc.model_dump())
 
     async def retrieve(self, key: str) -> list[str] | None:
         document = await self.retrieve_document(key)
@@ -112,16 +112,14 @@ class FirestoreFeedCache(FeedCache):
         expires_at = cache_doc.expires_at
         # Firestore may return naive datetimes; treat them as UTC.
         if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
-        if datetime.now(timezone.utc) >= expires_at:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if datetime.now(UTC) >= expires_at:
             return None
 
         return cache_doc
 
     async def store_document(self, key: str, document: FeedCacheDocument) -> None:
-        await self._db.collection(FEED_CACHE_COLLECTION).document(key).set(
-            document.model_dump()
-        )
+        await self._db.collection(FEED_CACHE_COLLECTION).document(key).set(document.model_dump())
 
     async def append(self, key: str, new_items: list[str]) -> list[str] | None:
         ref = self._db.collection(FEED_CACHE_COLLECTION).document(key)
@@ -137,8 +135,8 @@ class FirestoreFeedCache(FeedCache):
             return None
         expires_at = cache_doc.expires_at
         if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
-        if datetime.now(timezone.utc) >= expires_at:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if datetime.now(UTC) >= expires_at:
             return None
         updated_items = cache_doc.items + new_items
         await ref.update({"items": updated_items})
@@ -166,16 +164,14 @@ class FirestoreFeedCache(FeedCache):
 
         expires_at = cache_doc.expires_at
         if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
-        if datetime.now(timezone.utc) >= expires_at:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if datetime.now(UTC) >= expires_at:
             return None
 
         updated_items = list(dict.fromkeys([*cache_doc.items, *new_items]))
         meta_by_uri = {meta.at_uri: meta for meta in cache_doc.items_meta}
         meta_by_uri.update({meta.at_uri: meta for meta in new_items_meta})
         updated_meta = [meta_by_uri[uri] for uri in updated_items if uri in meta_by_uri]
-        updated = cache_doc.model_copy(
-            update={"items": updated_items, "items_meta": updated_meta}
-        )
+        updated = cache_doc.model_copy(update={"items": updated_items, "items_meta": updated_meta})
         await ref.set(updated.model_dump())
         return updated

--- a/src/app/lib/feed_cache_test.py
+++ b/src/app/lib/feed_cache_test.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from ..lib.feed_cache import (
-    DEFAULT_TTL_SECONDS,
     FEED_CACHE_COLLECTION,
     FirestoreFeedCache,
 )
 from ..models import FeedCursor
 
-
 # ---------------------------------------------------------------------------
 # FeedCursor model
 # ---------------------------------------------------------------------------
+
 
 class TestFeedCursor:
     def test_roundtrip_encode_decode(self):
@@ -34,18 +33,20 @@ class TestFeedCursor:
 
     def test_decode_bad_json_raises(self):
         import base64
+
         raw = base64.urlsafe_b64encode(b"not json").decode()
         with pytest.raises(ValueError, match="Invalid cursor"):
             FeedCursor.decode(raw)
 
     def test_decode_missing_fields_raises(self):
         import base64
+
         raw = base64.urlsafe_b64encode(b'{"v": 1}').decode()
         with pytest.raises(ValueError, match="Invalid cursor"):
             FeedCursor.decode(raw)
 
     def test_offset_must_be_non_negative(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             FeedCursor(id="x", offset=-1)
 
     def test_default_version(self):
@@ -56,6 +57,7 @@ class TestFeedCursor:
 # ---------------------------------------------------------------------------
 # Firestore helpers
 # ---------------------------------------------------------------------------
+
 
 def _mock_firestore_client() -> tuple[MagicMock, MagicMock, AsyncMock]:
     db = MagicMock()
@@ -69,6 +71,7 @@ def _mock_firestore_client() -> tuple[MagicMock, MagicMock, AsyncMock]:
 # ---------------------------------------------------------------------------
 # FirestoreFeedCache.store
 # ---------------------------------------------------------------------------
+
 
 class TestFirestoreFeedCacheStore:
     @pytest.mark.asyncio
@@ -86,13 +89,14 @@ class TestFirestoreFeedCacheStore:
         assert stored["items"] == ["at://a/1", "at://a/2"]
         assert "expires_at" in stored
         # expires_at should be roughly 10 minutes from now.
-        delta = stored["expires_at"] - datetime.now(timezone.utc)
+        delta = stored["expires_at"] - datetime.now(UTC)
         assert timedelta(seconds=590) < delta < timedelta(seconds=610)
 
 
 # ---------------------------------------------------------------------------
 # FirestoreFeedCache.retrieve
 # ---------------------------------------------------------------------------
+
 
 class TestFirestoreFeedCacheRetrieve:
     @pytest.mark.asyncio
@@ -104,7 +108,7 @@ class TestFirestoreFeedCacheRetrieve:
         snap.exists = True
         snap.to_dict.return_value = {
             "items": ["at://a/1"],
-            "expires_at": datetime.now(timezone.utc) + timedelta(minutes=5),
+            "expires_at": datetime.now(UTC) + timedelta(minutes=5),
         }
         doc_ref.get.return_value = snap
 
@@ -120,7 +124,7 @@ class TestFirestoreFeedCacheRetrieve:
         snap.exists = True
         snap.to_dict.return_value = {
             "items": ["at://a/1"],
-            "expires_at": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "expires_at": datetime.now(UTC) - timedelta(minutes=1),
         }
         doc_ref.get.return_value = snap
 
@@ -163,7 +167,7 @@ class TestFirestoreFeedCacheRetrieve:
         # A naive datetime in the future.
         snap.to_dict.return_value = {
             "items": ["at://a/1"],
-            "expires_at": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(minutes=5),
+            "expires_at": datetime.now(UTC).replace(tzinfo=None) + timedelta(minutes=5),
         }
         doc_ref.get.return_value = snap
 
@@ -175,6 +179,7 @@ class TestFirestoreFeedCacheRetrieve:
 # FirestoreFeedCache.append
 # ---------------------------------------------------------------------------
 
+
 class TestFirestoreFeedCacheAppend:
     @pytest.mark.asyncio
     async def test_appends_items_to_existing_doc(self):
@@ -185,7 +190,7 @@ class TestFirestoreFeedCacheAppend:
         snap.exists = True
         snap.to_dict.return_value = {
             "items": ["at://a/1"],
-            "expires_at": datetime.now(timezone.utc) + timedelta(minutes=5),
+            "expires_at": datetime.now(UTC) + timedelta(minutes=5),
         }
         doc_ref.get.return_value = snap
 
@@ -214,7 +219,7 @@ class TestFirestoreFeedCacheAppend:
         snap.exists = True
         snap.to_dict.return_value = {
             "items": ["at://a/1"],
-            "expires_at": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "expires_at": datetime.now(UTC) - timedelta(minutes=1),
         }
         doc_ref.get.return_value = snap
 

--- a/src/app/lib/feed_context_test.py
+++ b/src/app/lib/feed_context_test.py
@@ -17,7 +17,9 @@ def _set_secret(monkeypatch):
 
 
 def _payload(**overrides) -> FeedContextPayload:
-    payload = FeedContextPayload(did="did:plc:abc123", feed="your-feed", rid="req-1", iat=1730000000)
+    payload = FeedContextPayload(
+        did="did:plc:abc123", feed="your-feed", rid="req-1", iat=1730000000
+    )
     return payload.model_copy(update=overrides) if overrides else payload
 
 

--- a/src/app/lib/feed_debug.py
+++ b/src/app/lib/feed_debug.py
@@ -20,9 +20,9 @@ strips embeddings and truncates post content before storage.
 from __future__ import annotations
 
 import contextlib
+import math
 from contextvars import ContextVar
 from datetime import datetime
-import math
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -38,9 +38,7 @@ if TYPE_CHECKING:
 # full post) so debug documents stay well under Firestore's 1 MB limit.
 CONTENT_SNIPPET_MAX = 300
 
-_recorder: ContextVar["FeedDebugRecorder | None"] = ContextVar(
-    "ge_feed_debug_recorder", default=None
-)
+_recorder: ContextVar[FeedDebugRecorder | None] = ContextVar("ge_feed_debug_recorder", default=None)
 
 
 class FeedDebugRecorder:
@@ -55,11 +53,11 @@ class FeedDebugRecorder:
         self.regenerated = regenerated
         self.ranker_model: str | None = None
         self.diversify: bool = False
-        self.generate_request: "CandidateGenerateRequest | None" = None
-        self.generator_outputs: list["CandidateResult"] = []
-        self.final_candidates: list["CandidatePost"] = []
+        self.generate_request: CandidateGenerateRequest | None = None
+        self.generator_outputs: list[CandidateResult] = []
+        self.final_candidates: list[CandidatePost] = []
         self.user_features: list[tuple[str, list[str], int]] = []
-        self.ranking: "RankPredictResult | None" = None
+        self.ranking: RankPredictResult | None = None
         # (model_name, weight, {at_uri: normalized_score}) per configured rank
         # model, in the order they were run; populated only when ranking runs.
         self.model_scores: list[tuple[str, float, dict[str, float]]] = []
@@ -76,13 +74,13 @@ class FeedDebugRecorder:
 
     # -- recording -------------------------------------------------------
 
-    def set_generate_request(self, request: "CandidateGenerateRequest") -> None:
+    def set_generate_request(self, request: CandidateGenerateRequest) -> None:
         self.generate_request = request
 
-    def record_generator_output(self, result: "CandidateResult") -> None:
+    def record_generator_output(self, result: CandidateResult) -> None:
         self.generator_outputs.append(result)
 
-    def record_final_candidates(self, candidates: list["CandidatePost"]) -> None:
+    def record_final_candidates(self, candidates: list[CandidatePost]) -> None:
         self.final_candidates = list(candidates)
 
     def record_user_features(
@@ -90,7 +88,7 @@ class FeedDebugRecorder:
     ) -> None:
         self.user_features.append((source, list(liked_post_uris), num_embeddings))
 
-    def record_ranking(self, ranking: "RankPredictResult") -> None:
+    def record_ranking(self, ranking: RankPredictResult) -> None:
         self.ranking = ranking
 
     def record_model_scores(self, model_name: str, weight: float, scores: dict[str, float]) -> None:
@@ -130,7 +128,7 @@ class FeedDebugRecorder:
         generated_at: datetime,
         expires_at: datetime,
         author_usernames: dict[str, str] | None = None,
-    ) -> "FeedDebugDocument":
+    ) -> FeedDebugDocument:
         """Assemble a :class:`FeedDebugDocument`, stripping embeddings, truncating
         content, and stamping resolved author handles onto stored candidates.
         """
@@ -150,7 +148,7 @@ class FeedDebugRecorder:
 
         authors = author_usernames or {}
 
-        def sanitize(c: "CandidatePost") -> "CandidatePost":
+        def sanitize(c: CandidatePost) -> CandidatePost:
             content = c.content
             if content is not None and len(content) > CONTENT_SNIPPET_MAX:
                 content = content[:CONTENT_SNIPPET_MAX]
@@ -232,7 +230,7 @@ class FeedDebugRecorder:
         generated_at: datetime,
         expires_at: datetime,
         applied_social_radius: int | None = None,
-    ) -> "FeedSnapshotDocument":
+    ) -> FeedSnapshotDocument:
         """Assemble a lightweight :class:`FeedSnapshotDocument` with only the
         per-URI pipeline metadata needed by the transparency API.
 
@@ -261,8 +259,7 @@ class FeedDebugRecorder:
         gens_by_uri: dict[str, list[GeneratorMeta]] = {}
         for result in self.generator_outputs:
             finite_scores = [
-                c.score for c in result.candidates
-                if c.score is not None and math.isfinite(c.score)
+                c.score for c in result.candidates if c.score is not None and math.isfinite(c.score)
             ]
             lo = min(finite_scores) if finite_scores else None
             hi = max(finite_scores) if finite_scores else None
@@ -279,20 +276,22 @@ class FeedDebugRecorder:
         requested_by_name: dict[str, int] = {}
         if self.generate_request:
             from .candidates.generate import allocate_counts
+
             counts = allocate_counts(
                 self.generate_request.generators,
                 self.generate_request.num_candidates,
             )
             requested_by_name = {
                 spec.name: count
-                for spec, count in zip(self.generate_request.generators, counts)
+                for spec, count in zip(self.generate_request.generators, counts, strict=False)
             }
 
         diagnostics: list[GeneratorDiagnostic] = []
         specs = self.generate_request.generators if self.generate_request else []
         for spec in specs:
             staged = [
-                output for output in self.generator_outputs
+                output
+                for output in self.generator_outputs
                 if output.generator_name == spec.name and output.mode != "primary"
             ]
             if staged:
@@ -318,7 +317,8 @@ class FeedDebugRecorder:
                     remaining = max(0, remaining - len(returned_uris))
                 continue
             matching = [
-                output for output in self.generator_outputs
+                output
+                for output in self.generator_outputs
                 if output.generator_name == spec.name and output.mode == "primary"
             ]
             returned_uris = {
@@ -329,7 +329,8 @@ class FeedDebugRecorder:
             }
             output = matching[-1] if matching else None
             contributed = sum(
-                1 for uri in self.final_order
+                1
+                for uri in self.final_order
                 if any(g.name == spec.name for g in gens_by_uri.get(uri, []))
             )
             diagnostics.append(
@@ -413,13 +414,13 @@ class FeedDebugRecorder:
         return dids
 
 
-def current_recorder() -> "FeedDebugRecorder | None":
+def current_recorder() -> FeedDebugRecorder | None:
     """Return the recorder for the current request, or ``None`` if not debugging."""
     return _recorder.get()
 
 
 @contextlib.contextmanager
-def feed_debug_scope(recorder: "FeedDebugRecorder"):
+def feed_debug_scope(recorder: FeedDebugRecorder):
     """Install *recorder* as the current feed-debug recorder for the block."""
     token = _recorder.set(recorder)
     try:

--- a/src/app/lib/feed_debug_test.py
+++ b/src/app/lib/feed_debug_test.py
@@ -2,25 +2,25 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from .candidates.base import CandidateResult
-from .diversify import BETA, mmr_rerank, AUTHOR_WEIGHT
-from .embeddings import encode_float32_b64
-from .feed_debug import (
-    CONTENT_SNIPPET_MAX,
-    FeedDebugRecorder,
-    current_recorder,
-    feed_debug_scope,
-)
 from ..models import (
     CandidateGenerateRequest,
     CandidatePost,
     GeneratorSpec,
     RankedCandidate,
     RankPredictResult,
+)
+from .candidates.base import CandidateResult
+from .diversify import AUTHOR_WEIGHT, BETA, mmr_rerank
+from .embeddings import encode_float32_b64
+from .feed_debug import (
+    CONTENT_SNIPPET_MAX,
+    FeedDebugRecorder,
+    current_recorder,
+    feed_debug_scope,
 )
 
 
@@ -87,7 +87,7 @@ class TestBuildDocument:
         return rec
 
     def _build(self, rec: FeedDebugRecorder, **kwargs):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         return rec.build_document(
             request_id="req123",
             username="user.bsky.app",
@@ -197,12 +197,15 @@ def test_snapshot_diagnostics_use_one_followed_users_source():
     )
     recent = _candidate("at://p/recent")
     older = _candidate("at://p/older")
-    rec.record_generator_output(CandidateResult(
-        generator_name="followed_users", candidates=[recent, older],
-    ))
+    rec.record_generator_output(
+        CandidateResult(
+            generator_name="followed_users",
+            candidates=[recent, older],
+        )
+    )
     rec.record_final_candidates([recent, older])
     rec.record_final_order(["at://p/recent", "at://p/older"])
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     snapshot = rec.build_pipeline_metadata(
         request_id="req", generated_at=now, expires_at=now + timedelta(minutes=15)
@@ -322,7 +325,7 @@ class TestBuildPipelineMetadata:
         rec.final_order = ["at://a"]
         rec.order_after_rank = ["at://a"]
 
-        now = datetime(2026, 7, 12, 15, 30, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 12, 15, 30, tzinfo=UTC)
         expires = now + timedelta(minutes=15)
         snap = rec.build_pipeline_metadata(request_id="req-1", generated_at=now, expires_at=expires)
 
@@ -358,7 +361,7 @@ class TestBuildPipelineMetadata:
         rec.final_order = ["at://a", "at://b"]
         rec.order_after_rank = ["at://a", "at://b"]
 
-        now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 12, tzinfo=UTC)
         snap = rec.build_pipeline_metadata(request_id="r", generated_at=now, expires_at=now)
 
         assert len(snap.items_meta) == 2
@@ -396,7 +399,7 @@ class TestBuildPipelineMetadata:
         rec.final_order = ["at://a", "at://b"]
         rec.order_after_rank = ["at://a", "at://b"]
 
-        now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 12, tzinfo=UTC)
         snap = rec.build_pipeline_metadata(request_id="r", generated_at=now, expires_at=now)
 
         assert snap.ranker_model == "two_tower"
@@ -427,7 +430,7 @@ class TestBuildPipelineMetadata:
         rec.final_order = ["at://a"]
         rec.order_after_rank = ["at://a"]
 
-        now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 12, tzinfo=UTC)
         snap = rec.build_pipeline_metadata(request_id="r", generated_at=now, expires_at=now)
 
         assert snap.diversify is True
@@ -454,7 +457,7 @@ class TestBuildPipelineMetadata:
         rec.final_order = ["at://a"]
         rec.order_after_rank = ["at://a"]
 
-        now = datetime(2026, 7, 12, tzinfo=timezone.utc)
+        now = datetime(2026, 7, 12, tzinfo=UTC)
         snap = rec.build_pipeline_metadata(request_id="r", generated_at=now, expires_at=now)
 
         assert snap.diversify is False

--- a/src/app/lib/firebase_auth.py
+++ b/src/app/lib/firebase_auth.py
@@ -22,9 +22,9 @@ import os
 from typing import Annotated
 
 import firebase_admin  # type: ignore[import-untyped]
-from firebase_admin import auth, credentials  # type: ignore[import-untyped]
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from firebase_admin import auth, credentials  # type: ignore[import-untyped]
 
 from .firestore import user_doc_id
 
@@ -73,11 +73,11 @@ async def verify_firebase_auth(
 
     try:
         decoded = auth.verify_id_token(authorization.credentials)
-    except Exception:
+    except Exception as err:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
-        )
+        ) from err
 
     uid: str = decoded.get("uid", "")
     if not uid or not uid.startswith("did:plc:"):

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from google.cloud.firestore import (  # type: ignore[import-untyped]
     ArrayUnion,
@@ -122,7 +122,7 @@ async def upsert_user(db: AsyncClient, user_did: str, username: str | None) -> U
     ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
     doc = await ref.get()
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     if doc.exists:
         data = doc.to_dict()
@@ -180,7 +180,7 @@ async def set_user_debug_flag(db: AsyncClient, user_did: str, enabled: bool) -> 
     doc = await ref.get()
     if not doc.exists:
         raise ValueError(f"No user document for {user_did}")
-    await ref.update({"debug_feeds": enabled, "updated_at": datetime.now(timezone.utc)})
+    await ref.update({"debug_feeds": enabled, "updated_at": datetime.now(UTC)})
 
 
 async def set_user_social_radius(db: AsyncClient, user_did: str, social_radius: int) -> None:
@@ -265,13 +265,14 @@ async def upsert_feed_activity(
     )
     doc = await ref.get()
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     if doc.exists:
         data = doc.to_dict()
         if data is None:
             raise ValueError(
-                f"Firestore feed_activity document exists but to_dict() returned None for {user_did}/{feed_name}"
+                "Firestore feed_activity document exists but to_dict() returned None "
+                f"for {user_did}/{feed_name}"
             )
         await ref.update({"last_seen_at": now})
         data["last_seen_at"] = now
@@ -323,7 +324,7 @@ async def _record_daily_bucket_uris(
     if not post_uris:
         return
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     bucket_id = now.strftime("%Y-%m-%d")
     expires_at = now + timedelta(days=retention_days)
 
@@ -350,7 +351,7 @@ async def _get_recent_bucket_uris(
     ``ArrayUnion`` preserves append order, so the result is roughly the most
     recent URIs.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     query = (
         db.collection(USERS_COLLECTION)
         .document(user_doc_id(user_did))
@@ -486,12 +487,8 @@ def _merge_feed_snapshots(
     meta_by_uri = {meta.at_uri: meta for meta in earlier.items_meta}
     meta_by_uri.update({meta.at_uri: meta for meta in later.items_meta})
     items_meta = [meta_by_uri[uri] for uri in ordered_items if uri in meta_by_uri]
-    existing_diag = {
-        (diag.name, diag.mode): diag for diag in existing.generator_diagnostics
-    }
-    incoming_diag = {
-        (diag.name, diag.mode): diag for diag in incoming.generator_diagnostics
-    }
+    existing_diag = {(diag.name, diag.mode): diag for diag in existing.generator_diagnostics}
+    incoming_diag = {(diag.name, diag.mode): diag for diag in incoming.generator_diagnostics}
     incoming_new = set(incoming.items) - set(existing.items)
     diagnostics = []
     for key in dict.fromkeys([*existing_diag, *incoming_diag]):

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from google.cloud.firestore import ArrayUnion
 
-from ..documents import FeedDebugDocument, FeedSnapshotDocument, InteractionDocument, PipelineItemMeta, UserDocument
-from ..models import CandidateGenerateRequest, GeneratorSpec
+from ..documents import (
+    FeedDebugDocument,
+    FeedSnapshotDocument,
+    InteractionDocument,
+    PipelineItemMeta,
+)
 from ..lib.firestore import (
     DISCARDED_POSTS_COLLECTION,
-    FEED_DEBUG_COLLECTION,
-    FEED_SNAPSHOTS_COLLECTION,
-    MAX_FEED_SNAPSHOT_ITEMS,
     INTERACTIONS_COLLECTION,
+    MAX_FEED_SNAPSHOT_ITEMS,
     SEEN_POSTS_COLLECTION,
     USERS_COLLECTION,
+    _merge_feed_snapshots,
     get_feed_activity,
     get_feed_debug,
     get_newer_feed_snapshot_uris,
@@ -27,7 +29,6 @@ from ..lib.firestore import (
     get_recent_seen_uris,
     get_user,
     get_user_by_username,
-    _merge_feed_snapshots,
     init_firestore_client,
     merge_feed_snapshot,
     record_discarded_posts,
@@ -39,7 +40,7 @@ from ..lib.firestore import (
     user_doc_id,
     write_feed_debug,
 )
-
+from ..models import CandidateGenerateRequest, GeneratorSpec
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -53,7 +54,8 @@ FEED_NAME = "unranked-your-feed"
 def _mock_feed_activity_client():
     db = MagicMock()
     doc_ref = AsyncMock()
-    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    nested_doc = db.collection.return_value.document.return_value.collection.return_value.document
+    nested_doc.return_value = doc_ref
     return db, doc_ref
 
 
@@ -61,7 +63,8 @@ def _mock_seen_posts_write_client():
     """Mock the users/{did}/seen_posts/{bucket} document-write chain."""
     db = MagicMock()
     doc_ref = AsyncMock()
-    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    nested_doc = db.collection.return_value.document.return_value.collection.return_value.document
+    nested_doc.return_value = doc_ref
     return db, doc_ref
 
 
@@ -78,7 +81,9 @@ def _mock_seen_posts_query_client(buckets):
     db = MagicMock()
     query = MagicMock()
     query.stream.return_value = _async_iter(buckets)
-    db.collection.return_value.document.return_value.collection.return_value.where.return_value = query
+    db.collection.return_value.document.return_value.collection.return_value.where.return_value = (
+        query
+    )
     return db, query
 
 
@@ -97,7 +102,9 @@ def _mock_doc_snapshot(exists: bool, data: dict | None = None) -> MagicMock:
     return snap
 
 
-def _feed_snapshot(request_id: str, generated_at: datetime, items: list[str], *, expires_at: datetime | None = None) -> FeedSnapshotDocument:
+def _feed_snapshot(
+    request_id: str, generated_at: datetime, items: list[str], *, expires_at: datetime | None = None
+) -> FeedSnapshotDocument:
     return FeedSnapshotDocument(
         request_id=request_id,
         items=items,
@@ -205,14 +212,17 @@ class TestGetUser:
     @pytest.mark.asyncio
     async def test_returns_user_when_exists(self):
         db, _, doc_ref = _mock_firestore_client()
-        now = datetime.now(timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": now,
-            "updated_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": now,
+                "updated_at": now,
+                "last_seen_at": now,
+            },
+        )
 
         user = await get_user(db, USER_DID)
 
@@ -262,14 +272,17 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_updates_existing_user(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME)
 
@@ -302,14 +315,17 @@ class TestUpsertUser:
     async def test_unresolved_handle_does_not_erase_a_known_one(self):
         # A directory blip shouldn't wipe a handle we already resolved.
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, None)
 
@@ -322,14 +338,17 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_updates_username_when_changed(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": "old-handle.bsky.app",
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": "old-handle.bsky.app",
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME)
 
@@ -353,12 +372,15 @@ class TestGetFeedActivity:
     @pytest.mark.asyncio
     async def test_returns_doc_when_exists(self):
         db, doc_ref = _mock_feed_activity_client()
-        now = datetime.now(timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": now,
+                "last_seen_at": now,
+            },
+        )
 
         activity = await get_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -402,12 +424,15 @@ class TestUpsertFeedActivity:
     @pytest.mark.asyncio
     async def test_updates_only_last_seen_at_on_revisit(self):
         db, doc_ref = _mock_feed_activity_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -421,12 +446,15 @@ class TestUpsertFeedActivity:
     @pytest.mark.asyncio
     async def test_does_not_overwrite_first_seen_at(self):
         db, doc_ref = _mock_feed_activity_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -485,7 +513,7 @@ class TestRecordSeenPosts:
             SEEN_POSTS_COLLECTION
         )
         # Bucket id is the current UTC date.
-        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        bucket_id = datetime.now(UTC).strftime("%Y-%m-%d")
         db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
             bucket_id
         )
@@ -496,7 +524,7 @@ class TestRecordSeenPosts:
         assert kwargs == {"merge": True}
         assert isinstance(payload["post_uris"], ArrayUnion)
         assert payload["post_uris"].values == ["at://post/1", "at://post/2"]
-        assert payload["expires_at"] > datetime.now(timezone.utc)
+        assert payload["expires_at"] > datetime.now(UTC)
 
     @pytest.mark.asyncio
     async def test_noop_on_empty(self):
@@ -526,7 +554,8 @@ class TestGetRecentSeenUris:
         # Newest bucket first, duplicate "at://b" collapsed.
         assert uris == ["at://b", "at://c", "at://a"]
         # Query filters on a future expiry.
-        where_args = db.collection.return_value.document.return_value.collection.return_value.where.call_args[0]
+        collection_mock = db.collection.return_value.document.return_value.collection.return_value
+        where_args = collection_mock.where.call_args[0]
         assert where_args[0] == "expires_at"
         assert where_args[1] == ">"
 
@@ -561,7 +590,7 @@ class TestDiscardedPosts:
         db.collection.return_value.document.return_value.collection.assert_called_with(
             DISCARDED_POSTS_COLLECTION
         )
-        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        bucket_id = datetime.now(UTC).strftime("%Y-%m-%d")
         db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
             bucket_id
         )
@@ -572,7 +601,7 @@ class TestDiscardedPosts:
         assert kwargs == {"merge": True}
         assert isinstance(payload["post_uris"], ArrayUnion)
         assert payload["post_uris"].values == ["at://post/1", "at://post/2"]
-        assert payload["expires_at"] > datetime.now(timezone.utc)
+        assert payload["expires_at"] > datetime.now(UTC)
 
     @pytest.mark.asyncio
     async def test_noop_on_empty(self):
@@ -616,7 +645,7 @@ REQUEST_ID = "req-abc123"
 
 
 def _feed_debug_doc() -> FeedDebugDocument:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return FeedDebugDocument(
         request_id=REQUEST_ID,
         user_did=USER_DID,
@@ -639,14 +668,17 @@ def _feed_debug_doc() -> FeedDebugDocument:
 class TestGetUserByUsername:
     @pytest.mark.asyncio
     async def test_returns_first_match(self):
-        now = datetime.now(timezone.utc)
-        snap = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": now,
-            "updated_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        snap = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": now,
+                "updated_at": now,
+                "last_seen_at": now,
+            },
+        )
         db = MagicMock()
         query = MagicMock()
         query.stream.return_value = _async_iter([snap])
@@ -749,7 +781,7 @@ class TestGetFeedDebug:
 class TestGetNewerFeedSnapshotUris:
     @pytest.mark.asyncio
     async def test_returns_uris_from_newer_snapshots(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         snap1 = _mock_doc_snapshot(True, {"items": ["at://a", "at://b"]})
         snap2 = _mock_doc_snapshot(True, {"items": ["at://c"]})
@@ -767,7 +799,7 @@ class TestGetNewerFeedSnapshotUris:
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_newer_snapshots(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         query = MagicMock()
         query.stream.return_value = _async_iter([])
@@ -783,7 +815,7 @@ class TestGetNewerFeedSnapshotUris:
 
     @pytest.mark.asyncio
     async def test_allows_empty_items_lists(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         snap = _mock_doc_snapshot(True, {"items": []})
         query = MagicMock()
@@ -801,10 +833,12 @@ class TestGetNewerFeedSnapshotUris:
 
 class TestMergeFeedSnapshots:
     def test_appends_regeneration_and_extends_expiration(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot("session-1", now, ["at://a", "at://b"])
         regenerated = _feed_snapshot(
-            "session-1", now + timedelta(minutes=2), ["at://c"],
+            "session-1",
+            now + timedelta(minutes=2),
+            ["at://c"],
             expires_at=now + timedelta(minutes=17),
         )
 
@@ -816,7 +850,7 @@ class TestMergeFeedSnapshots:
         assert truncated is False
 
     def test_deduplicates_and_uses_newer_metadata(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot("session-1", now, ["at://a", "at://b"])
         regenerated = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://b", "at://c"])
         regenerated.items_meta[0] = PipelineItemMeta(at_uri="at://b", rank=99)
@@ -827,7 +861,7 @@ class TestMergeFeedSnapshots:
         assert next(m for m in merged.items_meta if m.at_uri == "at://b").rank == 99
 
     def test_orders_out_of_order_background_writes(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         later = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://c"])
         earlier = _feed_snapshot("session-1", now, ["at://a", "at://b"])
 
@@ -837,9 +871,10 @@ class TestMergeFeedSnapshots:
         assert merged.generated_at == now
 
     def test_caps_session_at_item_limit(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot(
-            "session-1", now,
+            "session-1",
+            now,
             [f"at://post/{i}" for i in range(MAX_FEED_SNAPSHOT_ITEMS)],
         )
         later = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://overflow"])
@@ -852,7 +887,7 @@ class TestMergeFeedSnapshots:
 
     @pytest.mark.asyncio
     async def test_creates_snapshot_in_transaction(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         doc = _feed_snapshot("session-1", now, ["at://a"])
         db, doc_ref = _mock_feed_activity_client()
         transaction = MagicMock()
@@ -868,7 +903,7 @@ class TestMergeFeedSnapshots:
 
     @pytest.mark.asyncio
     async def test_empty_batch_skips_transaction(self):
-        doc = _feed_snapshot("session-1", datetime.now(timezone.utc), [])
+        doc = _feed_snapshot("session-1", datetime.now(UTC), [])
         db = MagicMock()
 
         assert await merge_feed_snapshot(db, USER_DID, "session-1", doc) is False

--- a/src/app/lib/inference.py
+++ b/src/app/lib/inference.py
@@ -10,13 +10,13 @@ import os
 import time
 
 from .elasticsearch import (
-    fetch_recent_liked_post_uris_and_times,
     fetch_post_embeddings_and_metadata,
+    fetch_recent_liked_post_uris_and_times,
 )
 from .feed_debug import current_recorder
-from .telemetry import timed
-from .request_context import get_request_id
 from .http_client import get_http_client
+from .request_context import get_request_id
+from .telemetry import timed
 
 logger = logging.getLogger(__name__)
 
@@ -58,11 +58,7 @@ def get_inference_settings() -> tuple[str, str]:
     return base_url, api_key
 
 
-def raise_inference_response_error(
-    source_name: str,
-    status_code: int,
-    body: str
-) -> None:
+def raise_inference_response_error(source_name: str, status_code: int, body: str) -> None:
     body = body.strip()
     if len(body) > 2000:
         body = f"{body[:2000]}..."
@@ -187,7 +183,7 @@ async def predict_heavy_ranker_single_user(
         logger,
         "ranker_predict_http",
         n_history=len(history_embeddings),
-        n_candidates=len(candidate_post_embeddings)
+        n_candidates=len(candidate_post_embeddings),
     ):
         resp = await client.post(url, json=payload, headers=headers)
     if resp.is_error:
@@ -220,8 +216,11 @@ async def compute_user_embedding(
             if rec is not None:
                 rec.record_user_features(source, [], 0)
         else:
-            user_history_embedding_pairs: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
-                es, user_history_liked_uris,
+            user_history_embedding_pairs: list[
+                tuple[str, list[float], str, int]
+            ] = await fetch_post_embeddings_and_metadata(
+                es,
+                user_history_liked_uris,
             )
             if rec is not None:
                 rec.record_user_features(
@@ -234,8 +233,12 @@ async def compute_user_embedding(
                     user_did,
                 )
             else:
-                user_history_vectors = [embedding for _, embedding, _, _ in user_history_embedding_pairs]
-                history_author_dids = [author_did for _, _, author_did, _ in user_history_embedding_pairs]
+                user_history_vectors = [
+                    embedding for _, embedding, _, _ in user_history_embedding_pairs
+                ]
+                history_author_dids = [
+                    author_did for _, _, author_did, _ in user_history_embedding_pairs
+                ]
 
         output_user_embedding_list = await predict_user_tower_single(
             user_history_vectors,

--- a/src/app/lib/inference_test.py
+++ b/src/app/lib/inference_test.py
@@ -164,9 +164,7 @@ async def test_cached_post_tower_uuid_reuses_successful_lookup(monkeypatch):
         calls += 1
         return f"{base_url}:{api_key}:uuid"
 
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
     first = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
     second = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
@@ -186,9 +184,7 @@ async def test_cached_post_tower_uuid_collapses_concurrent_lookups(monkeypatch):
         await asyncio.sleep(0)
         return "post-tower-uuid"
 
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
     results = await asyncio.gather(
         inference_module.get_cached_post_tower_uuid("https://inference", "key"),
@@ -208,9 +204,7 @@ async def test_cached_post_tower_uuid_does_not_cache_missing_uuid(monkeypatch):
         calls += 1
         return None
 
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
     first = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
     second = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
@@ -230,13 +224,9 @@ async def test_cached_post_tower_uuid_refreshes_stale_uuid(monkeypatch):
         return "new-uuid"
 
     monkeypatch.setattr(inference_module.time, "monotonic", lambda: now)
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
-    result = await inference_module.get_cached_post_tower_uuid(
-        "https://inference", "key"
-    )
+    result = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
 
     assert result == "new-uuid"
     assert inference_module._post_tower_uuid_cache[key] == (
@@ -257,13 +247,9 @@ async def test_cached_post_tower_uuid_returns_stale_uuid_on_refresh_error(
         raise RuntimeError("ready down")
 
     monkeypatch.setattr(inference_module.time, "monotonic", lambda: now)
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
-    result = await inference_module.get_cached_post_tower_uuid(
-        "https://inference", "key"
-    )
+    result = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
 
     assert result == "stale-uuid"
     assert inference_module._post_tower_uuid_cache[key] == ("stale-uuid", now - 1)
@@ -281,13 +267,9 @@ async def test_cached_post_tower_uuid_returns_none_when_post_tower_not_configure
         return None
 
     monkeypatch.setattr(inference_module.time, "monotonic", lambda: now)
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
-    result = await inference_module.get_cached_post_tower_uuid(
-        "https://inference", "key"
-    )
+    result = await inference_module.get_cached_post_tower_uuid("https://inference", "key")
 
     assert result is None
     assert inference_module._post_tower_uuid_cache[key] == ("stale-uuid", now - 1)
@@ -306,9 +288,7 @@ async def test_cached_post_tower_uuid_raises_refresh_error_after_stale_grace(
         raise RuntimeError("ready down")
 
     monkeypatch.setattr(inference_module.time, "monotonic", lambda: now)
-    monkeypatch.setattr(
-        inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid
-    )
+    monkeypatch.setattr(inference_module, "get_post_tower_uuid", fake_get_post_tower_uuid)
 
     with pytest.raises(RuntimeError, match="ready down"):
         await inference_module.get_cached_post_tower_uuid("https://inference", "key")

--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -21,15 +21,15 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
-_metric_collector: "MetricCollector | None" = None
+_metric_collector: MetricCollector | None = None
 
 
-def set_metric_collector(collector: "MetricCollector | None") -> None:
+def set_metric_collector(collector: MetricCollector | None) -> None:
     global _metric_collector
     _metric_collector = collector
 
 
-def get_metric_collector() -> "MetricCollector | None":
+def get_metric_collector() -> MetricCollector | None:
     return _metric_collector
 
 
@@ -50,6 +50,7 @@ class MetricCollector:
             from opentelemetry.exporter.cloud_monitoring import (
                 CloudMonitoringMetricsExporter,
             )
+
             exporter = CloudMonitoringMetricsExporter(
                 prefix="custom.googleapis.com/greenearth-api",
                 # Cloud Run scales this service to multiple concurrent
@@ -80,7 +81,7 @@ class MetricCollector:
         reader: Any,
         service_name: str,
         env: str,
-    ) -> "MetricCollector":
+    ) -> MetricCollector:
         instance = cls.__new__(cls)
         instance._init(reader, service_name, env)
         return instance

--- a/src/app/lib/metrics_test.py
+++ b/src/app/lib/metrics_test.py
@@ -3,20 +3,20 @@
 from unittest.mock import patch
 
 import pytest
-from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
     InMemoryMetricReader,
-    MetricExportResult,
 )
 
 from .metrics import MetricCollector, get_metric_collector, set_metric_collector
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_collector(service_name: str = "test-svc", env: str = "test") -> tuple[MetricCollector, InMemoryMetricReader]:
+
+def _make_collector(
+    service_name: str = "test-svc", env: str = "test"
+) -> tuple[MetricCollector, InMemoryMetricReader]:
     reader = InMemoryMetricReader()
     collector = MetricCollector._from_reader(reader, service_name=service_name, env=env)
     return collector, reader
@@ -41,6 +41,7 @@ def _collect_names_from_data(data) -> set[str]:
 # Instrument type inference
 # ---------------------------------------------------------------------------
 
+
 def test_counter_inferred_for_count_suffix():
     collector, reader = _make_collector()
     collector.record("requests_count", 5)
@@ -51,6 +52,7 @@ def test_counter_inferred_for_count_suffix():
             for metric in sm.metrics:
                 if metric.name == "requests_count":
                     from opentelemetry.sdk.metrics._internal.point import Sum
+
                     assert isinstance(metric.data, Sum)
                     found = True
     assert found, "requests_count not found in exported metrics"
@@ -66,6 +68,7 @@ def test_gauge_inferred_for_rate_suffix():
             for metric in sm.metrics:
                 if metric.name == "throughput_rate":
                     from opentelemetry.sdk.metrics._internal.point import Gauge
+
                     assert isinstance(metric.data, Gauge)
                     found = True
     assert found, "throughput_rate not found in exported metrics"
@@ -81,6 +84,7 @@ def test_histogram_inferred_for_ms_suffix():
             for metric in sm.metrics:
                 if metric.name == "feed.render.duration_ms":
                     from opentelemetry.sdk.metrics._internal.point import Histogram
+
                     assert isinstance(metric.data, Histogram)
                     found = True
     assert found, "feed.render.duration_ms not found in exported metrics"
@@ -96,6 +100,7 @@ def test_histogram_inferred_for_arbitrary_name():
 # ---------------------------------------------------------------------------
 # Attributes (labels)
 # ---------------------------------------------------------------------------
+
 
 def test_attributes_attached_to_histogram():
     collector, reader = _make_collector()
@@ -158,6 +163,7 @@ def test_explicit_endpoint_attribute_wins():
 # Lazy instrument reuse
 # ---------------------------------------------------------------------------
 
+
 def test_same_instrument_reused_across_calls():
     collector, reader = _make_collector()
     collector.record("feed.render.duration_ms", 10.0)
@@ -168,6 +174,7 @@ def test_same_instrument_reused_across_calls():
             for metric in sm.metrics:
                 if metric.name == "feed.render.duration_ms":
                     from opentelemetry.sdk.metrics._internal.point import Histogram
+
                     assert isinstance(metric.data, Histogram)
                     # Both values should be in the same histogram
                     dp = metric.data.data_points[0]
@@ -177,6 +184,7 @@ def test_same_instrument_reused_across_calls():
 # ---------------------------------------------------------------------------
 # GCP exporter construction
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("env", ["stage", "prod"])
 def test_gcp_exporter_uses_unique_identifier(env):
@@ -201,6 +209,7 @@ def test_gcp_exporter_uses_unique_identifier(env):
 # Local/dev (non-deployed environment)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_local_env_records_without_exporting(capsys):
     """Local/dev should record metrics without printing a resource_metrics blob."""
@@ -222,6 +231,7 @@ async def test_local_env_records_without_exporting(capsys):
 # Module-level singleton
 # ---------------------------------------------------------------------------
 
+
 def test_set_and_get_metric_collector():
     collector, _ = _make_collector()
     set_metric_collector(collector)
@@ -233,6 +243,7 @@ def test_set_and_get_metric_collector():
 # ---------------------------------------------------------------------------
 # Shutdown
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_shutdown_does_not_raise():

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -10,7 +10,6 @@ import time
 import aiohttp
 
 from ..models import CandidatePost
-from .http_client import get_http_client
 from .pipeline_context import DegradationEvent, DegradationStage, current_pipeline_context
 from .telemetry import timed
 
@@ -39,6 +38,7 @@ class PerspectiveLanguageNotSupportedError(Exception):
         self.language = language
         msg = f"language not supported: {language}" if language else "language not supported"
         super().__init__(msg)
+
 
 # `perspective_baseline_minus_outrage_toxic` from the PRC reference
 # implementation (PRC paper's "Uprank Bridging, Downrank Toxic" condition —
@@ -94,7 +94,9 @@ def _raw_weighted_score_bounds(weights: dict[str, float]) -> tuple[float, float]
     return (lo, hi)
 
 
-def _change_bounds(raw: float, original_bounds: tuple[float, float], new_bounds: tuple[float, float]) -> float:
+def _change_bounds(
+    raw: float, original_bounds: tuple[float, float], new_bounds: tuple[float, float]
+) -> float:
     """Linearly map *raw* from *original_bounds* into *new_bounds*."""
     orig_lo, orig_hi = original_bounds
     if orig_hi <= orig_lo:
@@ -244,6 +246,7 @@ async def _rate_limit_acquire() -> bool:
         _rate_count += 1
         return True
 
+
 _client: PerspectiveClient | None = None
 
 
@@ -278,7 +281,9 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
         if not c.content or not c.content.strip():
             return None
         if not await _rate_limit_acquire():
-            logger.warning("Perspective API minute quota exhausted; using missing score for post %s", c.at_uri)
+            logger.warning(
+                "Perspective API minute quota exhausted; using missing score for post %s", c.at_uri
+            )
             return None
         try:
             return await client.score(c.content)
@@ -298,27 +303,29 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
             logger.exception("Perspective API scoring failed for post %s", c.at_uri)
             ctx = current_pipeline_context()
             if ctx is not None:
-                ctx.record(DegradationEvent(
-                    stage=DegradationStage.RANK,
-                    component="perspective",
-                    cause=exc,
-                ))
+                ctx.record(
+                    DegradationEvent(
+                        stage=DegradationStage.RANK,
+                        component="perspective",
+                        cause=exc,
+                    )
+                )
             return None
         except Exception as exc:
             logger.exception("Perspective API scoring failed for post %s", c.at_uri)
             ctx = current_pipeline_context()
             if ctx is not None:
-                ctx.record(DegradationEvent(
-                    stage=DegradationStage.RANK,
-                    component="perspective",
-                    cause=exc,
-                ))
+                ctx.record(
+                    DegradationEvent(
+                        stage=DegradationStage.RANK,
+                        component="perspective",
+                        cause=exc,
+                    )
+                )
             return None
 
     scorable = [c for c in candidates if c.at_uri]
     scores = await asyncio.gather(*(_score_one(c) for c in scorable))
     return {
-        c.at_uri: score
-        for c, score in zip(scorable, scores, strict=True)
-        if c.at_uri is not None
+        c.at_uri: score for c, score in zip(scorable, scores, strict=True) if c.at_uri is not None
     }

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -70,7 +70,9 @@ _OUTRAGE_EIGHTEENTH_ATTRS = [
     "ALIENATION_EXPERIMENTAL",
 ]
 _TOXIC_EIGHTH_ATTRS = ["TOXICITY", "IDENTITY_ATTACK", "INSULT", "THREAT"]
-_ALL_PRC_ATTRS = _BRIDGING_ATTRS + _OUTRAGE_SIXTH_ATTRS + _OUTRAGE_EIGHTEENTH_ATTRS + _TOXIC_EIGHTH_ATTRS
+_ALL_PRC_ATTRS = (
+    _BRIDGING_ATTRS + _OUTRAGE_SIXTH_ATTRS + _OUTRAGE_EIGHTEENTH_ATTRS + _TOXIC_EIGHTH_ATTRS
+)
 
 
 def _zero_attr() -> dict[str, float]:
@@ -117,6 +119,7 @@ class TestPrcScore:
 # ---------------------------------------------------------------------------
 # score_candidates
 # ---------------------------------------------------------------------------
+
 
 def _make_candidate(uri: str, content: str | None = "text", score: float = 1.0) -> CandidatePost:
     return CandidatePost(
@@ -327,6 +330,7 @@ class TestScoreCandidates:
     def test_empty_list_returns_empty(self):
         with patch("app.lib.perspective._get_client") as mock_get:
             import asyncio
+
             result = asyncio.run(score_candidates([]))
         mock_get.assert_not_called()
         assert result == {}
@@ -341,6 +345,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert result == {"at://a/1": 0.1, "at://a/2": 0.5, "at://a/3": 0.9}
@@ -354,6 +359,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert result == {"at://a/1": 0.0, "at://a/2": 0.8}
@@ -367,6 +373,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert result == {"at://a/1": None, "at://a/2": 0.8}
@@ -381,6 +388,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert result == {"at://a/1": None, "at://a/2": 0.7}
@@ -415,6 +423,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert result == {"at://a/1": None, "at://a/2": 0.7}
@@ -428,6 +437,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         fake.score.assert_not_called()
@@ -439,6 +449,7 @@ class TestScoreCandidates:
 
         with patch("app.lib.perspective._get_client", return_value=fake):
             import asyncio
+
             result = asyncio.run(score_candidates(candidates))
 
         assert len(result) == 5
@@ -520,9 +531,7 @@ class TestScoreCandidatesDegradation:
     @pytest.mark.asyncio
     async def test_language_not_supported_does_not_record_degradation(self, monkeypatch):
         mock_client = MagicMock()
-        mock_client.score = AsyncMock(
-            side_effect=PerspectiveLanguageNotSupportedError("ja")
-        )
+        mock_client.score = AsyncMock(side_effect=PerspectiveLanguageNotSupportedError("ja"))
         monkeypatch.setattr(perspective_module, "_client", mock_client)
 
         ctx = PipelineContext(feed_name="your-feed")

--- a/src/app/lib/pipeline_context.py
+++ b/src/app/lib/pipeline_context.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import contextlib
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class DegradationStage(str, Enum):
+class DegradationStage(StrEnum):
     CANDIDATE_GEN = "candidate_gen"
     RANK = "rank"
     EMBED_HYDRATION = "embed_hydration"
@@ -25,7 +25,7 @@ class DegradationStage(str, Enum):
 @dataclass
 class DegradationEvent:
     stage: DegradationStage
-    component: str    # e.g. "two_tower", "perspective", "fetch_post_embeddings"
+    component: str  # e.g. "two_tower", "perspective", "fetch_post_embeddings"
     cause: BaseException
 
 
@@ -44,9 +44,7 @@ class PipelineContext:
             raise event.cause
 
 
-_context: ContextVar[PipelineContext | None] = ContextVar(
-    "ge_pipeline_context", default=None
-)
+_context: ContextVar[PipelineContext | None] = ContextVar("ge_pipeline_context", default=None)
 
 
 def current_pipeline_context() -> PipelineContext | None:

--- a/src/app/lib/post_hydration.py
+++ b/src/app/lib/post_hydration.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import httpx
 from google.cloud.firestore import AsyncClient
@@ -54,7 +54,9 @@ async def _fetch_posts_batch(uris: list[str]) -> list[dict]:
             data = resp.json()
             return data.get("posts", []) if isinstance(data, dict) else []
         except httpx.HTTPStatusError as exc:
-            if attempt == 0 and (exc.response.status_code == 429 or 500 <= exc.response.status_code < 600):
+            if attempt == 0 and (
+                exc.response.status_code == 429 or 500 <= exc.response.status_code < 600
+            ):
                 await asyncio.sleep(0.5)
                 continue
             logger.warning(
@@ -94,8 +96,7 @@ def _parse_bsky_post(post: dict) -> tuple[str, dict]:
         return [
             value
             for label in raw_labels
-            if isinstance(label, dict)
-            and isinstance((value := label.get("val")), str)
+            if isinstance(label, dict) and isinstance((value := label.get("val")), str)
         ]
 
     moderation = {
@@ -185,12 +186,14 @@ async def get_cached_hydrated_posts(
     db: AsyncClient, at_uris: list[str]
 ) -> tuple[dict[str, dict], list[str]]:
     """Check the hydration cache.  Returns ``(cached_posts, missing_uris)``."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     cached: dict[str, dict] = {}
     missing: list[str] = []
 
     uri_to_rkey = {uri: _post_rkey(uri) for uri in at_uris}
-    refs = [db.collection(HYDRATED_POSTS_COLLECTION).document(rkey) for rkey in uri_to_rkey.values()]
+    refs = [
+        db.collection(HYDRATED_POSTS_COLLECTION).document(rkey) for rkey in uri_to_rkey.values()
+    ]
 
     try:
         docs = [doc async for doc in db.get_all(refs)]
@@ -221,15 +224,18 @@ async def cache_hydrated_posts(db: AsyncClient, posts: dict[str, dict]) -> None:
 
     Failures are logged but not surfaced — the cache is a best-effort optimisation.
     """
-    expires = datetime.now(timezone.utc) + timedelta(hours=HYDRATION_CACHE_TTL_HOURS)
+    expires = datetime.now(UTC) + timedelta(hours=HYDRATION_CACHE_TTL_HOURS)
     batch = db.batch()
     for uri, data in posts.items():
         ref = db.collection(HYDRATED_POSTS_COLLECTION).document(_post_rkey(uri))
-        batch.set(ref, {
-            "data": data,
-            "expires_at": expires,
-            "version": HYDRATION_CACHE_VERSION,
-        })
+        batch.set(
+            ref,
+            {
+                "data": data,
+                "expires_at": expires,
+                "version": HYDRATION_CACHE_VERSION,
+            },
+        )
     try:
         await batch.commit()
     except Exception:

--- a/src/app/lib/post_hydration_test.py
+++ b/src/app/lib/post_hydration_test.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-
-async def _async_iter(items):
-    for item in items:
-        yield item
-
 
 from .post_hydration import (
     _empty_hydration,
@@ -22,6 +17,11 @@ from .post_hydration import (
     get_cached_hydrated_posts,
     hydrate_posts,
 )
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ def test_parse_basic_post():
     assert data["author"]["display_name"] == "Alice Chen"
     assert data["author"]["avatar_url"] == "https://cdn.bsky.app/img/avatar.jpg"
     assert data["content"] == "Hello world"
-    assert data["created_at"] == datetime(2026, 7, 12, 10, 0, tzinfo=timezone.utc)
+    assert data["created_at"] == datetime(2026, 7, 12, 10, 0, tzinfo=UTC)
     assert data["engagement"]["reply_count"] == 3
     assert data["engagement"]["repost_count"] == 12
     assert data["engagement"]["like_count"] == 47
@@ -159,23 +159,25 @@ def test_parse_post_with_video():
 
 
 def test_parse_post_missing_author():
-    uri, data = _parse_bsky_post({"uri": "at://a/app.bsky.feed.post/p1", "record": {}, "author": {}})
+    uri, data = _parse_bsky_post(
+        {"uri": "at://a/app.bsky.feed.post/p1", "record": {}, "author": {}}
+    )
     assert data["author"]["handle"] is None
     assert data["author"]["display_name"] is None
     assert data["author"]["avatar_url"] is None
 
 
 def test_parse_post_missing_engagement():
-    uri, data = _parse_bsky_post({"uri": "at://a/app.bsky.feed.post/p1", "record": {}, "author": {}})
+    uri, data = _parse_bsky_post(
+        {"uri": "at://a/app.bsky.feed.post/p1", "record": {}, "author": {}}
+    )
     assert data["engagement"]["reply_count"] == 0
     assert data["engagement"]["repost_count"] == 0
     assert data["engagement"]["like_count"] == 0
 
 
 def test_parse_post_invalid_created_at():
-    uri, data = _parse_bsky_post(
-        _post(record={"text": "x", "createdAt": "not-a-date"})
-    )
+    uri, data = _parse_bsky_post(_post(record={"text": "x", "createdAt": "not-a-date"}))
     assert data["created_at"] is None
 
 
@@ -202,9 +204,7 @@ def test_empty_hydration_has_all_keys():
 @pytest.mark.asyncio
 async def test_fetch_posts_batch_returns_posts():
     mock_resp = MagicMock()
-    mock_resp.json.return_value = {
-        "posts": [_post(record={"text": "fetched post"})]
-    }
+    mock_resp.json.return_value = {"posts": [_post(record={"text": "fetched post"})]}
 
     with patch("app.lib.post_hydration.get_http_client") as mock_client:
         mock_client.return_value.get = AsyncMock(return_value=mock_resp)
@@ -241,6 +241,7 @@ async def test_fetch_posts_batch_timeout_returns_empty():
 @pytest.mark.asyncio
 async def test_get_cached_hydrated_posts_hit():
     from .post_hydration import _post_rkey
+
     db = MagicMock()
     uri = "at://a/app.bsky.feed.post/p1"
     mock_doc = MagicMock()
@@ -248,7 +249,7 @@ async def test_get_cached_hydrated_posts_hit():
     mock_doc.id = _post_rkey(uri)
     mock_doc.to_dict.return_value = {
         "data": {"author": {"handle": "cached.bsky.social"}},
-        "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc),
+        "expires_at": datetime(2099, 1, 1, tzinfo=UTC),
         "version": 2,
     }
     db.get_all = MagicMock(return_value=_async_iter([mock_doc]))
@@ -262,6 +263,7 @@ async def test_get_cached_hydrated_posts_hit():
 @pytest.mark.asyncio
 async def test_get_cached_hydrated_posts_expired():
     from .post_hydration import _post_rkey
+
     db = MagicMock()
     uri = "at://a/app.bsky.feed.post/p1"
     mock_doc = MagicMock()
@@ -269,7 +271,7 @@ async def test_get_cached_hydrated_posts_expired():
     mock_doc.id = _post_rkey(uri)
     mock_doc.to_dict.return_value = {
         "data": {"author": {"handle": "stale.bsky.social"}},
-        "expires_at": datetime(2000, 1, 1, tzinfo=timezone.utc),
+        "expires_at": datetime(2000, 1, 1, tzinfo=UTC),
         "version": 2,
     }
     db.get_all = MagicMock(return_value=_async_iter([mock_doc]))
@@ -282,6 +284,7 @@ async def test_get_cached_hydrated_posts_expired():
 @pytest.mark.asyncio
 async def test_get_cached_hydrated_posts_reloads_legacy_shape_without_moderation():
     from .post_hydration import _post_rkey
+
     db = MagicMock()
     uri = "at://a/app.bsky.feed.post/p1"
     mock_doc = MagicMock()
@@ -289,7 +292,7 @@ async def test_get_cached_hydrated_posts_reloads_legacy_shape_without_moderation
     mock_doc.id = _post_rkey(uri)
     mock_doc.to_dict.return_value = {
         "data": {"author": {"handle": "legacy.bsky.social"}},
-        "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc),
+        "expires_at": datetime(2099, 1, 1, tzinfo=UTC),
     }
     db.get_all = MagicMock(return_value=_async_iter([mock_doc]))
 
@@ -302,6 +305,7 @@ async def test_get_cached_hydrated_posts_reloads_legacy_shape_without_moderation
 @pytest.mark.asyncio
 async def test_get_cached_hydrated_posts_miss():
     from .post_hydration import _post_rkey
+
     db = MagicMock()
     uri = "at://a/app.bsky.feed.post/p1"
     mock_doc = MagicMock()
@@ -328,7 +332,9 @@ async def test_cache_hydrated_posts_writes():
 @pytest.mark.asyncio
 async def test_cache_hydrated_posts_catches_errors():
     db = MagicMock()
-    db.collection.return_value.document.return_value.set = AsyncMock(side_effect=RuntimeError("fail"))
+    db.collection.return_value.document.return_value.set = AsyncMock(
+        side_effect=RuntimeError("fail")
+    )
 
     # Should not raise.
     await cache_hydrated_posts(db, {"at://a/app.bsky.feed.post/p1": {"author": {}}})
@@ -349,6 +355,7 @@ async def test_hydrate_posts_empty_list():
 @pytest.mark.asyncio
 async def test_hydrate_posts_all_cached():
     from .post_hydration import _post_rkey
+
     db = MagicMock()
     uri = "at://a/app.bsky.feed.post/p1"
     mock_doc = MagicMock()
@@ -356,7 +363,7 @@ async def test_hydrate_posts_all_cached():
     mock_doc.id = _post_rkey(uri)
     mock_doc.to_dict.return_value = {
         "data": {"author": {"handle": "cached.bsky.social"}, "content": "cached content"},
-        "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc),
+        "expires_at": datetime(2099, 1, 1, tzinfo=UTC),
         "version": 2,
     }
     db.get_all = MagicMock(return_value=_async_iter([mock_doc]))
@@ -382,4 +389,7 @@ async def test_hydrate_posts_miss_fetches_and_caches():
         result = await hydrate_posts(db, ["at://did:plc:author/app.bsky.feed.post/post1"])
 
     assert result["at://did:plc:author/app.bsky.feed.post/post1"]["content"] == "Hello world"
-    assert result["at://did:plc:author/app.bsky.feed.post/post1"]["author"]["handle"] == "alice.bsky.social"
+    assert (
+        result["at://did:plc:author/app.bsky.feed.post/post1"]["author"]["handle"]
+        == "alice.bsky.social"
+    )

--- a/src/app/lib/profiling.py
+++ b/src/app/lib/profiling.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -59,7 +59,7 @@ def install_profiling(app: FastAPI) -> None:
             profiler.stop()
 
         rid = get_request_id() or "no-rid"
-        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
         filename = f"{ts}-{rid}-{_path_slug(request.url.path)}.html"
         output_path = profile_dir / filename
         try:

--- a/src/app/lib/rankers/__init__.py
+++ b/src/app/lib/rankers/__init__.py
@@ -14,14 +14,14 @@ from .base import (
     list_rankers,
     register_ranker,
 )
+from .candidate_score import CandidateScoreRanker
+from .heavy_ranker import HeavyRanker
+from .perspective import PerspectiveRanker
 from .predict import (
     RankModelNotFoundError,
     run_predict,
 )
-from .candidate_score import CandidateScoreRanker
-from .perspective import PerspectiveRanker
 from .two_tower import TwoTowerRanker
-from .heavy_ranker import HeavyRanker
 
 _candidate_score = CandidateScoreRanker()
 register_ranker(_candidate_score)

--- a/src/app/lib/rankers/base.py
+++ b/src/app/lib/rankers/base.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
-from ...models import RankPredictResult, CandidatePost
+from ...models import CandidatePost, RankPredictResult
 
 
 class RankerResult(BaseModel):
@@ -52,12 +52,7 @@ class Ranker(ABC):
         ...
 
     @abstractmethod
-    async def predict(
-        self, 
-        es,
-        user_did: str,
-        candidates: list[CandidatePost]
-    ) -> RankerResult:
+    async def predict(self, es, user_did: str, candidates: list[CandidatePost]) -> RankerResult:
         """Rank the supplied candidates."""
         ...
 

--- a/src/app/lib/rankers/candidate_score.py
+++ b/src/app/lib/rankers/candidate_score.py
@@ -4,7 +4,7 @@ Ranks candidates using their existing `score` field. This is a temporary
 fallback until inference-service-backed ranking is wired in.
 """
 
-from ...models import RankedCandidate, CandidatePost, RankPredictResult
+from ...models import CandidatePost, RankedCandidate, RankPredictResult
 from .base import Ranker, RankerResult
 
 
@@ -19,12 +19,7 @@ class CandidateScoreRanker(Ranker):
     def score_bounds(self) -> tuple[float, float]:
         return (0.0, 1.0)
 
-    async def predict(
-        self, 
-        es,
-        user_did: str,
-        candidates: list[CandidatePost]
-    ) -> RankerResult:
+    async def predict(self, es, user_did: str, candidates: list[CandidatePost]) -> RankerResult:
         ranked_candidates = sorted(
             enumerate(candidates),
             key=lambda item: (

--- a/src/app/lib/rankers/heavy_ranker.py
+++ b/src/app/lib/rankers/heavy_ranker.py
@@ -1,22 +1,21 @@
-"""Heavy ranker model.
-"""
+"""Heavy ranker model."""
 
 import asyncio
 import logging
 
-from ...models import RankedCandidate, CandidatePost, RankPredictResult
-from .base import Ranker, RankerResult
+from ...models import CandidatePost, RankedCandidate, RankPredictResult
 from ..elasticsearch import (
     fetch_post_embeddings_and_metadata,
     fetch_recent_liked_post_uris_and_times,
 )
 from ..embeddings import decode_float32_b64
-from ..telemetry import timed
+from ..feed_debug import current_recorder
 from ..inference import (
     get_inference_settings,
     predict_heavy_ranker_single_user,
 )
-from ..feed_debug import current_recorder
+from ..telemetry import timed
+from .base import Ranker, RankerResult
 from .utils import get_rank_predict_results_from_candidates_and_scores
 
 logger = logging.getLogger(__name__)
@@ -34,15 +33,8 @@ class HeavyRanker(Ranker):
     def score_bounds(self) -> tuple[float, float]:
         return (0.0, 1.0)
 
-    async def predict(
-        self,
-        es,
-        user_did: str,
-        candidates: list[CandidatePost]
-    ) -> RankerResult:
-        inference_base_url, inference_api_key = (
-            get_inference_settings()
-        )
+    async def predict(self, es, user_did: str, candidates: list[CandidatePost]) -> RankerResult:
+        inference_base_url, inference_api_key = get_inference_settings()
 
         async def _get_user_features() -> tuple[list[list[float]], list[str], list[str], list[int]]:
             async with timed(logger, "ranker_get_user_features", user_did=user_did):
@@ -50,7 +42,10 @@ class HeavyRanker(Ranker):
                 history_author_dids: list[str] = []
                 filtered_history_liked_at_times: list[str] = []
                 history_like_counts: list[int] = []
-                user_history_liked_uris, history_liked_at_times = await fetch_recent_liked_post_uris_and_times(es, user_did)
+                (
+                    user_history_liked_uris,
+                    history_liked_at_times,
+                ) = await fetch_recent_liked_post_uris_and_times(es, user_did)
 
                 rec = current_recorder()
 
@@ -59,12 +54,17 @@ class HeavyRanker(Ranker):
                     if rec is not None:
                         rec.record_user_features(HEAVY_RANKER_MODEL_NAME, [], 0)
                 else:
-                    user_history_hydrated_posts: list[tuple[str, list[float], str, int]] = await fetch_post_embeddings_and_metadata(
-                        es, user_history_liked_uris,
+                    user_history_hydrated_posts: list[
+                        tuple[str, list[float], str, int]
+                    ] = await fetch_post_embeddings_and_metadata(
+                        es,
+                        user_history_liked_uris,
                     )
                     if rec is not None:
                         rec.record_user_features(
-                            HEAVY_RANKER_MODEL_NAME, user_history_liked_uris, len(user_history_hydrated_posts)
+                            HEAVY_RANKER_MODEL_NAME,
+                            user_history_liked_uris,
+                            len(user_history_hydrated_posts),
                         )
                     if not user_history_hydrated_posts:
                         logger.info(
@@ -73,19 +73,34 @@ class HeavyRanker(Ranker):
                             user_did,
                         )
                     else:
-                        user_history_vectors = [embedding for _, embedding, _, _ in user_history_hydrated_posts]
-                        history_author_dids = [author_did for _, _, author_did, _ in user_history_hydrated_posts]
-                        history_like_counts = [like_count for _, _, _, like_count in user_history_hydrated_posts]
-                        filtered_history_uris = [uri for uri, _, _, _ in user_history_hydrated_posts]
+                        user_history_vectors = [
+                            embedding for _, embedding, _, _ in user_history_hydrated_posts
+                        ]
+                        history_author_dids = [
+                            author_did for _, _, author_did, _ in user_history_hydrated_posts
+                        ]
+                        history_like_counts = [
+                            like_count for _, _, _, like_count in user_history_hydrated_posts
+                        ]
+                        filtered_history_uris = [
+                            uri for uri, _, _, _ in user_history_hydrated_posts
+                        ]
                         filtered_history_liked_at_times = [
                             liked_at_time
-                            for uri, liked_at_time in zip(user_history_liked_uris, history_liked_at_times)
+                            for uri, liked_at_time in zip(
+                                user_history_liked_uris, history_liked_at_times, strict=False
+                            )
                             if uri in filtered_history_uris
                         ]
 
-                return user_history_vectors, history_author_dids, filtered_history_liked_at_times, history_like_counts
-        # end _get_user_features()
+                return (
+                    user_history_vectors,
+                    history_author_dids,
+                    filtered_history_liked_at_times,
+                    history_like_counts,
+                )
 
+        # end _get_user_features()
 
         async def _get_candidate_features() -> (
             tuple[list[CandidatePost], list[list[float]], list[str], list[int]] | None
@@ -93,21 +108,26 @@ class HeavyRanker(Ranker):
             async with timed(
                 logger, "ranker_get_candidate_features", n_candidates=len(candidates_by_uri)
             ):
-                # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+                # Use embeddings already carried on CandidatePost when available
+                # (avoids an ES round-trip).
                 uris_and_metadata: list[tuple[str, list[float], str, int]] = []
                 missing_uris: list[str] = []
                 for uri, candidate in candidates_by_uri.items():
                     if candidate.minilm_l12_embedding and candidate.author_did:
                         try:
                             vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                            uris_and_metadata.append((uri, vec, candidate.author_did, candidate.like_count or 0))
+                            uris_and_metadata.append(
+                                (uri, vec, candidate.author_did, candidate.like_count or 0)
+                            )
                             continue
                         except Exception:
                             pass
                     missing_uris.append(uri)
 
                 if missing_uris:
-                    fetched = await fetch_post_embeddings_and_metadata(es, missing_uris, index="posts_recent")
+                    fetched = await fetch_post_embeddings_and_metadata(
+                        es, missing_uris, index="posts_recent"
+                    )
                     uris_and_metadata.extend(fetched)
 
                 if not uris_and_metadata:
@@ -118,27 +138,25 @@ class HeavyRanker(Ranker):
                     for at_uri, _, _, _ in uris_and_metadata
                     if at_uri in candidates_by_uri
                 ]
-                input_post_embeddings = [
-                    embedding for _, embedding, _, _ in uris_and_metadata
-                ]
-                author_dids = [
-                    author_did for _, _, author_did, _ in uris_and_metadata
-                ]
-                like_counts = [
-                    like_count for _, _, _, like_count in uris_and_metadata
-                ]
+                input_post_embeddings = [embedding for _, embedding, _, _ in uris_and_metadata]
+                author_dids = [author_did for _, _, author_did, _ in uris_and_metadata]
+                like_counts = [like_count for _, _, _, like_count in uris_and_metadata]
                 return candidates_with_embeddings, input_post_embeddings, author_dids, like_counts
+
         # end _get_candidate_features()
 
-
-        candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
+        candidates_by_uri = {
+            candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None
+        }
 
         user_features, candidate_features = await asyncio.gather(
             _get_user_features(),
             _get_candidate_features(),
         )
 
-        history_embeddings, history_author_dids, history_liked_at_times, history_like_counts = user_features
+        history_embeddings, history_author_dids, history_liked_at_times, history_like_counts = (
+            user_features
+        )
 
         def _return_empty_ranker_result(msg: str):
             logger.info(msg)
@@ -155,9 +173,12 @@ class HeavyRanker(Ranker):
 
         if candidate_features is None:
             return _return_empty_ranker_result(
-                f"No valid features found for any of {len(candidates_by_uri)} candidate posts of user {user_did}"
+                f"No valid features found for any of {len(candidates_by_uri)} "
+                f"candidate posts of user {user_did}"
             )
-        candidate_posts, candidate_post_embeddings, candidate_author_dids, candidate_like_counts = candidate_features
+        candidate_posts, candidate_post_embeddings, candidate_author_dids, candidate_like_counts = (
+            candidate_features
+        )
 
         ranker_outputs = await predict_heavy_ranker_single_user(
             history_embeddings,
@@ -168,22 +189,22 @@ class HeavyRanker(Ranker):
             candidate_author_dids,
             candidate_like_counts,
             base_url=inference_base_url,
-            api_key=inference_api_key
+            api_key=inference_api_key,
         )
 
         if not ranker_outputs:
             return _return_empty_ranker_result(
-                f"No ranker outputs for any of {len(candidates_by_uri)} candidate posts of user {user_did}"
+                f"No ranker outputs for any of {len(candidates_by_uri)} "
+                f"candidate posts of user {user_did}"
             )
         if len(ranker_outputs) != len(candidate_posts):
             return _return_empty_ranker_result(
-                f"Heavy ranker returned {len(ranker_outputs)} results but {len(candidate_posts)} were requested."
+                f"Heavy ranker returned {len(ranker_outputs)} results but "
+                f"{len(candidate_posts)} were requested."
             )
 
         result = get_rank_predict_results_from_candidates_and_scores(
-            candidate_posts,
-            ranker_outputs,
-            candidates_by_uri.values()
+            candidate_posts, ranker_outputs, candidates_by_uri.values()
         )
 
         return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/heavy_ranker_test.py
+++ b/src/app/lib/rankers/heavy_ranker_test.py
@@ -1,7 +1,7 @@
 """Tests for the heavy ranker."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -12,7 +12,7 @@ from .heavy_ranker import HeavyRanker
 
 
 def _time(hour: int) -> datetime:
-    return datetime(2026, 1, 1, hour, tzinfo=timezone.utc)
+    return datetime(2026, 1, 1, hour, tzinfo=UTC)
 
 
 def test_score_bounds_match_inference_service_output_range():

--- a/src/app/lib/rankers/perspective_test.py
+++ b/src/app/lib/rankers/perspective_test.py
@@ -34,7 +34,11 @@ class TestPerspectiveRanker:
             new_callable=AsyncMock,
             return_value=scores,
         ):
-            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+            result = asyncio.run(
+                PerspectiveRanker().predict(
+                    es=object(), user_did="did:plc:user1", candidates=candidates
+                )
+            )
 
         rankings = result.result.rankings
         assert [r.at_uri for r in rankings] == ["at://a/3", "at://a/2", "at://a/1"]
@@ -49,7 +53,11 @@ class TestPerspectiveRanker:
             new_callable=AsyncMock,
             return_value={"at://a/1": 0.42},
         ):
-            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+            result = asyncio.run(
+                PerspectiveRanker().predict(
+                    es=object(), user_did="did:plc:user1", candidates=candidates
+                )
+            )
 
         assert result.result.rankings[0].rank_score == 0.42
 
@@ -63,7 +71,11 @@ class TestPerspectiveRanker:
             new_callable=AsyncMock,
             return_value={"at://a/1": 0.5},
         ) as mock_score:
-            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+            result = asyncio.run(
+                PerspectiveRanker().predict(
+                    es=object(), user_did="did:plc:user1", candidates=candidates
+                )
+            )
 
         # score_candidates is only called with candidates that have an at_uri
         (scored_candidates,), _ = mock_score.call_args
@@ -80,7 +92,11 @@ class TestPerspectiveRanker:
             new_callable=AsyncMock,
             return_value={"at://a/1": 0.5},  # at://a/2 missing -> None
         ):
-            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+            result = asyncio.run(
+                PerspectiveRanker().predict(
+                    es=object(), user_did="did:plc:user1", candidates=candidates
+                )
+            )
 
         by_uri = {r.at_uri: r.rank_score for r in result.result.rankings}
         assert by_uri == {"at://a/1": 0.5, "at://a/2": None}
@@ -102,7 +118,11 @@ class TestPerspectiveRanker:
                 "at://a/high": 0.85,
             },
         ):
-            result = asyncio.run(PerspectiveRanker().predict(es=object(), user_did="did:plc:user1", candidates=candidates))
+            result = asyncio.run(
+                PerspectiveRanker().predict(
+                    es=object(), user_did="did:plc:user1", candidates=candidates
+                )
+            )
 
         assert [(r.at_uri, r.rank, r.rank_score) for r in result.result.rankings] == [
             ("at://a/high", 1, 0.85),

--- a/src/app/lib/rankers/predict.py
+++ b/src/app/lib/rankers/predict.py
@@ -13,16 +13,14 @@ import statistics
 
 from ...models import RankedCandidate, RankPredictRequest, RankPredictResult
 from ..feed_debug import current_recorder
+from ..metrics import get_metric_collector
 from ..telemetry import timed
 from .base import Ranker, RankerError, RankerExecutionError, RankerResult, get_ranker
-from ..metrics import get_metric_collector
 
 logger = logging.getLogger(__name__)
 
 try:
-    _RANK_MODEL_TIMEOUT_SEC: float = float(
-        os.environ.get("GE_RANK_MODEL_TIMEOUT_SEC", "2.5")
-    )
+    _RANK_MODEL_TIMEOUT_SEC: float = float(os.environ.get("GE_RANK_MODEL_TIMEOUT_SEC", "2.5"))
 except ValueError:
     _RANK_MODEL_TIMEOUT_SEC = 2.5
 
@@ -80,9 +78,7 @@ async def _run_one(
     except RankerExecutionError:
         raise
     except TimeoutError:
-        logger.warning(
-            "Ranker '%s' timed out after %.1fs", name, _RANK_MODEL_TIMEOUT_SEC
-        )
+        logger.warning("Ranker '%s' timed out after %.1fs", name, _RANK_MODEL_TIMEOUT_SEC)
         raise
     except Exception as exc:
         logger.exception("Ranker '%s' failed", name)
@@ -132,8 +128,8 @@ async def run_predict(
     # loop through results once to calculate medians and get scores per candidate
     medians_by_model: dict[str, float] = {}  # {model_name: median_score}
     results_by_candidate: dict[str, dict[str, float]] = {}  # {uri: {model_name: score}}
-    models_with_valid_results: list[tuple[str, float, Ranker]] = [] # filtered version of resolved
-    for (name, weight, ranker), result in zip(resolved, results):
+    models_with_valid_results: list[tuple[str, float, Ranker]] = []  # filtered version of resolved
+    for (name, weight, ranker), result in zip(resolved, results, strict=False):
         if isinstance(result, BaseException):
             # A model that timed out contributes no scores, same as one that
             # returned zero valid rankings. Any other error still propagates.
@@ -204,13 +200,15 @@ async def run_predict(
         )
 
     candidates_with_scores_initial_order = [
-        (initial_idx, uri, _combined(uri))
-        for initial_idx, uri in enumerate(valid_candidate_uris)
+        (initial_idx, uri, _combined(uri)) for initial_idx, uri in enumerate(valid_candidate_uris)
     ]
-    ranked = enumerate(sorted(
-        candidates_with_scores_initial_order,
-        key=lambda item: (-item[2], item[0]),
-    ), start=1)
+    ranked = enumerate(
+        sorted(
+            candidates_with_scores_initial_order,
+            key=lambda item: (-item[2], item[0]),
+        ),
+        start=1,
+    )
 
     rankings: list[RankedCandidate] = []
     for rank_idx, (_, at_uri, score) in ranked:

--- a/src/app/lib/rankers/two_tower.py
+++ b/src/app/lib/rankers/two_tower.py
@@ -8,20 +8,19 @@ Performs vector-matrix multiplication to get scores for each post, and returns t
 import asyncio
 import logging
 
-from ...models import RankedCandidate, CandidatePost, RankPredictResult
-from .base import Ranker, RankerExecutionError, RankerResult
+from ...models import CandidatePost, RankedCandidate, RankPredictResult
 from ..elasticsearch import fetch_post_embeddings_and_metadata
 from ..embeddings import decode_float32_b64
 from ..http_client import get_http_client
-from ..telemetry import timed
 from ..inference import (
-    get_inference_settings,
     build_inference_headers,
-    raise_inference_response_error,
     compute_user_embedding,
+    get_inference_settings,
+    raise_inference_response_error,
 )
+from ..telemetry import timed
+from .base import Ranker, RankerExecutionError, RankerResult
 from .utils import get_rank_predict_results_from_candidates_and_scores
-
 
 logger = logging.getLogger(__name__)
 TWO_TOWER_MODEL_NAME = "two_tower"
@@ -43,10 +42,11 @@ async def predict_post_tower_batch(
     if len(post_embeddings) != len(author_dids):
         raise RankerExecutionError(
             TWO_TOWER_MODEL_NAME,
-            f"number of post embeddings {len(post_embeddings)} does not match number of author DIDs {len(author_dids)}",
+            f"number of post embeddings {len(post_embeddings)} does not match "
+            f"number of author DIDs {len(author_dids)}",
         )
 
-    embeddings_and_authors = list(zip(post_embeddings, author_dids))
+    embeddings_and_authors = list(zip(post_embeddings, author_dids, strict=False))
     chunks = [
         embeddings_and_authors[i : i + POST_TOWER_BATCH_SIZE]
         for i in range(0, len(post_embeddings), POST_TOWER_BATCH_SIZE)
@@ -56,10 +56,10 @@ async def predict_post_tower_batch(
 
     async def _call_chunk(chunk: list[tuple[list[float], str]]) -> list[list[float]]:
         resp = await client.post(
-            url, 
+            url,
             json={
                 "post_embeddings": [emb for emb, _ in chunk],
-                "target_author_dids": [author_did for _, author_did in chunk]
+                "target_author_dids": [author_did for _, author_did in chunk],
             },
             headers=headers,
         )
@@ -72,9 +72,7 @@ async def predict_post_tower_batch(
             raise_inference_response_error("post-tower", resp.status_code, resp.text)
         return resp.json()["outputs"]
 
-    async with timed(
-        logger, "post_tower_http", n_posts=len(post_embeddings), n_chunks=len(chunks)
-    ):
+    async with timed(logger, "post_tower_http", n_posts=len(post_embeddings), n_chunks=len(chunks)):
         chunk_outputs = await asyncio.gather(*(_call_chunk(c) for c in chunks))
     return [item for chunk_out in chunk_outputs for item in chunk_out]
 
@@ -88,45 +86,43 @@ class TwoTowerRanker(Ranker):
 
     @property
     def score_bounds(self) -> tuple[float, float]:
-        # User tower and post tower each L2-normalize the output embeddings 
-        # (they sum to 1), so the dot product is in the range [-1,1]. 
+        # User tower and post tower each L2-normalize the output embeddings
+        # (they sum to 1), so the dot product is in the range [-1,1].
         # Said another way, the two tower performs cosine similarity.
         return (-1.0, 1.0)
 
-    async def predict(
-        self,
-        es,
-        user_did: str,
-        candidates: list[CandidatePost]
-    ) -> RankerResult:
-        inference_base_url, inference_api_key = (
-            get_inference_settings()
-        )
+    async def predict(self, es, user_did: str, candidates: list[CandidatePost]) -> RankerResult:
+        inference_base_url, inference_api_key = get_inference_settings()
 
         valid_candidates = [candidate for candidate in candidates if candidate.at_uri is not None]
-        candidates_by_uri = {candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None}
+        candidates_by_uri = {
+            candidate.at_uri: candidate for candidate in candidates if candidate.at_uri is not None
+        }
 
         async def _compute_candidate_post_embeddings() -> (
             tuple[list[CandidatePost], list[list[float]]] | None
         ):
-            async with timed(
-                logger, "two_tower_post_side", n_candidates=len(candidates_by_uri)
-            ):
-                # Use embeddings already carried on CandidatePost when available (avoids an ES round-trip).
+            async with timed(logger, "two_tower_post_side", n_candidates=len(candidates_by_uri)):
+                # Use embeddings already carried on CandidatePost when available
+                # (avoids an ES round-trip).
                 uris_and_metadata: list[tuple[str, list[float], str, int]] = []
                 missing_uris: list[str] = []
                 for uri, candidate in candidates_by_uri.items():
                     if candidate.minilm_l12_embedding and candidate.author_did:
                         try:
                             vec = decode_float32_b64(candidate.minilm_l12_embedding)
-                            uris_and_metadata.append((uri, vec, candidate.author_did, candidate.like_count or 0))
+                            uris_and_metadata.append(
+                                (uri, vec, candidate.author_did, candidate.like_count or 0)
+                            )
                             continue
                         except Exception:
                             pass
                     missing_uris.append(uri)
 
                 if missing_uris:
-                    fetched = await fetch_post_embeddings_and_metadata(es, missing_uris, index="posts_recent")
+                    fetched = await fetch_post_embeddings_and_metadata(
+                        es, missing_uris, index="posts_recent"
+                    )
                     uris_and_metadata.extend(fetched)
 
                 if not uris_and_metadata:
@@ -137,12 +133,8 @@ class TwoTowerRanker(Ranker):
                     for at_uri, _, _, _ in uris_and_metadata
                     if at_uri in candidates_by_uri
                 ]
-                input_post_embeddings = [
-                    embedding for _, embedding, _, _ in uris_and_metadata
-                ]
-                author_dids = [
-                    author_did for _, _, author_did, _ in uris_and_metadata
-                ]
+                input_post_embeddings = [embedding for _, embedding, _, _ in uris_and_metadata]
+                author_dids = [author_did for _, _, author_did, _ in uris_and_metadata]
 
                 output_post_embeddings = await predict_post_tower_batch(
                     input_post_embeddings,
@@ -159,11 +151,7 @@ class TwoTowerRanker(Ranker):
 
         output_user_embedding, candidate_result = await asyncio.gather(
             compute_user_embedding(
-                user_did,
-                es,
-                inference_base_url,
-                inference_api_key,
-                TWO_TOWER_MODEL_NAME
+                user_did, es, inference_base_url, inference_api_key, TWO_TOWER_MODEL_NAME
             ),
             _compute_candidate_post_embeddings(),
         )
@@ -187,19 +175,21 @@ class TwoTowerRanker(Ranker):
 
         ranked_candidates_input, output_post_embeddings = candidate_result
 
-        # For each candidate post, take the dot product of its output embedding with the user output embedding
+        # For each candidate post, take the dot product of its output embedding
+        # with the user output embedding
         final_scores = []
         for post_embedding in output_post_embeddings:
             if len(post_embedding) != len(output_user_embedding):
                 raise RankerExecutionError(
                     self.name,
-                    f"embedding dimension mismatch: post={len(post_embedding)} user={len(output_user_embedding)}",
+                    f"embedding dimension mismatch: post={len(post_embedding)} "
+                    f"user={len(output_user_embedding)}",
                 )
-            final_scores.append(sum([ u*p for u,p in zip(post_embedding, output_user_embedding)]))
+            final_scores.append(
+                sum(u * p for u, p in zip(post_embedding, output_user_embedding, strict=False))
+            )
 
         result = get_rank_predict_results_from_candidates_and_scores(
-            ranked_candidates_input,
-            final_scores,
-            valid_candidates
+            ranked_candidates_input, final_scores, valid_candidates
         )
         return RankerResult(model=self.name, result=result)

--- a/src/app/lib/rankers/two_tower_test.py
+++ b/src/app/lib/rankers/two_tower_test.py
@@ -5,10 +5,9 @@ import asyncio
 import pytest
 
 from ...models import CandidatePost
-from . import two_tower as two_tower_module
-from .. import inference as inference_module
 from .. import elasticsearch as elasticsearch_module
-from .base import RankerExecutionError
+from .. import inference as inference_module
+from . import two_tower as two_tower_module
 from .two_tower import TwoTowerRanker
 
 
@@ -52,10 +51,20 @@ def test_predict_keeps_candidate_uris_aligned_with_embeddings(monkeypatch):
             ("at://post/a", [1.0, 0.0], "did:plc:a", 1),
         ]
 
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
-    monkeypatch.setattr(inference_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
 
-    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+    async def fake_predict_user_tower_single(
+        history_embeddings, history_author_dids, *, base_url, api_key
+    ):
         assert history_embeddings == [[0.5, 0.5]]
         assert history_author_dids == ["did:plc:liked"]
         return [[1.0, 0.0]]
@@ -106,7 +115,9 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
         seen.setdefault("fetch_post_embeddings_calls", []).append(at_uris)
         return [("at://post/a", [2.0, 0.0], "did:plc:a", 1)]
 
-    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+    async def fake_predict_user_tower_single(
+        history_embeddings, history_author_dids, *, base_url, api_key
+    ):
         seen["history_embeddings"] = history_embeddings
         seen["history_author_dids"] = history_author_dids
         return [[1.0, 0.0]]
@@ -125,8 +136,16 @@ def test_predict_calls_user_tower_with_empty_history_when_user_has_no_likes(monk
         "fetch_recent_liked_post_uris_and_times",
         fake_fetch_recent_liked_post_uris_and_times,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
-    monkeypatch.setattr(inference_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
     monkeypatch.setattr(
         inference_module,
         "predict_user_tower_single",
@@ -167,7 +186,9 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
             return []
         return [("at://post/a", [2.0, 0.0], "did:plc:a", 1)]
 
-    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+    async def fake_predict_user_tower_single(
+        history_embeddings, history_author_dids, *, base_url, api_key
+    ):
         seen["history_embeddings"] = history_embeddings
         seen["history_author_dids"] = history_author_dids
         return [[1.0, 0.0]]
@@ -186,8 +207,16 @@ def test_predict_calls_user_tower_with_empty_history_when_likes_have_no_embeddin
         "fetch_recent_liked_post_uris_and_times",
         fake_fetch_recent_liked_post_uris_and_times,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
-    monkeypatch.setattr(inference_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
     monkeypatch.setattr(
         inference_module,
         "predict_user_tower_single",
@@ -227,7 +256,9 @@ def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missi
     async def fake_fetch_post_embeddings_and_metadata(es, at_uris, index=None):
         return []
 
-    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+    async def fake_predict_user_tower_single(
+        history_embeddings, history_author_dids, *, base_url, api_key
+    ):
         assert history_author_dids == []
         return [[1.0, 0.0]]
 
@@ -244,7 +275,11 @@ def test_predict_returns_unscored_candidates_when_candidate_embeddings_are_missi
         "fetch_recent_liked_post_uris_and_times",
         fake_fetch_recent_liked_post_uris_and_times,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
     monkeypatch.setattr(
         inference_module,
         "predict_user_tower_single",
@@ -284,7 +319,9 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
             return [("at://liked/1", [0.5, 0.5], "did:plc:liked", 4)]
         return [("at://post/a", [1.0, 0.0], "did:plc:a", 1)]
 
-    async def fake_predict_user_tower_single(history_embeddings, history_author_dids, *, base_url, api_key):
+    async def fake_predict_user_tower_single(
+        history_embeddings, history_author_dids, *, base_url, api_key
+    ):
         assert history_author_dids == ["did:plc:liked"]
         return []
 
@@ -302,8 +339,16 @@ def test_predict_raises_when_user_tower_returns_wrong_number_of_embeddings(monke
         "fetch_recent_liked_post_uris_and_times",
         fake_fetch_recent_liked_post_uris_and_times,
     )
-    monkeypatch.setattr(two_tower_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
-    monkeypatch.setattr(inference_module, "fetch_post_embeddings_and_metadata", fake_fetch_post_embeddings_and_metadata)
+    monkeypatch.setattr(
+        two_tower_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "fetch_post_embeddings_and_metadata",
+        fake_fetch_post_embeddings_and_metadata,
+    )
     monkeypatch.setattr(
         inference_module,
         "predict_user_tower_single",

--- a/src/app/lib/rankers/utils.py
+++ b/src/app/lib/rankers/utils.py
@@ -4,14 +4,12 @@ from ...models import RankedCandidate, RankPredictResult
 
 
 def get_rank_predict_results_from_candidates_and_scores(
-    candidate_posts,
-    scores,
-    valid_candidates
+    candidate_posts, scores, valid_candidates
 ) -> RankPredictResult:
     # Rank by the final scores, breaking ties by original order in candidates list
-    candidates_with_scores = zip(candidate_posts, scores)
+    candidates_with_scores = zip(candidate_posts, scores, strict=False)
     ranked_candidates = sorted(
-        enumerate(candidates_with_scores), # (index, (candidate, score))
+        enumerate(candidates_with_scores),  # (index, (candidate, score))
         key=lambda item: (
             -(item[1][1] if item[1][1] is not None else float("-inf")),
             item[0],

--- a/src/app/lib/request_cache.py
+++ b/src/app/lib/request_cache.py
@@ -15,12 +15,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
-from typing import Any, Awaitable, Callable
+from typing import Any
 
-_current_cache: ContextVar["RequestCache | None"] = ContextVar(
-    "ge_request_cache", default=None
-)
+_current_cache: ContextVar[RequestCache | None] = ContextVar("ge_request_cache", default=None)
 
 
 class RequestCache:
@@ -35,9 +34,7 @@ class RequestCache:
         self._store: dict[Any, Any] = {}
         self._locks: dict[Any, asyncio.Lock] = {}
 
-    async def get_or_compute(
-        self, key: Any, factory: Callable[[], Awaitable[Any]]
-    ) -> Any:
+    async def get_or_compute(self, key: Any, factory: Callable[[], Awaitable[Any]]) -> Any:
         if key in self._store:
             return self._store[key]
         lock = self._locks.setdefault(key, asyncio.Lock())

--- a/src/app/lib/request_cache_test.py
+++ b/src/app/lib/request_cache_test.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 from .request_cache import (
     RequestCache,
     get_request_cache,

--- a/src/app/lib/telemetry.py
+++ b/src/app/lib/telemetry.py
@@ -84,6 +84,7 @@ async def timed(
 
         if record_metric:
             from .metrics import get_metric_collector
+
             collector = get_metric_collector()
             if collector is not None:
                 collector.record(label, elapsed_ms, **(metric_attrs or {}))

--- a/src/app/lib/telemetry_test.py
+++ b/src/app/lib/telemetry_test.py
@@ -1,6 +1,7 @@
 """Tests for telemetry.timed()."""
 
 import logging
+
 import pytest
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 
+
 def _is_deployed_environment() -> bool:
     """True when running in a deployed environment (stage/prod) rather than local dev or tests."""
     env = (os.environ.get("ENVIRONMENT") or os.environ.get("GE_ENVIRONMENT") or "").strip().lower()
@@ -37,16 +38,18 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 
-from .routers import candidates, diversify, feed_transparency, health, rank, skylight, xrpc
-from .security import RequireApiKey
+from elasticsearch import AsyncElasticsearch
+from starlette.routing import BaseRoute, Match
+from starlette.types import Scope
+
 from .lib.atproto_auth import init_id_resolver
-from .lib.firebase_auth import init_firebase_auth
 from .lib.es_client import SlowQueryLoggingES
 from .lib.feed_cache import FirestoreFeedCache
+from .lib.firebase_auth import init_firebase_auth
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
-from .lib.perspective import close_perspective_client
 from .lib.metrics import MetricCollector, set_metric_collector
+from .lib.perspective import close_perspective_client
 from .lib.posthog_client import get_posthog_client, init_posthog_client, set_posthog_client
 from .lib.profiling import install_profiling
 from .lib.request_context import (
@@ -55,10 +58,8 @@ from .lib.request_context import (
     set_endpoint,
     set_request_id,
 )
-
-from elasticsearch import AsyncElasticsearch
-from starlette.routing import BaseRoute, Match
-from starlette.types import Scope
+from .routers import candidates, diversify, feed_transparency, health, rank, skylight, xrpc
+from .security import RequireApiKey
 
 
 def _reject_dev_session_secret_in_deployment() -> None:

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -18,9 +18,7 @@ class FeedCursor(BaseModel):
 
     def encode(self) -> str:
         """Serialise to a URL-safe, opaque string."""
-        return base64.urlsafe_b64encode(
-            self.model_dump_json().encode()
-        ).decode()
+        return base64.urlsafe_b64encode(self.model_dump_json().encode()).decode()
 
     @classmethod
     def decode(cls, raw: str) -> "FeedCursor":
@@ -38,8 +36,7 @@ class FeedCursor(BaseModel):
 class CandidatePost(BaseModel):
     """A post returned by search or candidate generation."""
 
-    at_uri: str | None = Field(
-        default=None, description="The AT URI of the post (e.g. at://...)")
+    at_uri: str | None = Field(default=None, description="The AT URI of the post (e.g. at://...)")
     content: str | None = Field(default=None, description="The post text content")
     minilm_l12_embedding: str | None = Field(
         default=None, description="Base64-encoded float32 MiniLM L12 embedding (384-d)"
@@ -50,9 +47,7 @@ class CandidatePost(BaseModel):
     generator_name: str | None = Field(
         default=None, description="Name of the candidate generator that produced this post"
     )
-    author_did: str | None = Field(
-        default=None, description="AT Protocol DID of the post author"
-    )
+    author_did: str | None = Field(default=None, description="AT Protocol DID of the post author")
     author_username: str | None = Field(
         default=None,
         description="AT Protocol handle of the post author (resolved from author_did; "
@@ -61,9 +56,7 @@ class CandidatePost(BaseModel):
     contains_images: bool | None = Field(
         default=None, description="Whether the post embeds one or more images"
     )
-    contains_video: bool | None = Field(
-        default=None, description="Whether the post embeds video"
-    )
+    contains_video: bool | None = Field(default=None, description="Whether the post embeds video")
     image_count: int | None = Field(
         default=None, description="Number of images embedded in the post"
     )
@@ -256,6 +249,7 @@ class FeedConfig(BaseModel):
     )
     avatar: str | None = Field(
         None,
-        description="Path to avatar image relative to repo root (e.g. 'assets/icons/your-feed.png'). "
+        description="Path to avatar image relative to repo root "
+        "(e.g. 'assets/icons/your-feed.png'). "
         "Used by publish_feed.py at publish time; not read at runtime.",
     )

--- a/src/app/models_feed_transparency.py
+++ b/src/app/models_feed_transparency.py
@@ -16,7 +16,7 @@ class FeedSummary(BaseModel):
     generated_at: datetime
     feed_name: str
     applied_social_radius: int | None = None
-    generator_diagnostics: list["GeneratorDiagnosticView"] = Field(default_factory=list)
+    generator_diagnostics: list[GeneratorDiagnosticView] = Field(default_factory=list)
 
 
 class FeedListResponse(BaseModel):

--- a/src/app/routers/candidates.py
+++ b/src/app/routers/candidates.py
@@ -12,13 +12,13 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from ..models import CandidateGenerateRequest, CandidateGenerateResult
 from ..lib.candidates import (
     GeneratorError,
     GeneratorNotFoundError,
     list_generators,
     run_generate,
 )
+from ..models import CandidateGenerateRequest, CandidateGenerateResult
 from ..security import verify_api_key
 
 router = APIRouter(tags=["candidates"], dependencies=[Depends(verify_api_key)])
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Response models
 # ---------------------------------------------------------------------------
+
 
 class GeneratorListResponse(BaseModel):
     """Lists available generator names."""
@@ -42,6 +43,7 @@ class GeneratorListResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
 
 @router.get("/candidates/generators", response_model=GeneratorListResponse)
 async def candidates_list_generators() -> GeneratorListResponse:

--- a/src/app/routers/candidates_test.py
+++ b/src/app/routers/candidates_test.py
@@ -10,17 +10,19 @@ from ..lib.embeddings import MINILM_L12_EMBEDDING_KEY
 from ..main import app
 from ..security import verify_api_key
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def fake_app_es():
     """Set up a fake ES client and API key for every test, then clean up."""
 
     class FakeEs:
-        async def search(self, *, index=None, query=None, size=None, sort=None, _source=None, **kwargs):
+        async def search(
+            self, *, index=None, query=None, size=None, sort=None, _source=None, **kwargs
+        ):
             if index == "likes":
                 return {
                     "hits": {
@@ -115,6 +117,7 @@ HEADERS = {"X-API-Key": "testkey"}
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 def test_list_generators():
     client = TestClient(app, headers=HEADERS)
@@ -332,7 +335,9 @@ def test_generate_unknown_infill_returns_404():
 
 def test_generate_requires_auth():
     def _raise():
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key"
+        )
 
     app.dependency_overrides[verify_api_key] = _raise
     try:

--- a/src/app/routers/diversify_test.py
+++ b/src/app/routers/diversify_test.py
@@ -25,7 +25,9 @@ def set_api_key():
 
 def test_auth_required():
     def _raise():
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key"
+        )
 
     app.dependency_overrides[verify_api_key] = _raise
     try:

--- a/src/app/routers/feed_transparency.py
+++ b/src/app/routers/feed_transparency.py
@@ -30,8 +30,8 @@ from ..models_feed_transparency import (
     FeedItemView,
     FeedListResponse,
     FeedSummary,
-    GeneratorView,
     GeneratorDiagnosticView,
+    GeneratorView,
     MediaView,
     ModelScoreView,
     Preferences,
@@ -169,9 +169,7 @@ async def list_feeds(
     # its own feed_name, so which of them to surface is the client's call.
     # Dropping the filter also drops the (feed_name, generated_at) composite
     # index this query used to need.
-    docs = await get_recent_feed_snapshots(
-        db, user_doc_id, cutoff=cutoff, limit=DEFAULT_LIST_LIMIT
-    )
+    docs = await get_recent_feed_snapshots(db, user_doc_id, cutoff=cutoff, limit=DEFAULT_LIST_LIMIT)
 
     summaries: list[FeedSummary] = []
     seen_snapshots: set[tuple[str, tuple[str, ...]]] = set()

--- a/src/app/routers/feed_transparency_test.py
+++ b/src/app/routers/feed_transparency_test.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from ..main import app
 from ..documents import (
     DiversificationMeta,
     FeedSnapshotDocument,
@@ -17,6 +16,7 @@ from ..documents import (
     ModelScoreMeta,
     PipelineItemMeta,
 )
+from ..main import app
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -51,7 +51,7 @@ def _snapshot_doc(
     diversify: bool = True,
     **overrides,
 ) -> FeedSnapshotDocument:
-    now = generated_at or datetime(2026, 7, 12, 15, 30, tzinfo=timezone.utc)
+    now = generated_at or datetime(2026, 7, 12, 15, 30, tzinfo=UTC)
     meta = items_meta or [
         PipelineItemMeta(
             at_uri="at://did:plc:author/app.bsky.feed.post/post1",
@@ -92,15 +92,19 @@ def test_list_feeds_returns_summaries(mock_query, client):
     mock_query.return_value = [
         _snapshot_doc(
             request_id="req-1",
-            generated_at=datetime.now(timezone.utc),
+            generated_at=datetime.now(UTC),
             items=["at://a"],
-            items_meta=[PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)],
+            items_meta=[
+                PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)
+            ],
         ),
         _snapshot_doc(
             request_id="req-2",
-            generated_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            generated_at=datetime.now(UTC) - timedelta(minutes=5),
             items=["at://b"],
-            items_meta=[PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)],
+            items_meta=[
+                PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)
+            ],
         ),
     ]
 
@@ -120,9 +124,11 @@ def test_list_feeds_covers_every_feed_not_one_hardcoded_name(mock_query, client)
     client's call. Filtering server-side would also reintroduce the
     (feed_name, generated_at) composite index this query no longer needs.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     mock_query.return_value = [
-        _snapshot_doc(request_id="req-1", generated_at=now, items=["at://a"], feed_name="your-feed"),
+        _snapshot_doc(
+            request_id="req-1", generated_at=now, items=["at://a"], feed_name="your-feed"
+        ),
         _snapshot_doc(
             request_id="req-2",
             generated_at=now - timedelta(minutes=1),
@@ -162,7 +168,7 @@ def test_list_feeds_returns_401_without_auth():
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_collapses_identical_snapshots_and_keeps_newest(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newer = _snapshot_doc(
         request_id="req-1",
         generated_at=now,
@@ -190,7 +196,7 @@ def test_list_feeds_collapses_identical_snapshots_and_keeps_newest(mock_query, c
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_same_posts_in_different_order(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     mock_query.return_value = [
         _snapshot_doc(
             request_id="req-1",
@@ -214,7 +220,7 @@ def test_list_feeds_preserves_same_posts_in_different_order(mock_query, client):
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_identical_posts_from_different_feeds(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     mock_query.return_value = [
         _snapshot_doc(
             request_id="req-1",
@@ -240,21 +246,30 @@ def test_list_feeds_preserves_identical_posts_from_different_feeds(mock_query, c
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_newest_first_order(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newest = _snapshot_doc(
-        request_id="req-3", generated_at=now,
+        request_id="req-3",
+        generated_at=now,
         items=["at://c"],
-        items_meta=[PipelineItemMeta(at_uri="at://c", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://c", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     middle = _snapshot_doc(
-        request_id="req-2", generated_at=now - timedelta(minutes=3),
+        request_id="req-2",
+        generated_at=now - timedelta(minutes=3),
         items=["at://b"],
-        items_meta=[PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     oldest = _snapshot_doc(
-        request_id="req-1", generated_at=now - timedelta(minutes=6),
+        request_id="req-1",
+        generated_at=now - timedelta(minutes=6),
         items=["at://a"],
-        items_meta=[PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     mock_query.return_value = [newest, middle, oldest]
 
@@ -268,9 +283,10 @@ def test_list_feeds_newest_first_order(mock_query, client):
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newest = _snapshot_doc(
-        request_id="req-3", generated_at=now,
+        request_id="req-3",
+        generated_at=now,
         items=["at://a", "at://b", "at://c"],
         items_meta=[
             PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1),
@@ -279,7 +295,8 @@ def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, clie
         ],
     )
     middle = _snapshot_doc(
-        request_id="req-2", generated_at=now - timedelta(minutes=3),
+        request_id="req-2",
+        generated_at=now - timedelta(minutes=3),
         items=["at://a", "at://b"],
         items_meta=[
             PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1),
@@ -287,9 +304,12 @@ def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, clie
         ],
     )
     oldest = _snapshot_doc(
-        request_id="req-1", generated_at=now - timedelta(minutes=6),
+        request_id="req-1",
+        generated_at=now - timedelta(minutes=6),
         items=["at://d"],
-        items_meta=[PipelineItemMeta(at_uri="at://d", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://d", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     mock_query.return_value = [newest, middle, oldest]
 
@@ -320,7 +340,7 @@ def test_get_feed_detail_returns_merged_data(mock_get_snapshot, mock_hydrate, cl
                 "avatar_url": "https://cdn.bsky.app/avatar.jpg",
             },
             "content": "Hello world",
-            "created_at": datetime(2026, 7, 12, 10, 0, tzinfo=timezone.utc),
+            "created_at": datetime(2026, 7, 12, 10, 0, tzinfo=UTC),
             "media": {
                 "image_urls": [],
                 "video_url": None,
@@ -676,12 +696,18 @@ def test_get_feed_detail_preserves_items_seen_in_newer_snapshots(
     doc = _snapshot_doc(
         items_meta=[
             PipelineItemMeta(
-                at_uri=uri1, rank=1, rank_score=0.92, after_rank_position=1,
+                at_uri=uri1,
+                rank=1,
+                rank_score=0.92,
+                after_rank_position=1,
                 generators=[GeneratorMeta(name="two_tower", score=0.85)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.92)],
             ),
             PipelineItemMeta(
-                at_uri=uri2, rank=2, rank_score=0.88, after_rank_position=2,
+                at_uri=uri2,
+                rank=2,
+                rank_score=0.88,
+                after_rank_position=2,
                 generators=[GeneratorMeta(name="popularity", score=0.80)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.88)],
             ),
@@ -755,12 +781,8 @@ def test_get_feed_detail_filters_public_post_and_author_labels(
         **_hydrated(labeled_author, "author.bsky.social"),
     }
     hydrated[safe]["moderation"] = {"post_labels": [], "author_labels": []}
-    hydrated[labeled_post]["moderation"] = {
-        "post_labels": ["graphic-media"], "author_labels": []
-    }
-    hydrated[labeled_author]["moderation"] = {
-        "post_labels": [], "author_labels": ["porn"]
-    }
+    hydrated[labeled_post]["moderation"] = {"post_labels": ["graphic-media"], "author_labels": []}
+    hydrated[labeled_author]["moderation"] = {"post_labels": [], "author_labels": ["porn"]}
     mock_hydrate.return_value = hydrated
 
     response = client.get("/api/feeds/req-abc")
@@ -784,12 +806,18 @@ def test_get_feed_detail_returns_all_when_no_newer_snapshots(
     doc = _snapshot_doc(
         items_meta=[
             PipelineItemMeta(
-                at_uri=uri1, rank=1, rank_score=0.92, after_rank_position=1,
+                at_uri=uri1,
+                rank=1,
+                rank_score=0.92,
+                after_rank_position=1,
                 generators=[GeneratorMeta(name="two_tower", score=0.85)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.92)],
             ),
             PipelineItemMeta(
-                at_uri=uri2, rank=2, rank_score=0.88, after_rank_position=2,
+                at_uri=uri2,
+                rank=2,
+                rank_score=0.88,
+                after_rank_position=2,
                 generators=[GeneratorMeta(name="popularity", score=0.80)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.88)],
             ),
@@ -813,9 +841,7 @@ def test_get_feed_detail_returns_all_when_no_newer_snapshots(
 
 @patch("app.routers.feed_transparency.hydrate_posts")
 @patch("app.routers.feed_transparency.get_feed_snapshot")
-def test_get_feed_detail_diverse_pipeline_metadata(
-    mock_get_snapshot, mock_hydrate, client
-):
+def test_get_feed_detail_diverse_pipeline_metadata(mock_get_snapshot, mock_hydrate, client):
     uri = "at://did:plc:author/app.bsky.feed.post/post1"
     doc = _snapshot_doc(
         items_meta=[

--- a/src/app/routers/rank.py
+++ b/src/app/routers/rank.py
@@ -13,9 +13,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from ..lib.rankers import (
-    RankModelNotFoundError,
     RankerError,
     RankerExecutionError,
+    RankModelNotFoundError,
     list_rankers,
     run_predict,
 )
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Response models
 # ---------------------------------------------------------------------------
 
+
 class RankModelListResponse(BaseModel):
     """Lists available ranking models."""
 
@@ -40,6 +41,7 @@ class RankModelListResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
 
 @router.get("/rank/models", response_model=RankModelListResponse)
 async def rank_list_models() -> RankModelListResponse:

--- a/src/app/routers/rank_test.py
+++ b/src/app/routers/rank_test.py
@@ -5,8 +5,7 @@ import os
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI
-from fastapi import HTTPException, status
+from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 from ..lib.rankers import RankerExecutionError
@@ -67,7 +66,7 @@ def test_predict_ranks_candidates_by_score_desc(app):
                 {"at_uri": "at://post/low", "score": 0.1, "generator_name": "random_posts"},
                 {"at_uri": "at://post/high", "score": 0.9, "generator_name": "popularity"},
                 {"at_uri": "at://post/mid", "score": 0.4},
-            ]
+            ],
         },
     )
 
@@ -110,7 +109,7 @@ def test_predict_keeps_duplicate_candidate_count_and_collapses_scores_by_uri(app
                 {"at_uri": "at://post/a", "score": 0.9, "content": "first"},
                 {"at_uri": "at://post/a", "score": 0.5, "content": "duplicate"},
                 {"at_uri": "at://post/b", "score": 0.7, "content": "second"},
-            ]
+            ],
         },
     )
 
@@ -180,7 +179,9 @@ def test_predict_requires_auth():
     from ..security import verify_api_key
 
     def _raise():
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or missing API key"
+        )
 
     a = FastAPI()
     a.state.es = object()

--- a/src/app/routers/skylight.py
+++ b/src/app/routers/skylight.py
@@ -3,19 +3,19 @@ import logging
 
 # The `elasticsearch` package exposes several specific exceptions; catch
 # client errors as general exceptions here to avoid import-time issues.
-from fastapi import APIRouter, HTTPException, Query, Request, Depends
-from ..security import verify_api_key
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
-from ..models import CandidatePost
 
+from ..lib.elasticsearch import POSTS_KNN_INDEX, unwrap_es_response
 from ..lib.embeddings import (
     MINILM_L12_EMBEDDING_FIELD,
     MINILM_L12_EMBEDDING_KEY,
     decode_float32_b64,
     encode_float32_b64,
 )
-from ..lib.elasticsearch import unwrap_es_response, POSTS_KNN_INDEX
 from ..lib.telemetry import timed
+from ..models import CandidatePost
+from ..security import verify_api_key
 
 router = APIRouter(tags=["skylight"], dependencies=[Depends(verify_api_key)])
 
@@ -99,7 +99,13 @@ def posts_response_to_results(resp) -> list[CandidatePost]:
 )
 async def skylight_search(
     request: Request,
-    q: str = Query(..., description="Elasticsearch query string syntax — supports field qualifiers, wildcards, and boolean operators"),
+    q: str = Query(
+        ...,
+        description=(
+            "Elasticsearch query string syntax — supports field qualifiers, "
+            "wildcards, and boolean operators"
+        ),
+    ),
     size: int = Query(10, ge=1, le=100, description="Maximum number of results to return (1–100)"),
 ) -> SkylightSearchResponse:
     """Search the `posts` index `content` field and return matching posts.
@@ -114,10 +120,8 @@ async def skylight_search(
     body = {
         "query": {
             "bool": {
-                "must": {
-                    "query_string": {"query": q, "fields": ["content"]}
-                },
-                "filter": [{"term": {"contains_video": True}}]
+                "must": {"query_string": {"query": q, "fields": ["content"]}},
+                "filter": [{"term": {"contains_video": True}}],
             }
         }
     }
@@ -143,7 +147,6 @@ async def skylight_search(
 
     results = posts_response_to_results(resp)
     return SkylightSearchResponse(results=results)
-
 
 
 @router.post(
@@ -199,8 +202,8 @@ async def skylight_similar(request: Request, payload: SkylightSimilarRequest):
         for b64 in payload.embeddings:
             try:
                 vec = decode_float32_b64(b64)
-            except Exception:
-                raise HTTPException(status_code=400, detail="Invalid base64 embedding")
+            except Exception as err:
+                raise HTTPException(status_code=400, detail="Invalid base64 embedding") from err
             vectors.append(vec)
 
     if not vectors:
@@ -236,7 +239,9 @@ async def skylight_similar(request: Request, payload: SkylightSimilarRequest):
 
     try:
         async with timed(logger, "skylight_similar_knn", index=POSTS_KNN_INDEX, size=payload.size):
-            resp = await request.app.state.es.search(index=POSTS_KNN_INDEX, query=knn_q, size=payload.size)
+            resp = await request.app.state.es.search(
+                index=POSTS_KNN_INDEX, query=knn_q, size=payload.size
+            )
     except Exception as exc:
         logger.exception("Elasticsearch similar search failed")
         raise HTTPException(status_code=502, detail="Elasticsearch request failed") from exc

--- a/src/app/routers/skylight_test.py
+++ b/src/app/routers/skylight_test.py
@@ -1,9 +1,10 @@
 import os
+
 import pytest
 from fastapi.testclient import TestClient
 
-from ..main import app
 from ..lib.embeddings import MINILM_L12_EMBEDDING_KEY, encode_float32_b64
+from ..main import app
 
 
 @pytest.fixture
@@ -21,7 +22,7 @@ def es_response():
                             MINILM_L12_EMBEDDING_KEY: [0.1, 0.2],
                             "all_MiniLM_L6_v2": [0.3, 0.4],
                         },
-                    }
+                    },
                 }
             ]
         }
@@ -31,21 +32,36 @@ def es_response():
 @pytest.fixture(autouse=True)
 def fake_app_es(es_response):
     class FakeEs:
-            async def search(self, *, index=None, query=None, size=None, **kwargs):
-                # If this is a lookup by at_uri terms, return a doc. Allow
-                # simulating a 'missing' at_uri that has no embeddings.
-                if isinstance(query, dict) and "terms" in query:
-                    at_list = query.get("terms", {}).get("at_uri")
-                    # If the test asks for an at_uri named "missing", return
-                    # a document without embeddings to trigger a 404 path.
-                    if isinstance(at_list, (list, tuple)) and "missing" in at_list:
-                        doc = {**es_response["hits"]["hits"][0]["_source"], "at_uri": "at://missing", "embeddings": {}}
-                        return {"hits": {"hits": [{"_source": doc}]}}
-                    return {"hits": {"hits": [{"_source": {**es_response["hits"]["hits"][0]["_source"], "at_uri": "at://1"}}]}}
-                # If it's a knn search (similar), return same hit list
-                if isinstance(query, dict) and "knn" in query:
-                    return es_response
+        async def search(self, *, index=None, query=None, size=None, **kwargs):
+            # If this is a lookup by at_uri terms, return a doc. Allow
+            # simulating a 'missing' at_uri that has no embeddings.
+            if isinstance(query, dict) and "terms" in query:
+                at_list = query.get("terms", {}).get("at_uri")
+                # If the test asks for an at_uri named "missing", return
+                # a document without embeddings to trigger a 404 path.
+                if isinstance(at_list, (list, tuple)) and "missing" in at_list:
+                    doc = {
+                        **es_response["hits"]["hits"][0]["_source"],
+                        "at_uri": "at://missing",
+                        "embeddings": {},
+                    }
+                    return {"hits": {"hits": [{"_source": doc}]}}
+                return {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_source": {
+                                    **es_response["hits"]["hits"][0]["_source"],
+                                    "at_uri": "at://1",
+                                }
+                            }
+                        ]
+                    }
+                }
+            # If it's a knn search (similar), return same hit list
+            if isinstance(query, dict) and "knn" in query:
                 return es_response
+            return es_response
 
     # ensure a predictable API key for tests and restore previous value
     prev = os.environ.get("API_KEY")

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -23,7 +23,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from concurrent.futures import Future
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import wraps
 from threading import Lock
 from typing import NamedTuple
@@ -47,7 +47,6 @@ from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import DEFAULT_TTL_SECONDS, FeedCache
 from ..lib.feed_context import FeedContextPayload, decode_feed_context, encode_feed_context
 from ..lib.feed_debug import FeedDebugRecorder, current_recorder, feed_debug_scope
-from ..lib.freshness import DEFAULT_FRESHNESS_INDEX, max_age_hours_for_freshness
 from ..lib.firestore import (
     FEED_DEBUG_RETENTION_DAYS,
     get_recent_discarded_uris,
@@ -61,6 +60,7 @@ from ..lib.firestore import (
     upsert_user,
     write_feed_debug,
 )
+from ..lib.freshness import DEFAULT_FRESHNESS_INDEX, max_age_hours_for_freshness
 from ..lib.metrics import get_metric_collector
 from ..lib.pipeline_context import (
     DegradationEvent,
@@ -368,11 +368,13 @@ async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[Candi
         logger.exception("Embedding hydration failed; continuing without")
         ctx = current_pipeline_context()
         if ctx is not None:
-            ctx.record(DegradationEvent(
-                stage=DegradationStage.EMBED_HYDRATION,
-                component="fetch_post_embeddings",
-                cause=exc,
-            ))
+            ctx.record(
+                DegradationEvent(
+                    stage=DegradationStage.EMBED_HYDRATION,
+                    component="fetch_post_embeddings",
+                    cause=exc,
+                )
+            )
         return candidates
 
     encoded: dict[str, str] = {}
@@ -414,9 +416,7 @@ def _record_cutoff(feed_name: str, reason: str, uris: list[str]) -> None:
         return
     collector = get_metric_collector()
     if collector:
-        collector.record(
-            "feed.slate.cutoff_count", len(uris), feed_name=feed_name, reason=reason
-        )
+        collector.record("feed.slate.cutoff_count", len(uris), feed_name=feed_name, reason=reason)
     rec = current_recorder()
     if rec is not None:
         rec.record_cutoff(reason, uris)
@@ -520,12 +520,15 @@ async def _run_ranking_pipeline(
                 logger.exception("Ranking stage failed; falling back to unranked ordering")
                 if ctx is not None:
                     component = getattr(exc, "name", type(exc).__name__)
-                    ctx.record(DegradationEvent(
-                        stage=DegradationStage.RANK,
-                        component=component,
-                        cause=exc,
-                    ))
-                    # ctx.record re-raises exc when fail_fast=True, so reaching here means fail_fast=False
+                    ctx.record(
+                        DegradationEvent(
+                            stage=DegradationStage.RANK,
+                            component=component,
+                            cause=exc,
+                        )
+                    )
+                    # ctx.record re-raises exc when fail_fast=True, so reaching here
+                    # means fail_fast=False
                     ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
                 else:
                     raise
@@ -540,11 +543,7 @@ async def _run_ranking_pipeline(
             # ordered is sorted desc by the combined score, so everything from
             # the first sub-floor candidate on is below the floor.
             cut_idx = next(
-                (
-                    i
-                    for i, c in enumerate(ordered)
-                    if (c.score or 0.0) < feed_cfg.min_rank_score
-                ),
+                (i for i, c in enumerate(ordered) if (c.score or 0.0) < feed_cfg.min_rank_score),
                 len(ordered),
             )
             low_score_uris = [c.at_uri for c in ordered[cut_idx:] if c.at_uri]
@@ -575,9 +574,7 @@ async def _run_ranking_pipeline(
         if feed_cfg.max_render_share is not None:
             max_keep = max(1, math.floor(feed_cfg.max_render_share * n_retrieved))
             if len(final) > max_keep:
-                _record_cutoff(
-                    feed_name, "share", [c.at_uri for c in final[max_keep:] if c.at_uri]
-                )
+                _record_cutoff(feed_name, "share", [c.at_uri for c in final[max_keep:] if c.at_uri])
                 final = final[:max_keep]
 
         final_uris = [c.at_uri for c in final if c.at_uri]
@@ -592,9 +589,7 @@ async def _run_ranking_pipeline(
         if not final_uris and pre_cut_uris:
             # The quality gates rejected everything we retrieved.
             if collector:
-                collector.record(
-                    "feed.slate.empty_after_cutoff_count", 1, feed_name=feed_name
-                )
+                collector.record("feed.slate.empty_after_cutoff_count", 1, feed_name=feed_name)
             if EMPTY_SLATE_FAIL_OPEN:
                 logger.warning(
                     "Slate cutoffs emptied feed '%s' (%d candidates retrieved); failing open",
@@ -647,7 +642,7 @@ async def _run_pipeline_capturing(
     for now; PostHog per-user flag (issue 279) will pass it in when implemented.
     """
     recorder = FeedDebugRecorder(feed_name=feed_name, regenerated=regenerated)
-    generated_at = datetime.now(timezone.utc)
+    generated_at = datetime.now(UTC)
     ctx = PipelineContext(feed_name=feed_name)
 
     with feed_debug_scope(recorder), pipeline_context_scope(ctx):
@@ -727,10 +722,7 @@ def _snapshot_page(
 ) -> FeedSnapshotDocument:
     """Restrict pipeline metadata to posts actually returned in one page."""
     meta_by_uri = {meta.at_uri: meta for meta in snapshot.items_meta}
-    items_meta = [
-        meta_by_uri.get(uri, PipelineItemMeta(at_uri=uri))
-        for uri in uris
-    ]
+    items_meta = [meta_by_uri.get(uri, PipelineItemMeta(at_uri=uri)) for uri in uris]
     diagnostics = [
         diagnostic.model_copy(
             update={
@@ -874,7 +866,7 @@ async def _record_session(request: Request, user_did: str, feed_name: str, db) -
         )
         username = None
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     try:
         await upsert_user(db, user_did, username)
@@ -914,7 +906,7 @@ async def _resolve_handles(request: Request, dids: set[str]) -> dict[str, str]:
             return None
 
     handles = await asyncio.gather(*(_one(did) for did in did_list))
-    return {did: handle for did, handle in zip(did_list, handles) if handle}
+    return {did: handle for did, handle in zip(did_list, handles, strict=False) if handle}
 
 
 async def _write_feed_snapshot_background(
@@ -941,9 +933,7 @@ async def _write_feed_snapshot_background(
             )
             collector = get_metric_collector()
             if collector is not None:
-                collector.record(
-                    "feed.snapshot.truncated_count", 1, feed_name=snapshot.feed_name
-                )
+                collector.record("feed.snapshot.truncated_count", 1, feed_name=snapshot.feed_name)
     except Exception:
         logger.exception(
             "Failed to write feed snapshot for user '%s', request '%s'",
@@ -983,7 +973,7 @@ async def _write_feed_debug(
         logger.exception("Failed to write feed debug record for user '%s'", user_did)
 
 
-async def _record_interactions(db, interactions: list["Interaction"]) -> None:
+async def _record_interactions(db, interactions: list[Interaction]) -> None:
     """Verify each interaction's feedContext and persist the valid ones.
 
     The signed feedContext is the trust anchor: interactions with a missing or
@@ -1024,7 +1014,7 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
             event=event,
             feed_name=payload.feed,
             request_id=payload.rid,
-            feed_generated_at=datetime.fromtimestamp(payload.iat, tz=timezone.utc),
+            feed_generated_at=datetime.fromtimestamp(payload.iat, tz=UTC),
         )
         try:
             await record_interaction(db, doc)
@@ -1262,9 +1252,7 @@ async def get_feed_skeleton(
         if preset is not None:
             generators_override = {"generators": preset}
 
-    freshness_index = (
-        user_doc.freshness if user_doc is not None else DEFAULT_FRESHNESS_INDEX
-    )
+    freshness_index = user_doc.freshness if user_doc is not None else DEFAULT_FRESHNESS_INDEX
     max_age_hours = max_age_hours_for_freshness(freshness_index)
 
     feed_cache = _get_feed_cache(request)
@@ -1281,8 +1269,8 @@ async def get_feed_skeleton(
         if cursor is not None:
             try:
                 parsed = FeedCursor.decode(cursor)
-            except ValueError:
-                raise HTTPException(status_code=400, detail="Invalid cursor")
+            except ValueError as err:
+                raise HTTPException(status_code=400, detail="Invalid cursor") from err
 
             async with timed(logger, "feedcache_retrieve", cache_id=parsed.id):
                 cache_doc = await feed_cache.retrieve_document(parsed.id)
@@ -1304,7 +1292,7 @@ async def get_feed_skeleton(
                         request_id=parsed.id,
                         items=cached_uris,
                         feed_name=cache_doc.feed_name or feed_name,
-                        generated_at=cache_doc.generated_at or datetime.now(timezone.utc),
+                        generated_at=cache_doc.generated_at or datetime.now(UTC),
                         expires_at=cache_doc.expires_at,
                         generator_diagnostics=cache_doc.generator_diagnostics,
                         applied_social_radius=cache_doc.applied_social_radius,
@@ -1458,13 +1446,9 @@ async def get_feed_skeleton(
             # later pages would skip posts.
             next_cursor = None
             if cache_uris:
-                cache_meta_by_uri = {
-                    meta.at_uri: meta for meta in generated_snapshot.items_meta
-                }
+                cache_meta_by_uri = {meta.at_uri: meta for meta in generated_snapshot.items_meta}
                 cache_items_meta = [
-                    cache_meta_by_uri[uri]
-                    for uri in cache_uris
-                    if uri in cache_meta_by_uri
+                    cache_meta_by_uri[uri] for uri in cache_uris if uri in cache_meta_by_uri
                 ]
                 async with timed(logger, "feedcache_store", cache_id=request_id):
                     await feed_cache.store_document(
@@ -1476,8 +1460,7 @@ async def get_feed_skeleton(
                             applied_social_radius=applied_social_radius,
                             feed_name=feed_name,
                             generated_at=generated_snapshot.generated_at,
-                            expires_at=datetime.now(timezone.utc)
-                            + timedelta(seconds=DEFAULT_TTL_SECONDS),
+                            expires_at=datetime.now(UTC) + timedelta(seconds=DEFAULT_TTL_SECONDS),
                         ),
                     )
                 next_cursor = FeedCursor(id=request_id, offset=consumed).encode()

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -28,6 +28,7 @@ def _isolate_initial_request_reuse():
     yield
     _clear_initial_request_cache()
 
+
 SERVICE_DID = "did:web:test.example.com"
 PUBLISHER_DID = "did:plc:publisherabc123"
 FEED_RKEY = "unranked-your-feed"
@@ -51,10 +52,18 @@ CANDIDATE_ONLY_FEEDS = (
 TEST_EMBEDDING = encode_float32_b64([1.0, 0.0, 0.0])
 
 
-def _make_candidates(prefix: str, n: int, generator_name: str = "test", with_embedding: bool = False) -> list[CandidatePost]:
+def _make_candidates(
+    prefix: str, n: int, generator_name: str = "test", with_embedding: bool = False
+) -> list[CandidatePost]:
     embedding = TEST_EMBEDDING if with_embedding else None
     return [
-        CandidatePost(at_uri=f"at://{prefix}/{i}", content=f"post {i}", minilm_l12_embedding=embedding, score=None, generator_name=generator_name)
+        CandidatePost(
+            at_uri=f"at://{prefix}/{i}",
+            content=f"post {i}",
+            minilm_l12_embedding=embedding,
+            score=None,
+            generator_name=generator_name,
+        )
         for i in range(n)
     ]
 
@@ -80,9 +89,7 @@ def _patch_unranked_your_feed_generators(
     followed_users_gen.generate.return_value = CandidateResult(
         generator_name="followed_users",
         candidates=(
-            two_tower_candidates
-            if followed_users_candidates is None
-            else followed_users_candidates
+            two_tower_candidates if followed_users_candidates is None else followed_users_candidates
         ),
     )
     infill_gen = AsyncMock()
@@ -188,6 +195,7 @@ client = TestClient(app)
 # /.well-known/did.json
 # ---------------------------------------------------------------------------
 
+
 class TestWellKnownDid:
     def test_returns_200(self):
         resp = client.get("/.well-known/did.json")
@@ -223,6 +231,7 @@ class TestWellKnownDid:
 # ---------------------------------------------------------------------------
 # /xrpc/app.bsky.feed.describeFeedGenerator
 # ---------------------------------------------------------------------------
+
 
 class TestDescribeFeedGenerator:
     def test_returns_200(self):
@@ -268,20 +277,27 @@ class TestDescribeFeedGenerator:
 # /xrpc/app.bsky.feed.getFeedSkeleton
 # ---------------------------------------------------------------------------
 
+
 class TestGetFeedSkeleton:
     """Tests for the getFeedSkeleton endpoint."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
         """Default to an authenticated caller for non-auth-focused tests."""
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Keep Firestore I/O out of generic feed skeleton tests."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -304,7 +320,9 @@ class TestGetFeedSkeleton:
 
     def test_returns_feed_items(self):
         with self._patch_generators(_make_candidates("p", 3)):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert len(data["feed"]) == 3
         assert data["feed"][0]["post"] == "at://p/0"
 
@@ -312,15 +330,18 @@ class TestGetFeedSkeleton:
         """A fresh feed load excludes the user's recently-seen posts."""
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(
-            generator_name="two_tower", candidates=_make_candidates("p", 2),
+            generator_name="two_tower",
+            candidates=_make_candidates("p", 2),
         )
         followed_gen = AsyncMock()
         followed_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -338,9 +359,7 @@ class TestGetFeedSkeleton:
                 return_value=["at://seen/1", "at://seen/2"],
             ),
         ):
-            resp = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
-            )
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
 
         assert resp.status_code == 200
         assert primary_gen.generate.call_args.kwargs.get("exclude_uris") == [
@@ -354,15 +373,18 @@ class TestGetFeedSkeleton:
 
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(
-            generator_name="two_tower", candidates=_make_candidates("p", 2),
+            generator_name="two_tower",
+            candidates=_make_candidates("p", 2),
         )
         followed_gen = AsyncMock()
         followed_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -374,13 +396,9 @@ class TestGetFeedSkeleton:
 
         with (
             patch("app.lib.candidates.generate.get_generator", side_effect=fake_get),
-            patch(
-                "app.routers.xrpc.get_recent_seen_uris", new_callable=AsyncMock
-            ) as seen_fetch,
+            patch("app.routers.xrpc.get_recent_seen_uris", new_callable=AsyncMock) as seen_fetch,
         ):
-            resp = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
-            )
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
 
         assert resp.status_code == 200
         seen_fetch.assert_not_called()
@@ -448,9 +466,7 @@ class TestGetFeedSkeleton:
                 params={"feed": FEED_URI, "limit": 3},
             ).json()
             key = ("did:plc:testuser", FEED_RKEY, 3)
-            xrpc_mod._initial_requests[key].created_at -= (
-                xrpc_mod.INITIAL_REQUEST_REUSE_SECONDS + 1
-            )
+            xrpc_mod._initial_requests[key].created_at -= xrpc_mod.INITIAL_REQUEST_REUSE_SECONDS + 1
             second = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI, "limit": 3},
@@ -546,12 +562,32 @@ class TestGetFeedSkeleton:
 
     def test_deduplicates_by_at_uri(self):
         duped = [
-            CandidatePost(at_uri="at://dup/1", content="a", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://dup/1", content="a", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://dup/2", content="b", minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://dup/1",
+                content="a",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://dup/1",
+                content="a",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://dup/2",
+                content="b",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(duped):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         uris = [item["post"] for item in data["feed"]]
         assert uris == ["at://dup/1", "at://dup/2"]
 
@@ -648,7 +684,9 @@ class TestGetFeedSkeleton:
 
     def test_empty_feed_returns_empty_list(self):
         with self._patch_generators([]):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert data["feed"] == []
 
     # --- MMR diversification ---
@@ -656,13 +694,43 @@ class TestGetFeedSkeleton:
     def test_same_author_candidates_are_spread_in_feed(self):
         """MMR should interleave candidates from the same author with others."""
         candidates = [
-            CandidatePost(at_uri="at://alice/1", score=1.0, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://alice/2", score=0.9, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://alice/3", score=0.8, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://bob/1", score=0.5, author_did="did:plc:bob", content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://alice/1",
+                score=1.0,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://alice/2",
+                score=0.9,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://alice/3",
+                score=0.8,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://bob/1",
+                score=0.5,
+                author_did="did:plc:bob",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(candidates):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         uris = [item["post"] for item in data["feed"]]
         assert uris[0] == "at://alice/1"
         assert uris.index("at://bob/1") < uris.index("at://alice/2")
@@ -671,11 +739,25 @@ class TestGetFeedSkeleton:
 
     def test_posts_without_at_uri_are_skipped(self):
         candidates = [
-            CandidatePost(at_uri=None, content="no uri", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://good/1", content="has uri", minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri=None,
+                content="no uri",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://good/1",
+                content="has uri",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(candidates):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert len(data["feed"]) == 1
         assert data["feed"][0]["post"] == "at://good/1"
 
@@ -684,18 +766,25 @@ class TestGetFeedSkeleton:
 # Candidate-generator-only feeds
 # ---------------------------------------------------------------------------
 
+
 class TestCandidateGeneratorOnlyFeeds:
     """Tests for private feeds that expose one candidate generator directly."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.mark.parametrize("feed_name,expected_generator", CANDIDATE_ONLY_FEEDS)
@@ -743,18 +832,25 @@ class TestCandidateGeneratorOnlyFeeds:
 # Cursor / pagination
 # ---------------------------------------------------------------------------
 
+
 class TestFeedSkeletonCursor:
     """Tests for cursor-based feed pagination."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -915,7 +1011,8 @@ class TestFeedSkeletonCursor:
             app.state.feed_cache = saved
 
     def test_end_of_cache_regenerates_with_exclusions(self):
-        """When cursor offset >= cached length, new posts are generated excluding previously shown."""
+        """When cursor offset >= cached length, new posts are generated
+        excluding previously shown."""
         candidates = _make_candidates("p", 6)
         with self._patch_generators(candidates):
             first = client.get(
@@ -1044,11 +1141,13 @@ class TestFeedSkeletonCursor:
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
         followed_users_gen = AsyncMock()
         followed_users_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -1068,12 +1167,21 @@ class TestFeedSkeletonCursor:
         # containing the 5 initial URIs.
         call_kwargs = primary_gen.generate.call_args
         assert call_kwargs.kwargs.get("exclude_uris") == [
-            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
+            "at://p/0",
+            "at://p/1",
+            "at://p/2",
+            "at://p/3",
+            "at://p/4",
         ]
         followed_call_kwargs = followed_users_gen.generate.call_args
         assert followed_call_kwargs.kwargs.get("exclude_uris") == [
-            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
+            "at://p/0",
+            "at://p/1",
+            "at://p/2",
+            "at://p/3",
+            "at://p/4",
         ]
+
 
 class TestGetFeedSkeletonAuth:
     """Tests that getFeedSkeleton correctly passes through the authenticated DID."""
@@ -1084,8 +1192,10 @@ class TestGetFeedSkeletonAuth:
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Avoid real Firestore interactions unless a test explicitly patches it."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def test_authenticated_user_did_passed_to_generator(self):
@@ -1112,7 +1222,7 @@ class TestGetFeedSkeletonAuth:
 
     def test_unauthenticated_request_uses_empty_did(self):
         """Without auth header, endpoint should reject the request."""
-        with self._patch_generators(_make_candidates("p", 2)) as mock_get:
+        with self._patch_generators(_make_candidates("p", 2)):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI},
@@ -1183,7 +1293,9 @@ class TestGetFeedSkeletonAuth:
                 new_callable=AsyncMock,
                 return_value=mock_payload,
             ),
-            patch.object(app.state.id_resolver.did, "resolve", new_callable=AsyncMock, return_value=None),
+            patch.object(
+                app.state.id_resolver.did, "resolve", new_callable=AsyncMock, return_value=None
+            ),
         ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -1319,22 +1431,27 @@ class TestGetFeedSkeletonAuth:
 # _get_service_did / _get_hostname helpers
 # ---------------------------------------------------------------------------
 
+
 class TestConfigHelpers:
     def test_get_service_did_from_env(self):
         from ..routers.xrpc import _get_service_did
+
         assert _get_service_did() == SERVICE_DID
 
     def test_get_service_did_default(self, monkeypatch):
         from ..routers.xrpc import _get_service_did
+
         monkeypatch.delenv("GE_FEED_GENERATOR_DID", raising=False)
         assert _get_service_did() == "did:web:localhost"
 
     def test_get_hostname_from_did_web(self):
         from ..routers.xrpc import _get_hostname
+
         assert _get_hostname() == "test.example.com"
 
     def test_get_hostname_non_web_did(self, monkeypatch):
         from ..routers.xrpc import _get_hostname
+
         monkeypatch.setenv("GE_FEED_GENERATOR_DID", "did:plc:abc123")
         assert _get_hostname() == "localhost"
 
@@ -1343,18 +1460,25 @@ class TestConfigHelpers:
 # Ranked feed
 # ---------------------------------------------------------------------------
 
+
 class TestRankedFeed:
     """Tests for feeds with a rank_request_template wired in."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1402,8 +1526,10 @@ class TestRankedFeed:
         ]
         rank_result = RankPredictResult(rankings=reversed_rankings)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1415,13 +1541,23 @@ class TestRankedFeed:
     def test_hydrates_lightweight_candidates_before_ranking(self):
         """Embedding-free generated candidates are hydrated before ranking."""
         candidates = _make_candidates("p", 1)
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.fetch_post_embeddings", new_callable=AsyncMock, return_value=[("at://p/0", [1.0, 0.0, 0.0])]) as mock_fetch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.fetch_post_embeddings",
+                new_callable=AsyncMock,
+                return_value=[("at://p/0", [1.0, 0.0, 0.0])],
+            ) as mock_fetch,
+            patch(
+                "app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result
+            ) as mock_run,
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1438,17 +1574,39 @@ class TestRankedFeed:
     def test_drops_candidates_missing_embeddings_before_ranking(self):
         """Candidates still missing embeddings after hydration are not sent to ranking."""
         candidates = [
-            CandidatePost(at_uri="at://p/0", content=None, minilm_l12_embedding=TEST_EMBEDDING, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://p/1", content=None, minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://p/0",
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/1",
+                content=None,
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
-            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=0.5),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+                RankedCandidate(at_uri="at://p/1", rank=2, rank_score=0.5),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc._hydrate_embeddings", new_callable=AsyncMock, return_value=candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc._hydrate_embeddings",
+                new_callable=AsyncMock,
+                return_value=candidates,
+            ),
+            patch(
+                "app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result
+            ) as mock_run,
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1468,19 +1626,41 @@ class TestRankedFeed:
         """
         # Generator scores: p/0 highest, p/1 middle, p/2 lowest.
         candidates = [
-            CandidatePost(at_uri="at://p/0", score=3.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
-            CandidatePost(at_uri="at://p/1", score=2.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
-            CandidatePost(at_uri="at://p/2", score=1.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
+            CandidatePost(
+                at_uri="at://p/0",
+                score=3.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/1",
+                score=2.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/2",
+                score=1.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
         ]
         # Ranker reverses the order: p/2 best, p/1 middle, p/0 worst.
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/2", rank=1, rank_score=3.0),
-            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=2.0),
-            RankedCandidate(at_uri="at://p/0", rank=3, rank_score=1.0),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/2", rank=1, rank_score=3.0),
+                RankedCandidate(at_uri="at://p/1", rank=2, rank_score=2.0),
+                RankedCandidate(at_uri="at://p/0", rank=3, rank_score=1.0),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1494,8 +1674,14 @@ class TestRankedFeed:
         """When ranking raises, the feed soft-fails and returns candidates in unranked order."""
         candidates = _make_candidates("p", 3, with_embedding=True)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inference down"),
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1533,9 +1719,10 @@ class TestEmbeddingHydrationTimeout:
 
         candidates = [CandidatePost(at_uri="at://post/1", score=0.5)]
 
-        with patch(
-            "app.routers.xrpc.fetch_post_embeddings", side_effect=_hangs
-        ), pipeline_context_scope(PipelineContext(feed_name="f")) as ctx:
+        with (
+            patch("app.routers.xrpc.fetch_post_embeddings", side_effect=_hangs),
+            pipeline_context_scope(PipelineContext(feed_name="f")) as ctx,
+        ):
             result = await xrpc_module._hydrate_embeddings(object(), candidates)
 
         assert result == candidates
@@ -1549,18 +1736,25 @@ class TestEmbeddingHydrationTimeout:
 # Slate cutoffs (max_render_share / min_rank_score / min_mmr_score)
 # ---------------------------------------------------------------------------
 
+
 class TestSlateCutoffs:
     """The quality gates cut the slate and drive session restarts + discards."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1605,17 +1799,21 @@ class TestSlateCutoffs:
     def _rank_result(scores: list[float]) -> RankPredictResult:
         """Rank p/0..p/n-1 with the given scores, in descending-score order."""
         order = sorted(range(len(scores)), key=lambda i: -scores[i])
-        return RankPredictResult(rankings=[
-            RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=scores[i])
-            for r, i in enumerate(order)
-        ])
+        return RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=scores[i])
+                for r, i in enumerate(order)
+            ]
+        )
 
     def _get_feed(self, candidates, rank_result, discarded_mock=None):
         gen_patch, _ = self._patch_generators(candidates)
         discarded_mock = discarded_mock if discarded_mock is not None else AsyncMock()
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch("app.routers.xrpc.record_discarded_posts", discarded_mock):
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch("app.routers.xrpc.record_discarded_posts", discarded_mock),
+        ):
             return client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1708,19 +1906,21 @@ class TestSlateCutoffs:
         gen_patch, primary_gen = self._patch_generators(candidates)
 
         rank_result = self._rank_result([0.7, 0.6])
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch("app.routers.xrpc.record_discarded_posts", new_callable=AsyncMock), \
-             patch(
-                 "app.routers.xrpc.get_recent_seen_uris",
-                 new_callable=AsyncMock,
-                 return_value=["at://seen/1"],
-             ), \
-             patch(
-                 "app.routers.xrpc.get_recent_discarded_uris",
-                 new_callable=AsyncMock,
-                 return_value=["at://disc/1"],
-             ):
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch("app.routers.xrpc.record_discarded_posts", new_callable=AsyncMock),
+            patch(
+                "app.routers.xrpc.get_recent_seen_uris",
+                new_callable=AsyncMock,
+                return_value=["at://seen/1"],
+            ),
+            patch(
+                "app.routers.xrpc.get_recent_discarded_uris",
+                new_callable=AsyncMock,
+                return_value=["at://disc/1"],
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": RANKED_FEED_URI}
             )
@@ -1736,11 +1936,13 @@ class TestSlateCutoffs:
         gen_patch, _ = self._patch_generators(_make_candidates("p", 2, with_embedding=True))
 
         rank_result = self._rank_result([0.5, 0.4])
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch(
-                 "app.routers.xrpc.get_recent_discarded_uris", new_callable=AsyncMock
-             ) as discarded_fetch:
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch(
+                "app.routers.xrpc.get_recent_discarded_uris", new_callable=AsyncMock
+            ) as discarded_fetch,
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": RANKED_FEED_URI}
             )
@@ -1789,18 +1991,25 @@ class TestSlateCutoffs:
 # Best-of-friends feed
 # ---------------------------------------------------------------------------
 
+
 class TestBestOfFriendsFeed:
     """Tests for the best-of-friends feed (followed_users candidates + two-tower ranking)."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1835,8 +2044,10 @@ class TestBestOfFriendsFeed:
         ]
         rank_result = RankPredictResult(rankings=reversed_rankings)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -1846,11 +2057,18 @@ class TestBestOfFriendsFeed:
         assert posts == ["at://p/2", "at://p/1", "at://p/0"]
 
     def test_ranking_failure_soft_fails_to_unranked(self):
-        """When the two-tower ranker raises, the feed soft-fails and returns candidates in unranked order."""
+        """When the two-tower ranker raises, the feed soft-fails and returns
+        candidates in unranked order."""
         candidates = _make_candidates("p", 3, with_embedding=True)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inference down"),
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -1870,8 +2088,10 @@ class TestBestOfFriendsFeed:
         async def _slow_run_predict(*args, **kwargs):
             await asyncio.sleep(1)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", side_effect=_slow_run_predict):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", side_effect=_slow_run_predict),
+        ):
             resp = TestClient(app, raise_server_exceptions=False).get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -1916,9 +2136,7 @@ class TestShortEvent:
 
 class TestSendInteractions:
     def test_returns_empty_object(self):
-        resp = client.post(
-            "/xrpc/app.bsky.feed.sendInteractions", json={"interactions": []}
-        )
+        resp = client.post("/xrpc/app.bsky.feed.sendInteractions", json={"interactions": []})
         assert resp.status_code == 200
         assert resp.json() == {}
 
@@ -2058,7 +2276,9 @@ class TestSendInteractions:
         monkeypatch.setattr(FEEDS["your-feed"], "exclude_seen_posts", False)
         seen = "app.bsky.feed.defs#interactionSeen"
         ix = Interaction(
-            item="at://post/1", event=seen, feed_context=_make_token(feed="your-feed"),
+            item="at://post/1",
+            event=seen,
+            feed_context=_make_token(feed="your-feed"),
         )
         db = MagicMock()
         with (
@@ -2075,13 +2295,18 @@ class TestSendInteractions:
 # Feed debug capture
 # ---------------------------------------------------------------------------
 
+
 class TestFeedDebugCapture:
     """getFeedSkeleton always writes a lightweight snapshot; full debug is gated on debug_feeds."""
 
     @pytest.fixture(autouse=True)
     def _mock_auth_and_session(self):
         with (
-            patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"),
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value="did:plc:testuser",
+            ),
             patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
         ):
@@ -2093,7 +2318,9 @@ class TestFeedDebugCapture:
     def _user_doc(self, debug_feeds):
         from ..documents import UserDocument
 
-        return UserDocument(user_did="did:plc:testuser", username=TEST_USERNAME, debug_feeds=debug_feeds)
+        return UserDocument(
+            user_did="did:plc:testuser", username=TEST_USERNAME, debug_feeds=debug_feeds
+        )
 
     @staticmethod
     async def _drain(coros):
@@ -2117,7 +2344,9 @@ class TestFeedDebugCapture:
         snapshot = MagicMock(items=["at://a"], feed_name="your-feed")
         collector = MagicMock()
         with (
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=True),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=True
+            ),
             patch("app.routers.xrpc.get_metric_collector", return_value=collector),
         ):
             await _write_feed_snapshot_background(MagicMock(), "did:plc:testuser", "r1", snapshot)
@@ -2131,8 +2360,14 @@ class TestFeedDebugCapture:
         """Snapshot always written regardless of debug flag."""
         with (
             self._patch_generators(_make_candidates("p", 3)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(False)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(False),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2145,8 +2380,14 @@ class TestFeedDebugCapture:
         candidates = _make_candidates("p", 8)
         with (
             self._patch_generators(candidates),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(False)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(False),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
         ):
             response = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -2165,9 +2406,17 @@ class TestFeedDebugCapture:
         spawned: list = []
         with (
             self._patch_generators(_make_candidates("p", 3)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(True)),
-            patch("app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(True),
+            ),
+            patch(
+                "app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2186,8 +2435,14 @@ class TestFeedDebugCapture:
         """Snapshot still written even when user lookup fails."""
         with (
             self._patch_generators(_make_candidates("p", 2)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, side_effect=RuntimeError("boom")),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2200,6 +2455,7 @@ class TestFeedDebugCapture:
 # ---------------------------------------------------------------------------
 # Probe bypass (Cloud Scheduler)
 # ---------------------------------------------------------------------------
+
 
 class TestGetFeedSkeletonProbe:
     """Cloud Scheduler hits the endpoint without AT Protocol auth.
@@ -2217,13 +2473,17 @@ class TestGetFeedSkeletonProbe:
     @pytest.fixture(autouse=True)
     def _no_at_proto_auth(self):
         """Simulate requests with no AT Protocol Bearer token."""
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None):
+        with patch(
+            "app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def test_correct_probe_secret_returns_200(self):
@@ -2293,7 +2553,11 @@ class TestPinnedPost:
         cfg = FEEDS["random"].model_copy(update={"pinned_post_uri": self.PINNED_URI})
         return {"random": cfg, **{k: v for k, v in FEEDS.items() if k != "random"}}
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2311,8 +2575,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -2321,7 +2587,11 @@ class TestPinnedPost:
         assert resp.status_code == 200
         assert resp.json()["feed"][0]["post"] == self.PINNED_URI
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2361,7 +2631,11 @@ class TestPinnedPost:
         ]
         assert all(meta.at_uri != self.PINNED_URI for meta in snapshot.items_meta)
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2370,7 +2644,9 @@ class TestPinnedPost:
         from app.routers import xrpc as xrpc_mod
 
         candidates = [
-            CandidatePost(at_uri=self.PINNED_URI, content="pinned", score=None, generator_name="random_posts"),
+            CandidatePost(
+                at_uri=self.PINNED_URI, content="pinned", score=None, generator_name="random_posts"
+            ),
             *_make_candidates("did:plc:a", 4, "random_posts"),
         ]
         random_gen = AsyncMock()
@@ -2382,8 +2658,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -2394,7 +2672,11 @@ class TestPinnedPost:
         assert post_uris.count(self.PINNED_URI) == 1
         assert post_uris[0] == self.PINNED_URI
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2413,8 +2695,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             first = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -2432,7 +2716,11 @@ class TestPinnedPost:
 
         assert second["feed"][0]["post"] == "at://did:plc:a/9"
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2458,8 +2746,6 @@ class TestPinnedPost:
         assert self.PINNED_URI not in post_uris
 
 
-
-
 # ---------------------------------------------------------------------------
 # Social-radius override
 # ---------------------------------------------------------------------------
@@ -2470,13 +2756,19 @@ class TestSocialRadiusOverride:
 
     @pytest.fixture(autouse=True)
     def _mock_auth(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @patch("app.routers.xrpc.get_user")
@@ -2604,8 +2896,9 @@ class TestGetFeedSkeletonMetrics:
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), patch(
-            "app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
         ):
             yield
 
@@ -2624,24 +2917,18 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 200
-        success_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.success_count"
-        ]
+        success_calls = [call for call in self.mc.calls if call[0] == "feed.render.success_count"]
         assert len(success_calls) == 1
         assert success_calls[0][2]["feed_name"] == FEED_RKEY
 
     def test_unknown_feed_records_failure_count_400(self):
         response = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
-            params={
-                "feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"
-            },
+            params={"feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"},
         )
 
         assert response.status_code == 400
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": "unknown",
@@ -2660,9 +2947,7 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 401
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": FEED_RKEY,
@@ -2692,9 +2977,7 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 504
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": FEED_RKEY,
@@ -2704,14 +2987,10 @@ class TestGetFeedSkeletonMetrics:
     def test_failure_records_no_success_count(self):
         client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
-            params={
-                "feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"
-            },
+            params={"feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"},
         )
 
-        assert [
-            call for call in self.mc.calls if call[0] == "feed.render.success_count"
-        ] == []
+        assert [call for call in self.mc.calls if call[0] == "feed.render.success_count"] == []
 
 
 class TestDevSession:
@@ -2734,18 +3013,14 @@ class TestDevSession:
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.delenv("GE_DEV_SESSION_SECRET", raising=False)
-        request = self._request(
-            {"X-Dev-Session": "anything", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "anything", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) is None
 
     def test_ignores_a_wrong_secret(self, monkeypatch):
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "correct")
-        request = self._request(
-            {"X-Dev-Session": "wrong", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "wrong", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) is None
 
     def test_ignores_a_request_with_no_headers(self, monkeypatch):
@@ -2758,9 +3033,7 @@ class TestDevSession:
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "correct")
-        request = self._request(
-            {"X-Dev-Session": "correct", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "correct", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) == "did:plc:abc"
 
     def test_rejects_a_did_that_is_not_did_plc(self, monkeypatch):
@@ -2783,9 +3056,7 @@ class TestDevSessionStartupGuard:
     """It must be impossible to serve deployed traffic with this enabled."""
 
     @pytest.mark.asyncio
-    async def test_refuses_to_start_when_enabled_in_a_deployed_environment(
-        self, monkeypatch
-    ):
+    async def test_refuses_to_start_when_enabled_in_a_deployed_environment(self, monkeypatch):
         from ..main import app, lifespan
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "anything")


### PR DESCRIPTION
## Motivation

The Python CI workflow ran pyright and pytest but **never ran ruff**, so lint and formatting drift landed on `main` unchecked. This aligns the repo's CI with `internal-tools`, the current reference Python CI config.

## What changed

- **CI** (`python-ci.yml`): add `ruff check` and `ruff format --check` steps, and pin `actions/setup-python` to v6 to match the reference.
- **Formatting**: `ruff format` applied across the repo — this is the bulk of the diff and is purely mechanical.
- **Lint fixes**: import ordering (I001), unused imports/vars (F401/F841), `zip(..., strict=False)` (B905), `raise ... from err` in `except` (B904), `StrEnum` for `str`+`Enum` (UP042), specific-exception assert (B017), and line-length (E501) via manual wrapping.
- **E402**: moved imports to module top in two test files; scoped an `E402` per-file-ignore for `main.py`, whose imports intentionally follow root-logger configuration.

## Safety

No behavior changes. B905 fixes preserve current semantics (`strict=False`), and `DegradationStage` is never string-formatted (so the `StrEnum` switch is inert). Locally: `ruff check`, `ruff format --check`, `pyright`, and the full 887-test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)