### PR TITLE
Extend seen_posts retention to 14 days

### DIFF
--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -99,7 +99,7 @@ class SeenPostsDocument(BaseModel):
 
     One document per user per day under the ``seen_posts`` subcollection; the
     document ID is the ``YYYY-MM-DD`` date.  ``expires_at`` anchors the native
-    Firestore TTL policy so buckets self-delete ~5 days after the day they cover.
+    Firestore TTL policy so buckets self-delete ~14 days after the day they cover.
     """
 
     post_uris: list[str] = Field(default_factory=list, description="Seen post AT URIs for this day")

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -39,7 +39,7 @@ FEED_SNAPSHOTS_COLLECTION = "feed_snapshots"
 MAX_FEED_SNAPSHOT_ITEMS = 500
 
 # How long a seen-posts bucket lives before native Firestore TTL deletes it.
-SEEN_POSTS_RETENTION_DAYS = 5
+SEEN_POSTS_RETENTION_DAYS = 14
 
 # How long a discarded-posts bucket lives before native Firestore TTL deletes
 # it. Shorter than seen posts: the candidate pool refreshes quickly and ranker


### PR DESCRIPTION
Closes #260

seen_posts buckets currently expire after 5 days via Firestore TTL, so posts get recycled into the candidate pool sooner than intended. This PR only bumps the retention window per the issue; the ES terms query perf follow-up was explicitly deferred (see issue comment).

# This PR

- Bump `SEEN_POSTS_RETENTION_DAYS` from 5 to 14 in `src/app/lib/firestore.py`
- Update the stale "~5 days" docstring on `SeenPostsDocument` to match

# Testing

- `pipenv run python -m pytest -q` — 899 passed