### PR TITLE
Add GET /r UTM redirect endpoint

### DIFF
--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -92,6 +92,21 @@ def track_interaction(
     )
 
 
+def track_redirect(
+    client: Posthog | None,
+    to: str,
+    utm_params: dict[str, str],
+) -> None:
+    """Capture a redirectClicked event for UTM click counting."""
+    if client is None:
+        return
+    client.capture(
+        distinct_id="redirect_service",
+        event="redirectClicked",
+        properties={"to": to, **utm_params},
+    )
+
+
 def evaluate_fail_fast_flag(client: Posthog | None, user_did: str) -> bool:
     """Evaluate the fail-fast-feed PostHog feature flag for this user.
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -37,7 +37,7 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 
 logger = logging.getLogger(__name__)
 
-from .routers import candidates, diversify, feed_transparency, health, rank, skylight, xrpc
+from .routers import candidates, diversify, feed_transparency, health, rank, redirect, skylight, xrpc
 from .security import RequireApiKey
 from .lib.atproto_auth import init_id_resolver
 from .lib.firebase_auth import init_firebase_auth
@@ -346,6 +346,7 @@ app.include_router(feed_transparency.router)
 app.include_router(health.router)
 app.include_router(rank.router)
 app.include_router(skylight.router)
+app.include_router(redirect.router)
 app.include_router(xrpc.router)
 
 

--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -3,6 +3,8 @@ from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
 
+from ..lib.posthog_client import get_posthog_client, track_redirect
+
 router = APIRouter(tags=["redirect"])
 
 _UTM_KEYS = ("utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term")
@@ -38,4 +40,5 @@ async def redirect(
     new_query = urlencode({k: v[0] for k, v in existing.items()})
 
     destination = urlunparse(parsed._replace(query=new_query))
+    track_redirect(get_posthog_client(), to, extra)
     return RedirectResponse(url=destination, status_code=302)

--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -1,0 +1,41 @@
+from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import RedirectResponse
+
+router = APIRouter(tags=["redirect"])
+
+_UTM_KEYS = ("utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term")
+
+
+@router.get("/r", status_code=302, include_in_schema=True)
+async def redirect(
+    to: str | None = Query(None, description="Destination URL (must be https://)"),
+    utm_source: str | None = Query(None),
+    utm_medium: str | None = Query(None),
+    utm_campaign: str | None = Query(None),
+    utm_content: str | None = Query(None),
+    utm_term: str | None = Query(None),
+) -> RedirectResponse:
+    """302-redirect to *to* with any provided UTM params appended."""
+    if not to:
+        raise HTTPException(status_code=400, detail="to is required")
+    parsed: ParseResult = urlparse(to)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="to must be a valid https:// URL")
+
+    utm_values = {
+        "utm_source": utm_source,
+        "utm_medium": utm_medium,
+        "utm_campaign": utm_campaign,
+        "utm_content": utm_content,
+        "utm_term": utm_term,
+    }
+    extra = {k: v for k, v in utm_values.items() if v}
+
+    existing = parse_qs(parsed.query, keep_blank_values=False)
+    existing.update({k: [v] for k, v in extra.items()})
+    new_query = urlencode({k: v[0] for k, v in existing.items()})
+
+    destination = urlunparse(parsed._replace(query=new_query))
+    return RedirectResponse(url=destination, status_code=302)

--- a/src/app/routers/redirect_test.py
+++ b/src/app/routers/redirect_test.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+from ..main import app
+
+client = TestClient(app, follow_redirects=False)
+
+
+def test_redirect_basic():
+    response = client.get("/r?to=https://bsky.app/profile/greenearth.social")
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://bsky.app/profile/greenearth.social"
+
+
+def test_redirect_appends_utm_params():
+    response = client.get(
+        "/r?to=https://bsky.app/profile/greenearth.social"
+        "&utm_source=bluesky&utm_medium=social&utm_campaign=launch"
+    )
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "utm_source=bluesky" in location
+    assert "utm_medium=social" in location
+    assert "utm_campaign=launch" in location
+
+
+def test_redirect_preserves_existing_query_params():
+    response = client.get(
+        "/r?to=https://example.com/page%3Ffoo%3Dbar&utm_source=bluesky"
+    )
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "utm_source=bluesky" in location
+
+
+def test_redirect_missing_to_returns_400():
+    response = client.get("/r?utm_source=bluesky")
+    assert response.status_code == 400
+
+
+def test_redirect_non_https_returns_400():
+    response = client.get("/r?to=http://bsky.app")
+    assert response.status_code == 400
+
+
+def test_redirect_invalid_url_returns_400():
+    response = client.get("/r?to=not-a-url")
+    assert response.status_code == 400
+
+
+def test_redirect_omits_empty_utm_params():
+    response = client.get(
+        "/r?to=https://bsky.app&utm_source=bluesky&utm_medium="
+    )
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "utm_source=bluesky" in location
+    assert "utm_medium" not in location


### PR DESCRIPTION
## Summary

- Adds `GET /r` endpoint that validates `to` must be `https://`, appends any provided UTM params, and issues a `302` redirect
- Open redirect protection: rejects non-`https://` and missing `to` with 400

## Usage Example
`https://go.greenearth.social/r?to=https://bsky.app/profile/greenearth.social&utm_source=bluesky&utm_medium=social&utm_campaign=launch`

## Next Steps
- [x] Add `go.greenearth.social` in GCP Cloud DNS.
- [x] Add DNS Record (CNAME)
- [x] Domain mapping to `greenearth-api-prod` (@raindrift Could you do this? I can do it, but it needs to create an additional DNS config to get my account verified with the domain)
- [x] Create PostHog insights (e.g. Event: redirectClicked, Breakdown by: utm_source)
- [x] Do smoke test