### PR TITLE
Load test tooling: cleanup delete robustness + progress bars (#189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ profiles/
 
 # macOS metadata files
 .DS_Store
+
+load_test_data

--- a/scripts/load_test/cleanup.py
+++ b/scripts/load_test/cleanup.py
@@ -37,9 +37,12 @@ import asyncio
 import json
 import os
 import sys
+from contextlib import contextmanager
 
+from google.api_core.exceptions import InvalidArgument
 from google.cloud.firestore_v1.base_query import FieldFilter
 from rich.console import Console
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # scripts/
@@ -90,51 +93,143 @@ def _restrict_dids(path: str | None) -> set[str] | None:
     return {u["did"] for u in data.get("users", [])}
 
 
+# Firestore WriteBatch caps at 500 operations; also the page size we stream so no
+# single read stream stays open long enough to hit a gRPC deadline.
+DELETE_BATCH = 500
+
+
+async def _count_query(query) -> int | None:
+    """Total matching docs via a count() aggregation, or None if unavailable.
+
+    Only used to give the progress bar a denominator; a failure (e.g. an emulator
+    without aggregation support) just yields an indeterminate bar.
+    """
+    try:
+        result = await query.count().get()
+        return int(result[0][0].value)
+    except Exception:
+        return None
+
+
+@contextmanager
+def _delete_progress(label: str, total: int | None):
+    """A rich progress bar for a delete phase, yielding an ``advance(n)`` callback.
+
+    Auto-hidden when stdout isn't a TTY (piped output / CI).
+    """
+    progress = Progress(
+        TextColumn(f"[bold]deleting {label}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+        disable=None,
+    )
+    with progress:
+        task = progress.add_task(label, total=total)
+        yield lambda n: progress.advance(task, n)
+
+
 async def _delete_test_users(db, execute: bool) -> tuple[int, int]:
     """Delete all users flagged created_by_load_test. Returns (deleted, skipped)."""
     query = db.collection(USERS_COLLECTION).where(
         filter=FieldFilter("created_by_load_test", "==", True)
     )
+    # Drain the query into memory first so the read stream isn't held open across
+    # the (slow) per-user recursive deletes below — the same deadline trap that
+    # streaming-while-deleting hits on the interactions collection.
+    flagged: list[tuple[str, str | None]] = []
+    async for doc in query.stream():
+        data = doc.to_dict() or {}
+        flagged.append((data.get("user_did", doc.id), data.get("username")))
+
     deleted = skipped = 0
     table = Table(title="Load-test-created users", title_justify="left")
     table.add_column("did")
     table.add_column("username")
     table.add_column("action")
 
-    async for doc in query.stream():
-        data = doc.to_dict() or {}
-        did = data.get("user_did", doc.id)
-        if not execute:
-            table.add_row(did, data.get("username") or "—", "[yellow]would delete[/yellow]")
+    if not execute:
+        for did, username in flagged:
+            table.add_row(did, username or "—", "[yellow]would delete[/yellow]")
             deleted += 1
-            continue
+        console.print(table)
+        return deleted, skipped
 
-        # Re-read immediately before deleting: a real request may have cleared
-        # the flag between the query and now (the user became ours).
-        ref = db.collection(USERS_COLLECTION).document(user_doc_id(did))
-        fresh = await ref.get()
-        fresh_data = fresh.to_dict() or {}
-        if not fresh_data.get("created_by_load_test"):
-            table.add_row(did, data.get("username") or "—", "[dim]skipped (now real)[/dim]")
-            skipped += 1
-            continue
-        await db.recursive_delete(ref)
-        table.add_row(did, data.get("username") or "—", "[red]deleted[/red]")
-        deleted += 1
+    with _delete_progress("users", len(flagged)) as advance:
+        for did, username in flagged:
+            # Re-read immediately before deleting: a real request may have cleared
+            # the flag between the query and now (the user became ours).
+            ref = db.collection(USERS_COLLECTION).document(user_doc_id(did))
+            fresh = await ref.get()
+            if not (fresh.to_dict() or {}).get("created_by_load_test"):
+                table.add_row(did, username or "—", "[dim]skipped (now real)[/dim]")
+                skipped += 1
+            else:
+                await db.recursive_delete(ref)
+                table.add_row(did, username or "—", "[red]deleted[/red]")
+                deleted += 1
+            advance(1)
 
     console.print(table)
     return deleted, skipped
 
 
-async def _delete_flagged(db, collection: str, execute: bool) -> int:
-    """Delete all documents in ``collection`` with load_test == True."""
-    query = db.collection(collection).where(filter=FieldFilter("load_test", "==", True))
-    count = 0
-    async for doc in query.stream():
-        count += 1
-        if execute:
-            await doc.reference.delete()
-    return count
+async def _delete_flagged(db, collection: str, execute: bool, *, label: str | None = None) -> int:
+    """Delete all documents in ``collection`` with load_test == True.
+
+    Reads and deletes are kept separate and bounded. Each pass streams at most
+    ``DELETE_BATCH`` matching docs (a short-lived stream) and removes them in one
+    batched commit; deleted docs stop matching the filter, so the next pass
+    returns the following batch — no cursor needed, and nothing held open long
+    enough to trip a gRPC deadline (the failure mode of streaming the whole query
+    while deleting one document at a time).
+    """
+    base = db.collection(collection).where(filter=FieldFilter("load_test", "==", True))
+
+    if not execute:
+        # Dry run: a plain read stream is fast (no interleaved writes) — just count.
+        count = 0
+        async for _ in base.stream():
+            count += 1
+        return count
+
+    total = await _count_query(base)
+    deleted = 0
+    with _delete_progress(label or collection, total) as advance:
+        while True:
+            refs = [doc.reference async for doc in base.limit(DELETE_BATCH).stream()]
+            if not refs:
+                break
+            await _batch_delete(db, refs, advance)
+            deleted += len(refs)
+    return deleted
+
+
+async def _batch_delete(db, refs: list, advance) -> None:
+    """Delete ``refs`` in one batched commit, halving on 'transaction too big'.
+
+    A commit is capped both at 500 writes *and* at a maximum number of index-entry
+    mutations. Deleting heavily-indexed documents (feed_cache caches whole rendered
+    feeds) can exceed the latter well under 500 docs, raising INVALID_ARGUMENT. We
+    can't know a safe per-collection size up front, so recover by splitting the
+    batch and retrying — down to a single doc, whose failure is a real error.
+    """
+    if not refs:
+        return
+    batch = db.batch()
+    for ref in refs:
+        batch.delete(ref)
+    try:
+        await batch.commit()
+    except InvalidArgument:
+        if len(refs) == 1:
+            raise
+        mid = len(refs) // 2
+        await _batch_delete(db, refs[:mid], advance)
+        await _batch_delete(db, refs[mid:], advance)
+        return
+    advance(len(refs))
 
 
 async def _delete_suffixed_buckets(db, dids: set[str], execute: bool) -> int:

--- a/scripts/load_test/cleanup_test.py
+++ b/scripts/load_test/cleanup_test.py
@@ -44,8 +44,21 @@ def _make_db(*, user_stream, reread=None, flagged_stream=None):
     query = MagicMock()
     query.stream.side_effect = lambda: _AsyncIter(list(user_stream))
 
+    # load_test==True query. _delete_flagged pages it (limit().stream()) and
+    # deletes each page via a batch, so model deletion: `remaining` shrinks as
+    # batch.commit() applies the pending deletes, and the paged stream drains.
+    remaining = list(flagged_stream or [])
+    pending: list = []
+
     flagged_query = MagicMock()
-    flagged_query.stream.side_effect = lambda: _AsyncIter(list(flagged_stream or []))
+    flagged_query.stream.side_effect = lambda: _AsyncIter(list(remaining))
+
+    def _limit(n):
+        limited = MagicMock()
+        limited.stream.side_effect = lambda: _AsyncIter(remaining[:n])
+        return limited
+
+    flagged_query.limit.side_effect = _limit
 
     def _where(*, filter):  # noqa: A002 - mirrors the Firestore kwarg name
         field = getattr(filter, "field_path", "")
@@ -62,6 +75,17 @@ def _make_db(*, user_stream, reread=None, flagged_stream=None):
     collection.document.side_effect = _document
     db.collection.return_value = collection
     db.recursive_delete = AsyncMock()
+
+    batch = MagicMock()
+    batch.delete.side_effect = pending.append
+
+    def _commit():
+        dropped = {id(r) for r in pending}
+        remaining[:] = [d for d in remaining if id(d.reference) not in dropped]
+        pending.clear()
+
+    batch.commit = AsyncMock(side_effect=_commit)
+    db.batch.return_value = batch
     return db
 
 
@@ -96,24 +120,83 @@ async def test_execute_skips_user_that_became_real():
 
 
 @pytest.mark.asyncio
-async def test_delete_flagged_counts_and_deletes():
+async def test_delete_flagged_counts_and_batch_deletes():
     doc1, doc2 = MagicMock(), MagicMock()
-    doc1.reference.delete = AsyncMock()
-    doc2.reference.delete = AsyncMock()
     db = _make_db(user_stream=[], flagged_stream=[doc1, doc2])
     count = await cleanup._delete_flagged(db, "interactions", execute=True)
     assert count == 2
-    doc1.reference.delete.assert_awaited_once()
+    # Deleted via a batched commit, not per-doc, and both refs enqueued.
+    batch = db.batch.return_value
+    assert batch.delete.call_count == 2
+    batch.delete.assert_any_call(doc1.reference)
+    batch.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_flagged_paginates_until_empty():
+    # More docs than a single batch: must loop, deleting every one, and terminate.
+    docs = [MagicMock() for _ in range(cleanup.DELETE_BATCH + 7)]
+    db = _make_db(user_stream=[], flagged_stream=docs)
+    count = await cleanup._delete_flagged(db, "interactions", execute=True)
+    assert count == cleanup.DELETE_BATCH + 7
+    assert db.batch.return_value.delete.call_count == cleanup.DELETE_BATCH + 7
 
 
 @pytest.mark.asyncio
 async def test_delete_flagged_dry_run_does_not_delete():
     doc1 = MagicMock()
-    doc1.reference.delete = AsyncMock()
     db = _make_db(user_stream=[], flagged_stream=[doc1])
     count = await cleanup._delete_flagged(db, "feed_cache", execute=False)
     assert count == 1
-    doc1.reference.delete.assert_not_called()
+    db.batch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_splits_on_transaction_too_big():
+    # A backend that rejects any commit of more than 2 writes as "too big" — the
+    # heavy-feed_cache case. _batch_delete must split down until each commit fits
+    # and still delete every ref.
+    from google.api_core.exceptions import InvalidArgument
+
+    committed: list = []
+    max_ok = 2
+
+    def _make_batch():
+        pending: list = []
+        b = MagicMock()
+        b.delete.side_effect = pending.append
+
+        async def _commit():
+            if len(pending) > max_ok:
+                raise InvalidArgument("Transaction too big. Decrease transaction size.")
+            committed.extend(pending)
+
+        b.commit = AsyncMock(side_effect=_commit)
+        return b
+
+    db = MagicMock()
+    db.batch.side_effect = _make_batch
+
+    refs = [MagicMock() for _ in range(5)]
+    advanced: list = []
+    await cleanup._batch_delete(db, refs, advanced.append)
+
+    assert {id(r) for r in committed} == {id(r) for r in refs}
+    assert sum(advanced) == 5
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_reraises_single_doc_failure():
+    # If even a single-doc commit is rejected, it's a real error, not a size issue.
+    from google.api_core.exceptions import InvalidArgument
+
+    db = MagicMock()
+    batch = MagicMock()
+    batch.commit = AsyncMock(side_effect=InvalidArgument("nope"))
+    db.batch.return_value = batch
+
+    with pytest.raises(InvalidArgument):
+        await cleanup._batch_delete(db, [MagicMock()], lambda n: None)
 
 
 # --- dev fail-closed ---------------------------------------------------------

--- a/scripts/load_test/run.py
+++ b/scripts/load_test/run.py
@@ -39,6 +39,14 @@ from datetime import datetime, timezone
 
 import httpx
 from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
 from rich.table import Table
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # scripts/
@@ -313,29 +321,46 @@ async def run(args: argparse.Namespace) -> None:
             console.print(f"[dim]Feed {rkey}: {uri}[/dim]")
 
         start_wall = time.monotonic()
+        progress = Progress(
+            TextColumn("[bold]running"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("sessions"),
+            TimeElapsedColumn(),
+            TextColumn("[dim]eta[/dim]"),
+            TimeRemainingColumn(),
+            console=console,
+            # Off explicitly with --no-progress, and auto-off when stdout isn't a
+            # terminal (piped to a file / CI) so we don't spew control codes.
+            disable=True if args.no_progress else None,
+        )
 
-        async def _launch(session_id: int, delay: float) -> None:
-            now = time.monotonic() - start_wall
-            if delay > now:
-                await asyncio.sleep(delay - now)
-            async with semaphore:
-                user = weighted_cohort_choice(rng, users)
-                await run_session(
-                    session_id,
-                    user,
-                    client=client,
-                    api_url=api_url,
-                    feed_uri=feed_uris[user["feed"]],
-                    headers_for=headers_for,
-                    limit=args.limit,
-                    rng=random.Random(rng.random()),
-                    interaction_share=args.interaction_share,
-                    think_time_ms=args.think_time_ms,
-                    writer=writer,
-                )
+        with progress:
+            task_id = progress.add_task("run", total=len(offsets))
 
-        tasks = [asyncio.create_task(_launch(i, off)) for i, off in enumerate(offsets)]
-        await asyncio.gather(*tasks)
+            async def _launch(session_id: int, delay: float) -> None:
+                now = time.monotonic() - start_wall
+                if delay > now:
+                    await asyncio.sleep(delay - now)
+                async with semaphore:
+                    user = weighted_cohort_choice(rng, users)
+                    await run_session(
+                        session_id,
+                        user,
+                        client=client,
+                        api_url=api_url,
+                        feed_uri=feed_uris[user["feed"]],
+                        headers_for=headers_for,
+                        limit=args.limit,
+                        rng=random.Random(rng.random()),
+                        interaction_share=args.interaction_share,
+                        think_time_ms=args.think_time_ms,
+                        writer=writer,
+                    )
+                progress.advance(task_id)
+
+            tasks = [asyncio.create_task(_launch(i, off)) for i, off in enumerate(offsets)]
+            await asyncio.gather(*tasks)
 
     writer.close()
     _print_summary(writer.records)
@@ -411,6 +436,7 @@ def main() -> None:
     parser.add_argument("--secret", help="Load-test secret (else env / Secret Manager)")
     parser.add_argument("--out", default="results.jsonl")
     parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--no-progress", action="store_true", help="Hide the progress bar")
     parser.add_argument("--dry-run", action="store_true", help="Print the plan, send nothing")
     parser.add_argument("--force", action="store_true", help="Bypass the high-rate guardrail")
     args = parser.parse_args()


### PR DESCRIPTION
Follow-up to the merged #315 (simulated load testing, #189), from running it against prod.

## Cleanup: robust, batched deletes

Deleting a real run's data hit two separate Firestore limits:

- **`DEADLINE_EXCEEDED`** — the old loop streamed the whole `load_test` query while deleting one doc at a time, holding the read stream open past its gRPC deadline. Now each pass streams at most 500 matching docs and deletes them in one batched commit, looping until none match (deleted docs stop matching, so no cursor needed).
- **`INVALID_ARGUMENT: Transaction too big`** — a commit is capped both at 500 writes *and* at a maximum number of index-entry mutations. `feed_cache` docs cache whole rendered feeds with large indexed fields, so ~395 deletes exceeded the index limit even under 500 ops. A safe per-collection batch size can't be known up front, so `_batch_delete` halves the batch and retries on that error, recursing down to a single doc.

`_delete_test_users` now drains its query before the slow per-user `recursive_delete`s, avoiding the same deadline trap.

## Progress bars

- `run.py` shows a progress bar (sessions completed, live count + ETA) during a run, with `--no-progress`.
- Cleanup shows a bar per delete phase (total via a `count()` aggregation; indeterminate if unavailable).

Both auto-hide when stdout isn't a TTY.

## Verification

- Unit tests updated/added (pagination, adaptive split on "transaction too big", single-doc reraise); full `scripts/load_test/` suite green, ruff clean.
- Live against the Firestore emulator: 1,207 docs deleted in batches of 500 in <1s with the bar animating to completion. (The prod-only index-mutation limit isn't enforced by the emulator, so the split path is covered by unit tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)