### PR TITLE
Fix ES client concurrency bottleneck under load (#344)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn src.app.main:app --host 0.0.0.0 --port $PORT
+web: uvicorn src.app.main:app --host 0.0.0.0 --port $PORT --loop asyncio

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -61,6 +61,21 @@ from starlette.routing import BaseRoute, Match
 from starlette.types import Scope
 
 
+def _es_connections_per_node() -> int:
+    """Size of the ES client's per-node connection pool.
+
+    One feed render fans out to ~6-8 concurrent ES searches, so the
+    transport default of 10 connections serializes renders under load:
+    queries queue inside aiohttp while the event loop sits idle, showing
+    up as slow trivial queries and generator timeouts (api#344). aiohttp's
+    global connector limit is 100, so values above that have no effect.
+    """
+    try:
+        return int(os.environ.get("GE_ES_CONNECTIONS_PER_NODE", "100"))
+    except ValueError:
+        return 100
+
+
 def _reject_dev_session_secret_in_deployment() -> None:
     """Refuse to run with the dev-session escape hatch enabled outside local dev.
 
@@ -104,6 +119,7 @@ async def lifespan(app: FastAPI):
         api_key=es_api_key,
         verify_certs=es_verify,
         request_timeout=20,
+        connections_per_node=_es_connections_per_node(),
     )
 
     metrics = MetricCollector(

--- a/src/app/main_test.py
+++ b/src/app/main_test.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi import Request
 
-from .main import _is_deployed_environment, _resolve_endpoint, app
+from .main import _es_connections_per_node, _is_deployed_environment, _resolve_endpoint, app
 
 
 def _request_for(path: str, method: str = "GET") -> Request:
@@ -31,6 +31,21 @@ def test_resolve_endpoint_returns_route_name():
 
 def test_resolve_endpoint_none_for_unknown_path():
     assert _resolve_endpoint(_request_for("/no/such/route")) is None
+
+
+def test_es_connections_per_node_default(monkeypatch):
+    monkeypatch.delenv("GE_ES_CONNECTIONS_PER_NODE", raising=False)
+    assert _es_connections_per_node() == 100
+
+
+def test_es_connections_per_node_from_env(monkeypatch):
+    monkeypatch.setenv("GE_ES_CONNECTIONS_PER_NODE", "25")
+    assert _es_connections_per_node() == 25
+
+
+def test_es_connections_per_node_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("GE_ES_CONNECTIONS_PER_NODE", "lots")
+    assert _es_connections_per_node() == 100
 
 
 @pytest.mark.parametrize("env_value", ["prod", "production", "stage", "staging", "PROD", " stage "])


### PR DESCRIPTION
## Motivation

Load tests on 7/30 (#344) showed the api — not Elasticsearch — as the bottleneck: it needed 4 Cloud Run instances to serve ~1.5 qps, with candidate-generator failures (especially `two_tower`) and a flood of slow ES queries. Investigation traced this to two independent problems, both in how the api talks to ES.

## Root causes & fixes

**1. ES client connection pool starvation.** `AsyncElasticsearch` was created with the transport default of **10 connections per node**. A single `your-feed` render fans out to ~6–8 concurrent ES searches (three generators — `two_tower` alone issues likes + embeddings + kNN — plus embedding hydration and the ranker's history fetch). Under load, slow kNN searches hold all 10 connections and every other query queues *inside aiohttp on the client*. In the prod logs this showed up as ~1,100 `slow_es_query` warnings at p50 ≈ 918ms — including trivial `terms` lookups ES serves in ~10ms (queue wait, not ES time) — while instance CPU only peaked at ~64%. Adding instances "helped" only because each brought its own pool of 10.

Fix: default `connections_per_node` to 100 (aiohttp's global connector cap; higher has no effect), overridable via `GE_ES_CONNECTIONS_PER_NODE`.

**2. uvloop + aiohttp file-descriptor race.** Both 150qpm windows burst hundreds of `Bad file descriptor` `ClientOSError`s with uvloop `create_connection` frames — the known uvloop fd-bookkeeping race (uvloop#646/#653) under connection churn and `asyncio.wait_for` cancellation storms. Once triggered it poisons unrelated connections (perspective, inference) process-wide. Reproduced in the local devenv at 48-way concurrency on uvloop (`RuntimeError: File descriptor N is used by transport`); clean on the plain asyncio loop at identical load. The upstream root-cause fix (uvloop#740) is merged but unreleased (latest PyPI is 0.22.1), and aiohttp's workaround was reverted in 3.11.15 — so pin the loop for now.

Fix: run uvicorn with `--loop asyncio`. The api is I/O-bound on a 1-vCPU instance, so uvloop's throughput edge is irrelevant here.

## Validation

- Full api suite passes (997 tests); new unit tests cover `GE_ES_CONNECTIONS_PER_NODE` parsing.
- devenv A/B (pool=10 vs pool=100) at 16-way concurrency: pool=100 wins p50 3.2s vs 3.8s with full 30-item feeds. The uvloop fd race reproduced on demand and vanished on the asyncio loop.
- **Not yet validated at scale against stage/prod** — the bigger pool pushes genuinely more concurrent load into prod ES, so a stage load-test rerun (`scripts/load_test/`) is worth doing before/after deploy, watching ES latency and rejections.

Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)