### PR TITLE
Load test: auto-cleanup, fix server-side percentiles, quiet gcloud (#189)

### DIFF
--- a/scripts/load_test/README.md
+++ b/scripts/load_test/README.md
@@ -10,9 +10,9 @@ Four scripts, run in order:
 | Step | Script | What it does |
 |---|---|---|
 | 1 | `select_users.py` | Pick a diverse cohort of real user DIDs → JSON manifest |
-| 2 | `run.py` | Generate load (getFeedSkeleton + paging + sendInteractions), write per-request JSONL |
+| 2 | `run.py` | Generate load (getFeedSkeleton + paging + sendInteractions), write per-request JSONL, then clean up (unless `--skip-cleanup`) |
 | 3 | `analyze.py` | Report client-side latency + server-side percentiles from the JSONL |
-| 4 | `cleanup.py` | Delete the data the run created, restoring the pre-run baseline |
+| 4 | `cleanup.py` | Delete the data the run created, restoring the pre-run baseline (run automatically by step 2; also standalone) |
 
 ## How test traffic is isolated
 
@@ -109,6 +109,11 @@ pipenv run python scripts/load_test/run.py \
   resulting per-feed user counts.
 - `--api-url` overrides URL resolution; `--secret` overrides secret resolution.
 - `--dry-run` prints the schedule and feed assignment, and sends nothing.
+- **Cleanup runs automatically** when the run finishes: `run.py` invokes
+  `cleanup.py --environment <env> --users <manifest> --execute` for you. Pass
+  `--skip-cleanup` to leave the data in place (it then prints the exact cleanup
+  command to run later — e.g. when you want to inspect the data first). Analysis
+  reads only the JSONL, so cleaning up first never affects it.
 
 Prints a client-side latency summary and writes one JSONL record per HTTP call
 (each stamped with the feed it hit).
@@ -135,8 +140,10 @@ has no Cloud Monitoring). Accepts multiple `--results` files.
 
 ### 4. Cleanup
 
-The goal is always to remove **everything** the run created. Dry run by default;
-`--execute` actually deletes.
+Step 2 already runs this for you unless you passed `--skip-cleanup`. Run it
+standalone when you skipped it, want a dry-run preview first, or are mopping up
+after several runs. The goal is always to remove **everything** the run created.
+Dry run by default; `--execute` actually deletes.
 
 ```bash
 # Preview
@@ -186,12 +193,15 @@ The bypass is off in dev by default. To smoke-test the whole flow locally:
    ```
    (The ES API key comes from the container's `GE_ELASTICSEARCH_API_KEY`.)
 
-3. **Run** — point at the api's in-container port and pass the dev secret:
+3. **Run** — point at the api's in-container port and pass the dev secret. Use
+   `--skip-cleanup` here: `run.py` only knows `stage`/`prod` environments, so its
+   automatic cleanup would target real **stage** Firestore, not the dev emulator.
+   Clean up dev explicitly in step 4 instead.
    ```bash
    devctl exec api pipenv run python scripts/load_test/run.py \
        --users scripts/load_test/users.json \
        --api-url http://127.0.0.1:8000 --secret ge-dev-load-test \
-       --rate 20 --duration 1 --interaction-share 0.8 \
+       --rate 20 --duration 1 --interaction-share 0.8 --skip-cleanup \
        --out scripts/load_test/results.jsonl
    ```
 
@@ -207,4 +217,3 @@ The bypass is off in dev by default. To smoke-test the whole flow locally:
 
 Inspect emulator state before/after in the Firestore emulator UI
 (http://localhost:4000/firestore) to confirm cleanup restored the baseline.
-```

--- a/scripts/load_test/analyze.py
+++ b/scripts/load_test/analyze.py
@@ -33,7 +33,7 @@ from rich.table import Table
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # scripts/
 
-from load_test.lib import CLOUD_RUN_SERVICES, GCP_PROJECT, percentiles
+from load_test.lib import CLOUD_RUN_SERVICES, GCP_PROJECT, gcloud_env, percentiles
 
 console = Console()
 
@@ -106,13 +106,19 @@ def _client_summary(records: list[dict]) -> None:
 # It separates stage from prod, which share the project and the metric type.
 ENV_RESOURCE_LABEL = "namespace"
 
-# The percentiles to pull, mapped to Cloud Monitoring per-series aligners. The
-# distribution metric is reduced server-side, so we never reconstruct it
-# client-side (no cumulative double-counting, no mean-of-means).
-_PERCENTILE_ALIGNERS = {
-    50: "ALIGN_PERCENTILE_50",
-    95: "ALIGN_PERCENTILE_95",
-    99: "ALIGN_PERCENTILE_99",
+# The percentiles to pull, mapped to Cloud Monitoring cross-series reducers.
+# feed.render.duration_ms is exported as a CUMULATIVE DISTRIBUTION, and the
+# ALIGN_PERCENTILE_* *aligners* reject that metric kind. Instead we align with
+# ALIGN_DELTA (valid on cumulative → a per-period delta distribution) and take
+# the percentile with a REDUCE_PERCENTILE_* *reducer*, which accepts
+# distribution-typed series. It's all server-side, so we never reconstruct the
+# distribution client-side (no cumulative double-counting, no mean-of-means);
+# and reducing merges the per-instance distributions before taking the
+# percentile, rather than averaging per-instance percentiles.
+_PERCENTILE_REDUCERS = {
+    50: "REDUCE_PERCENTILE_50",
+    95: "REDUCE_PERCENTILE_95",
+    99: "REDUCE_PERCENTILE_99",
 }
 
 
@@ -127,16 +133,17 @@ def build_percentile_request(
 ):
     """Build a ListTimeSeries request for one percentile, grouped by traffic class.
 
-    Server-side aggregation aligns each series to the requested percentile over
-    the whole window, then reduces across series (e.g. per-instance) within each
-    ``traffic`` label. Filtered to one environment so stage and prod — which
+    Each series is aligned with ALIGN_DELTA over the whole window (converting the
+    cumulative distribution to a single delta distribution per series), then
+    reduced across series (e.g. per-instance) within each ``traffic`` label to the
+    requested percentile. Filtered to one environment so stage and prod — which
     write the same metric type to the same project — are never mixed.
     """
-    aligner = getattr(monitoring_v3.Aggregation.Aligner, _PERCENTILE_ALIGNERS[percentile])
+    reducer = getattr(monitoring_v3.Aggregation.Reducer, _PERCENTILE_REDUCERS[percentile])
     aggregation = monitoring_v3.Aggregation(
         alignment_period={"seconds": alignment_seconds},
-        per_series_aligner=aligner,
-        cross_series_reducer=monitoring_v3.Aggregation.Reducer.REDUCE_MEAN,
+        per_series_aligner=monitoring_v3.Aggregation.Aligner.ALIGN_DELTA,
+        cross_series_reducer=reducer,
         group_by_fields=["metric.label.traffic"],
     )
     return monitoring_v3.ListTimeSeriesRequest(
@@ -175,7 +182,7 @@ def _server_metrics(project: str, env: str, start: datetime, end: datetime) -> N
     # traffic -> {percentile -> value}
     by_traffic: dict[str, dict[int, float]] = defaultdict(dict)
     try:
-        for percentile in _PERCENTILE_ALIGNERS:
+        for percentile in _PERCENTILE_REDUCERS:
             request = build_percentile_request(
                 monitoring_v3, project, metric, env, interval, percentile, alignment_seconds
             )
@@ -238,6 +245,7 @@ def _server_logs(service: str, project: str, start: datetime, end: datetime) -> 
                     "1000",
                 ],
                 text=True,
+                env=gcloud_env(),
             )
             count = len([ln for ln in out.splitlines() if ln.strip()])
             console.print(f"  {label}: [bold]{count}[/bold]")

--- a/scripts/load_test/analyze_test.py
+++ b/scripts/load_test/analyze_test.py
@@ -26,19 +26,29 @@ def test_aggregates_percentile_grouped_by_traffic():
         monitoring_v3, "p", "m", "stage", _interval(), 99, alignment_seconds=600,
     )
     agg = req.aggregation
-    assert agg.per_series_aligner == monitoring_v3.Aggregation.Aligner.ALIGN_PERCENTILE_99
-    assert agg.cross_series_reducer == monitoring_v3.Aggregation.Reducer.REDUCE_MEAN
+    # ALIGN_DELTA is the only aligner valid on a CUMULATIVE DISTRIBUTION; the
+    # percentile is taken by the cross-series reducer, not the aligner.
+    assert agg.per_series_aligner == monitoring_v3.Aggregation.Aligner.ALIGN_DELTA
+    assert agg.cross_series_reducer == monitoring_v3.Aggregation.Reducer.REDUCE_PERCENTILE_99
     assert list(agg.group_by_fields) == ["metric.label.traffic"]
     assert agg.alignment_period.seconds == 600
 
 
-def test_each_percentile_maps_to_its_aligner():
+def test_each_percentile_maps_to_its_reducer():
+    reducers = {
+        p: build_percentile_request(
+            monitoring_v3, "p", "m", "stage", _interval(), p, alignment_seconds=60
+        ).aggregation.cross_series_reducer
+        for p in (50, 95, 99)
+    }
+    assert reducers[50] == monitoring_v3.Aggregation.Reducer.REDUCE_PERCENTILE_50
+    assert reducers[95] == monitoring_v3.Aggregation.Reducer.REDUCE_PERCENTILE_95
+    assert reducers[99] == monitoring_v3.Aggregation.Reducer.REDUCE_PERCENTILE_99
+    # Every percentile is aligned the same way — with ALIGN_DELTA.
     aligners = {
         p: build_percentile_request(
             monitoring_v3, "p", "m", "stage", _interval(), p, alignment_seconds=60
         ).aggregation.per_series_aligner
         for p in (50, 95, 99)
     }
-    assert aligners[50] == monitoring_v3.Aggregation.Aligner.ALIGN_PERCENTILE_50
-    assert aligners[95] == monitoring_v3.Aggregation.Aligner.ALIGN_PERCENTILE_95
-    assert aligners[99] == monitoring_v3.Aggregation.Aligner.ALIGN_PERCENTILE_99
+    assert set(aligners.values()) == {monitoring_v3.Aggregation.Aligner.ALIGN_DELTA}

--- a/scripts/load_test/lib.py
+++ b/scripts/load_test/lib.py
@@ -10,8 +10,21 @@ for the runnable entry points.
 from __future__ import annotations
 
 import math
+import os
 import random
 from dataclasses import dataclass
+
+
+def gcloud_env() -> dict[str, str]:
+    """Environment for ``gcloud`` subprocesses that keeps gRPC fork noise quiet.
+
+    ``gcloud`` is a gRPC client that forks worker processes, and gRPC's C-core
+    event engine logs a benign INFO line ("FD from fork parent still in poll
+    list") for every inherited fd on each fork — nothing actionable, just noise
+    that drowns the report. ``GRPC_VERBOSITY=ERROR`` drops those INFO lines while
+    keeping real errors visible.
+    """
+    return {**os.environ, "GRPC_VERBOSITY": "ERROR"}
 
 # GCP project + Firestore database per environment. Both environments live in
 # the same project and are separated by database (mirrors feed_debug.py and

--- a/scripts/load_test/run.py
+++ b/scripts/load_test/run.py
@@ -7,10 +7,13 @@ load-test bypass headers (``X-Load-Test-Secret`` / ``X-Load-Test-DID``) so the
 server skips AT Protocol auth, tags all resulting data as test traffic, and
 skips analytics — see load_test_did in src/app/routers/xrpc.py.
 
-This script only *generates* load and records raw per-request results to a JSONL
-file. Analyze the results afterwards with scripts/load_test/analyze.py, which
-reads that file (and Cloud Monitoring / logs) and never touches Firestore — so
-you can run scripts/load_test/cleanup.py before analysis if you like.
+This script *generates* load, records raw per-request results to a JSONL file,
+and — unless ``--skip-cleanup`` is given — deletes the data it created by
+invoking scripts/load_test/cleanup.py --execute when the run finishes (with
+``--skip-cleanup`` it prints that command for you to run later). Analyze the
+results afterwards with scripts/load_test/analyze.py, which reads only the JSONL
+file (and Cloud Monitoring / logs) and never touches Firestore — so cleanup
+running first never affects analysis.
 
 Run from the api/ directory:
 
@@ -57,6 +60,7 @@ from load_test.lib import (
     assign_feeds,
     build_interactions,
     feed_uri_from_describe,
+    gcloud_env,
     interactions_request_body,
     parse_feed_spec,
     percentiles,
@@ -89,6 +93,7 @@ def _resolve_api_url(args: argparse.Namespace) -> str:
             "value(status.url)",
         ],
         text=True,
+        env=gcloud_env(),
     ).strip()
     if not out:
         raise SystemExit(f"Could not resolve Cloud Run URL for {service}")
@@ -106,6 +111,7 @@ def _resolve_secret(args: argparse.Namespace) -> str:
         return subprocess.check_output(
             ["gcloud", "secrets", "versions", "access", "latest", "--secret", secret_name],
             text=True,
+            env=gcloud_env(),
         ).strip()
     except subprocess.CalledProcessError as exc:  # pragma: no cover - env dependent
         raise SystemExit(f"Could not read {secret_name} from Secret Manager: {exc}") from exc
@@ -366,6 +372,50 @@ async def run(args: argparse.Namespace) -> None:
     _print_summary(writer.records)
     console.print(f"[green]Wrote {args.out} ({len(writer.records)} records)[/green]")
 
+    _run_cleanup(args)
+
+
+def _cleanup_command(args: argparse.Namespace) -> list[str]:
+    """The cleanup invocation matching this run — deletes everything it created."""
+    cleanup_py = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cleanup.py")
+    return [
+        sys.executable,
+        cleanup_py,
+        "--environment",
+        args.environment,
+        "--users",
+        args.users,
+        "--execute",
+    ]
+
+
+def _cleanup_display(args: argparse.Namespace) -> str:
+    """Copy-pasteable form of the cleanup command (relative, no venv python path)."""
+    return (
+        "pipenv run python scripts/load_test/cleanup.py "
+        f"--environment {args.environment} --users {args.users} --execute"
+    )
+
+
+def _run_cleanup(args: argparse.Namespace) -> None:
+    """Delete this run's data unless --skip-cleanup; if skipped, show how to later."""
+    if args.skip_cleanup:
+        console.print(
+            "\n[yellow]--skip-cleanup: test data left in Firestore. "
+            "Remove it later with:[/yellow]\n"
+            f"  [bold]{_cleanup_display(args)}[/bold]"
+        )
+        return
+    console.print(
+        "\n[bold]Cleaning up test data[/bold] [dim](pass --skip-cleanup to keep it)[/dim]"
+    )
+    result = subprocess.run(_cleanup_command(args))
+    if result.returncode != 0:
+        console.print(
+            f"[red]Cleanup failed (exit {result.returncode}). Re-run manually:[/red]\n"
+            f"  [bold]{_cleanup_display(args)}[/bold]"
+        )
+
 
 def _print_feed_plan(users: list[dict], feed_weights: list[tuple[str, float]]) -> None:
     assigned: dict[str, int] = {}
@@ -437,6 +487,12 @@ def main() -> None:
     parser.add_argument("--out", default="results.jsonl")
     parser.add_argument("--seed", type=int, default=1234)
     parser.add_argument("--no-progress", action="store_true", help="Hide the progress bar")
+    parser.add_argument(
+        "--skip-cleanup",
+        action="store_true",
+        help="Don't delete the run's data afterwards (cleanup runs by default); "
+        "prints the cleanup command to run later instead.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print the plan, send nothing")
     parser.add_argument("--force", action="store_true", help="Bypass the high-rate guardrail")
     args = parser.parse_args()


### PR DESCRIPTION
Follow-up to the load-testing tooling (#189), on top of the merged #342.

## Changes

**Auto-cleanup after each run.** `run.py` now runs `cleanup.py --execute` for the run's environment + manifest when it finishes. `--skip-cleanup` opts out and prints the exact cleanup command to run later (e.g. to inspect the data first). Analysis reads only the JSONL, so cleaning up first never affects it. The local-devenv recipe uses `--skip-cleanup` and cleans up explicitly with `--environment dev`, since `run.py` only knows `stage`/`prod` and its auto-cleanup would otherwise target real *stage* Firestore.

**Fix server-side `feed.render.duration_ms` percentiles.** The Cloud Monitoring query failed with `The aligner cannot be applied to metrics with kind CUMULATIVE and value type DISTRIBUTION`. The OTel histogram is exported as a cumulative distribution, which the `ALIGN_PERCENTILE_*` *aligners* reject. Now the query aligns with `ALIGN_DELTA` (valid on cumulative → per-period delta distribution) and takes the percentile via a `REDUCE_PERCENTILE_*` *reducer*, which accepts distribution-typed series — and merges the per-instance distributions before computing the percentile rather than averaging per-instance percentiles.

**Quiet gcloud gRPC fork noise.** `gcloud` is a gRPC client that forks workers, and gRPC's C-core logs a benign INFO `FD from fork parent still in poll list` line per inherited fd on each fork, flooding the report. A shared `gcloud_env()` helper sets `GRPC_VERBOSITY=ERROR` on all `gcloud` subprocess calls (real errors still surface).

Also: README updated for the above; a stray unmatched code fence removed.

## Testing

- `scripts/load_test/` suite green (53 tests), including updated `analyze_test.py` for the new aggregation shape.
- ruff clean of newly-introduced issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)