### PR TITLE
Stamp deployed git sha on feeds, revisions, and /health (#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,37 @@ ENVIRONMENT=prod \
 
 The deployment script will:
 
+- Refuse to run with a dirty working tree (see below)
 - Generate `requirements.txt` from `Pipfile`
 - Auto-detect the Elasticsearch internal load balancer IP
 - Build the container using Google Cloud buildpacks
 - Deploy to Cloud Run with proper environment variables and secrets
+- Stamp the deployed git sha onto the revision and the debug feed records
 
 API deployments do not change Firebase configuration. Deploy Firebase rules,
 indexes, TTL policies, Functions, and Hosting from the frontend repository.
+
+#### Deployments must be from a clean tree (git sha traceability)
+
+So we always know exactly what code is live, `deploy.sh` **refuses to deploy
+with uncommitted changes**. Deploying an unpushed branch is fine — only a dirty
+working tree is rejected. Commit or stash first, then deploy.
+
+Each deploy stamps its short git sha in three places:
+
+- **Cloud Run env var `GE_GIT_SHA`** — the running app reports it at
+  `GET /health` (`{"status":"ok","git_sha":"e9f07f5"}`). Use this to confirm
+  which revision is live.
+- **Cloud Run label `git-sha=<sha>`** — tags the service/revision so past
+  deployments are identifiable when picking a rollback target
+  (`gcloud run revisions list --format='value(metadata.name,metadata.labels.git-sha)'`).
+- **Debug feed display names + descriptions** — every internal ("debug") feed
+  record is published as e.g. `GE e2 S e9f07f5`, with `Built by Caterpie · e9f07f5`
+  in the description. The public prod GreenEarth feeds are left unstamped.
+
+**Reporting a bug against a feed?** Open the debug feed in Bluesky and copy the
+trailing sha from its name (e.g. `e9f07f5`) into the report — it pins the bug to
+the exact deployed code. You can also read the live sha off `GET /health`.
 
 Inference endpoint resolution order during deploy:
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -292,38 +292,54 @@ deploy_api_service() {
     # identifiable when picking a rollback target (see issue #228).
     deploy_cmd="$deploy_cmd --labels=git-sha=$GIT_SHA"
 
+    # Fold GE_FEED_GENERATOR_DID into this single deploy whenever we can resolve
+    # it up front (prod is a constant; stage/dev is derived from the service URL,
+    # which is stable once the service exists). This avoids emitting a second,
+    # otherwise-identical revision from a post-deploy `services update` — and
+    # keeps the git-sha label on the revision that actually serves traffic. Only
+    # a brand-new service (first-ever deploy) can't be resolved yet; that case
+    # falls back to a follow-up update below. Note the emulator host vars need no
+    # explicit removal here: --set-env-vars replaces the whole env set, so any
+    # GE_FIRESTORE_EMULATOR_HOST/FIRESTORE_EMULATOR_HOST are dropped by omission.
+    local generator_did=""
+    local did_in_deploy=false
+    if generator_did=$(resolve_generator_did); then
+        deploy_cmd="$deploy_cmd --set-env-vars=GE_FEED_GENERATOR_DID=$generator_did"
+        did_in_deploy=true
+    fi
+
     # Allow unauthenticated access (adjust based on your needs)
     deploy_cmd="$deploy_cmd --allow-unauthenticated"
 
     log_build "Executing: $deploy_cmd"
-    eval "$deploy_cmd"
+    if ! eval "$deploy_cmd"; then
+        log_error "Failed to deploy greenearth-api-$ENVIRONMENT"
+        exit 1
+    fi
 
-    if [ $? -eq 0 ]; then
-        log_info "✓ greenearth-api-$ENVIRONMENT deployed successfully"
+    log_info "✓ greenearth-api-$ENVIRONMENT deployed successfully"
 
-        # Get the service URL
-        local service_url=$(gcloud run services describe greenearth-api-$ENVIRONMENT --region="$REGION" --project="$PROJECT_ID" --format="value(status.url)")
-        log_info "Service URL: $service_url"
+    local service_url
+    service_url=$(gcloud run services describe "greenearth-api-$ENVIRONMENT" --region="$REGION" --project="$PROJECT_ID" --format="value(status.url)")
+    log_info "Service URL: $service_url"
 
-        # Ensure runtime DID is explicitly set so /.well-known/did.json is env-correct
-        local generator_did
-        if [ "$ENVIRONMENT" = "prod" ]; then
-            generator_did="did:web:api.greenearth.social"
-        else
-            local service_host
-            service_host=$(echo "$service_url" | sed 's|https://||')
-            generator_did="did:web:$service_host"
-        fi
-
+    if [ "$did_in_deploy" = true ]; then
+        log_info "Set GE_FEED_GENERATOR_DID=$generator_did"
+    else
+        # First-ever deploy: the service URL wasn't known until the service
+        # existed, so set the DID now. This creates one extra revision, but only
+        # once in a service's lifetime — every later deploy folds the DID in
+        # above. Carry the git-sha label onto this revision too.
+        local service_host
+        service_host=$(echo "$service_url" | sed 's|https://||')
+        generator_did="did:web:$service_host"
         gcloud run services update "greenearth-api-$ENVIRONMENT" \
             --region="$REGION" \
             --project="$PROJECT_ID" \
+            --labels="git-sha=$GIT_SHA" \
             --update-env-vars="GE_FEED_GENERATOR_DID=$generator_did" \
             --remove-env-vars="GE_FIRESTORE_EMULATOR_HOST,FIRESTORE_EMULATOR_HOST" > /dev/null
-        log_info "Set GE_FEED_GENERATOR_DID=$generator_did"
-    else
-        log_error "Failed to deploy greenearth-api-$ENVIRONMENT"
-        exit 1
+        log_info "Set GE_FEED_GENERATOR_DID=$generator_did (follow-up revision)"
     fi
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,6 +20,11 @@ GE_ELASTICSEARCH_URL="INTERNAL_LB_PLACEHOLDER"
 # Inference configuration
 GE_INFERENCE_BASE_URL=""
 
+# Short git sha of the deployed code, resolved by require_clean_worktree().
+# Stamped onto the Cloud Run revision (env var + label) and onto debug feed
+# records so we can identify exactly what code is live (see issue #228).
+GIT_SHA=""
+
 # PostHog configuration. Each environment is a separate PostHog project (separate
 # API key, provisioned via scripts/gcp_setup.sh), but all projects live on the same
 # PostHog Cloud host, so the host is a constant here rather than a per-env secret.
@@ -66,6 +71,30 @@ resolve_inference_base_url() {
     inference_domain="$(default_inference_domain)"
     GE_INFERENCE_BASE_URL="https://$inference_domain"
     log_info "Using mapped inference URL: $GE_INFERENCE_BASE_URL"
+}
+
+require_clean_worktree() {
+    log_info "Verifying git working tree is clean..."
+
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        log_error "Not inside a git repository — cannot verify the deployed code."
+        log_error "Run deploy.sh from a checkout of the api repo."
+        exit 1
+    fi
+
+    # Refuse to deploy with uncommitted changes so the stamped git sha always
+    # matches the code that ships. Deploying an unpushed branch is fine — only a
+    # dirty tree is rejected (see issue #228).
+    if [ -n "$(git status --porcelain)" ]; then
+        log_error "Working tree has uncommitted changes. Commit or stash them before deploying"
+        log_error "so the deployed git sha reflects the running code."
+        git status --short
+        exit 1
+    fi
+
+    GIT_SHA="$(git rev-parse --short=7 HEAD)"
+    export GE_GIT_SHA="$GIT_SHA"  # picked up by publish_feed.py during feed sync
+    log_info "Deploying git sha: $GIT_SHA ($(git rev-parse --abbrev-ref HEAD))"
 }
 
 validate_config() {
@@ -220,6 +249,9 @@ deploy_api_service() {
     # Set environment variables. The app derives its default log level from
     # ENVIRONMENT (stage/prod -> WARNING, else INFO). Override with GE_LOG_LEVEL.
     deploy_cmd="$deploy_cmd --set-env-vars=ENVIRONMENT=$ENVIRONMENT"
+    # Stamp the deployed git sha so the app can report it (e.g. /health) and so
+    # revisions are identifiable for rollbacks (see issue #228).
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_GIT_SHA=$GIT_SHA"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_ELASTICSEARCH_URL=$GE_ELASTICSEARCH_URL"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_ELASTICSEARCH_VERIFY_SSL=false"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_FIRESTORE_PROJECT=$PROJECT_ID"
@@ -255,6 +287,10 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --memory=512Mi"
     deploy_cmd="$deploy_cmd --timeout=$API_REQUEST_TIMEOUT"
     deploy_cmd="$deploy_cmd --concurrency=80"
+
+    # Tag the service/revision with the git sha so past deployments are
+    # identifiable when picking a rollback target (see issue #228).
+    deploy_cmd="$deploy_cmd --labels=git-sha=$GIT_SHA"
 
     # Allow unauthenticated access (adjust based on your needs)
     deploy_cmd="$deploy_cmd --allow-unauthenticated"
@@ -384,6 +420,7 @@ main() {
     log_info "Region: $REGION"
     log_info "Environment: $ENVIRONMENT"
 
+    require_clean_worktree
     validate_config
     verify_vpc_connector
 

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -47,6 +47,7 @@ import argparse
 import getpass
 import os
 import pathlib
+import subprocess
 import sys
 from typing import Literal
 
@@ -58,6 +59,11 @@ sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent / "src
 from app.feeds import FEEDS  # type: ignore
 
 DEFAULT_PDS = "https://bsky.social"
+
+# AT Protocol app.bsky.feed.generator caps displayName at 24 graphemes. We append
+# the deployed git sha to internal ("debug") feed names, so guard the composed
+# name against this budget rather than only the base name.
+MAX_DISPLAY_NAME_GRAPHEMES = 24
 
 ENV_DISPLAY_PREFIX: dict[str, str] = {
     "dev": "GE Dev",
@@ -83,6 +89,48 @@ def _normalize_environment(environment: str | None) -> str | None:
     if not environment:
         return None
     return ENV_ALIASES.get(environment.strip().lower())
+
+
+def _git_short_sha() -> str | None:
+    """Return the short git sha to stamp onto debug feed records.
+
+    Prefers ``GE_GIT_SHA`` (set by ``deploy.sh`` from the clean tree it verified)
+    so the published sha always matches the deployed code. Falls back to the
+    local ``HEAD`` for manual/local publishes. Returns ``None`` when neither is
+    available (e.g. not a git checkout), in which case names are left unstamped.
+    """
+    env_sha = os.environ.get("GE_GIT_SHA")
+    if env_sha and env_sha.strip():
+        return env_sha.strip()[:7]
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short=7", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=pathlib.Path(__file__).parent.parent,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _with_git_sha(display_name: str, git_sha: str | None) -> str:
+    """Append *git_sha* to *display_name*, guarding the 24-grapheme budget.
+
+    Raises ``ValueError`` if the composed name would exceed the AT Protocol
+    displayName limit — a loud failure at publish time is preferable to Bluesky
+    silently truncating the sha, which would make it unusable for identifying
+    deployed code.
+    """
+    name = f"{display_name} {git_sha}" if git_sha else display_name
+    if len(name) > MAX_DISPLAY_NAME_GRAPHEMES:
+        raise ValueError(
+            f"Feed display name {name!r} is {len(name)} chars, exceeding the "
+            f"{MAX_DISPLAY_NAME_GRAPHEMES}-grapheme AT Protocol limit. Shorten "
+            "the feed's internal_display_name."
+        )
+    return name
 
 
 def _resolve_environment(cli_environment: str | None) -> str | None:
@@ -411,8 +459,15 @@ def _resolve_feed_publish_params(
     rkey: str,
     feed_cfg,
     normalized_env: str | None,
+    git_sha: str | None = None,
 ) -> tuple[str, str, str]:
-    """Return (published_rkey, display_name, description) for a feed based on routing rules."""
+    """Return (published_rkey, display_name, description) for a feed based on routing rules.
+
+    Internal ("debug") feeds are stamped with *git_sha* in both the display name
+    and description so testers can tell exactly which deployed code produced a
+    feed. The public prod GreenEarth records are left unstamped — real users see
+    them and the sha would be noise there.
+    """
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
         return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
@@ -422,7 +477,9 @@ def _resolve_feed_publish_params(
         published_display_name = f"GE {base_display_name}"
     else:
         published_display_name = base_display_name
-    return published_rkey, published_display_name, "Built by Caterpie"
+    published_display_name = _with_git_sha(published_display_name, git_sha)
+    description = f"Built by Caterpie · {git_sha}" if git_sha else "Built by Caterpie"
+    return published_rkey, published_display_name, description
 
 
 def sync_feeds(
@@ -432,6 +489,7 @@ def sync_feeds(
     generator_did: str,
     environment: str | None = None,
     visibility: Literal["public", "internal"] | None = None,
+    git_sha: str | None = None,
     pds: str = DEFAULT_PDS,
 ) -> None:
     """Sync published feed records with the FEEDS config.
@@ -440,6 +498,9 @@ def sync_feeds(
     *visibility* when set) and deletes any existing records whose rkey is
     *not* in the desired set.  Because ``putRecord`` is an upsert, feeds that
     already exist are updated in place without a visible gap.
+
+    *git_sha*, when provided, is stamped onto internal (debug) feed records so
+    testers can identify the deployed code behind a feed.
     """
     feed_items = list(FEEDS.items())
     if visibility == "public":
@@ -466,7 +527,7 @@ def sync_feeds(
         desired_rkeys: set[str] = set()
         for rkey, feed_cfg in feed_items:
             published_rkey, display_name, description = _resolve_feed_publish_params(
-                rkey, feed_cfg, normalized_env
+                rkey, feed_cfg, normalized_env, git_sha
             )
             desired_rkeys.add(published_rkey)
             avatar_blob = _upload_blob(client, pds, access_jwt, feed_cfg.avatar)
@@ -596,6 +657,14 @@ def main() -> None:
         default=DEFAULT_PDS,
         help=f"PDS endpoint to authenticate against (default: {DEFAULT_PDS})",
     )
+    parser.add_argument(
+        "--git-sha",
+        default=None,
+        help=(
+            "Short git sha to stamp onto internal (debug) feed names/descriptions. "
+            "Falls back to GE_GIT_SHA, then to the local HEAD sha."
+        ),
+    )
     args = parser.parse_args()
 
     # Load .env file to pick up GE_FEED_GENERATOR_DID and other env vars
@@ -643,6 +712,7 @@ def main() -> None:
             generator_did=generator_did,
             environment=resolved_environment,
             visibility=visibility,
+            git_sha=args.git_sha or _git_short_sha(),
             pds=args.pds,
         )
         return

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -18,7 +18,9 @@ from publish_feed import (
     _put_record,
     _resolve_environment,
     _resolve_feed_publish_params,
+    _git_short_sha,
     _upload_blob,
+    _with_git_sha,
     delete_all_feeds,
     delete_feed,
     list_feeds,
@@ -843,11 +845,60 @@ class TestSearchability:
 
 
 class TestDisplayNameLength:
+    # git_sha=None covers the unstamped path; "e9f07f5" is a representative
+    # 7-char short sha (the widest form deploy.sh produces via --short=7), so a
+    # feed that fits with it stamped fits for any deployment.
     @pytest.mark.parametrize("rkey,feed_cfg", list(FEEDS.items()))
     @pytest.mark.parametrize("env", ["prod", "stage", "dev"])
-    def test_display_name_within_24_chars(self, rkey, feed_cfg, env):
-        _, name, _ = _resolve_feed_publish_params(rkey, feed_cfg, env)
-        assert len(name) <= 24, f"{rkey} @ {env}: '{name}' is {len(name)} chars"
+    @pytest.mark.parametrize("git_sha", [None, "e9f07f5"])
+    def test_display_name_within_24_chars(self, rkey, feed_cfg, env, git_sha):
+        _, name, _ = _resolve_feed_publish_params(rkey, feed_cfg, env, git_sha)
+        assert len(name) <= 24, f"{rkey} @ {env} (sha={git_sha}): '{name}' is {len(name)} chars"
+
+
+# ---------------------------------------------------------------------------
+# git sha stamping
+# ---------------------------------------------------------------------------
+
+
+class TestGitShaStamping:
+    def test_internal_name_and_description_carry_sha(self):
+        feed = FEEDS["unranked-your-feed"]
+        _, name, desc = _resolve_feed_publish_params(
+            "unranked-your-feed", feed, "stage", "e9f07f5"
+        )
+        assert name.endswith(" e9f07f5")
+        assert desc == "Built by Caterpie · e9f07f5"
+
+    def test_prod_public_name_is_not_stamped(self):
+        feed = FEEDS["best-of-friends"]
+        _, name, desc = _resolve_feed_publish_params(
+            "best-of-friends", feed, "prod", "e9f07f5"
+        )
+        assert name == feed.display_name
+        assert "e9f07f5" not in name
+        assert "e9f07f5" not in desc
+
+    def test_missing_sha_leaves_names_unstamped(self):
+        feed = FEEDS["unranked-your-feed"]
+        _, name, desc = _resolve_feed_publish_params(
+            "unranked-your-feed", feed, "stage", None
+        )
+        assert name == "GE e2 S"
+        assert desc == "Built by Caterpie"
+
+    def test_with_git_sha_appends_within_budget(self):
+        assert _with_git_sha("GE e2 S", "e9f07f5") == "GE e2 S e9f07f5"
+        assert _with_git_sha("GE e2 S", None) == "GE e2 S"
+
+    def test_with_git_sha_rejects_over_budget_name(self):
+        with pytest.raises(ValueError, match="exceeding"):
+            _with_git_sha("This name is already long", "e9f07f5")
+
+    def test_git_short_sha_prefers_env(self, monkeypatch):
+        monkeypatch.setenv("GE_GIT_SHA", "deadbeefcafe")
+        # Truncated to 7 chars even if the env value is longer.
+        assert _git_short_sha() == "deadbee"
 
 
 # ---------------------------------------------------------------------------

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -49,7 +49,9 @@ SOCIAL_RADIUS_PRESETS: dict[int, list[GeneratorSpec]] = {
     ],
 }
 
-# NOTE: display_name is limited to 24 chars, including the prefix ("GreenEarth, GE Dev, or GE Stg")
+# NOTE: published display names are limited to 24 graphemes. Internal ("debug")
+# feeds are published as "GE <internal_display_name> <git_sha>" (see issue #228),
+# so keep internal_display_name to 13 chars or fewer. feeds_test.py enforces this.
 FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
         display_name="Unranked YF",

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -9,6 +9,16 @@ CANDIDATE_ONLY_FEEDS = {
     "two-tower": "two_tower",
 }
 
+# AT Protocol app.bsky.feed.generator caps displayName at 24 graphemes. Published
+# names are composed from this metadata: prod publishes public feeds under the raw
+# display_name, while internal ("debug") feeds are published as
+# "GE <internal_display_name> <git_sha>" in dev/stage (see publish_feed.py and
+# issue #228). Budgeting for the widest composition here means an over-long name in
+# feeds.py fails next to its definition, not only in the publish script's tests.
+MAX_DISPLAY_NAME_GRAPHEMES = 24
+DEV_STAGE_PREFIX = "GE "  # widest env prefix applied to internal feeds
+GIT_SHA_SUFFIX_LEN = len(" ") + 7  # " " + 7-char short git sha
+
 
 class TestFeedsRegistry:
     def test_social_radius_splits_everyone_weight_evenly(self):
@@ -115,3 +125,33 @@ class TestFeedsRegistry:
         assert cfg.max_render_share == pytest.approx(0.5)
         assert cfg.min_rank_score == pytest.approx(0.425)
         assert cfg.min_mmr_score == pytest.approx(-0.05)
+
+
+class TestFeedNameLengths:
+    """Surface over-long feed names at definition time.
+
+    ``publish_feed.py`` also asserts the composed published name fits (via
+    ``_resolve_feed_publish_params``); these checks are the same budget applied
+    directly to the raw metadata in ``feeds.py`` so the failure points at the
+    offending field.
+    """
+
+    @pytest.mark.parametrize("feed_name,cfg", list(FEEDS.items()))
+    def test_internal_display_name_fits_with_prefix_and_sha(self, feed_name, cfg):
+        # Worst case: dev/stage publishes internal feeds as "GE <name> <sha>".
+        composed = (
+            len(DEV_STAGE_PREFIX) + len(cfg.internal_display_name) + GIT_SHA_SUFFIX_LEN
+        )
+        assert composed <= MAX_DISPLAY_NAME_GRAPHEMES, (
+            f"{feed_name}: internal_display_name {cfg.internal_display_name!r} is too long — "
+            f"'GE {cfg.internal_display_name} <sha>' would be {composed} chars "
+            f"(limit {MAX_DISPLAY_NAME_GRAPHEMES})"
+        )
+
+    @pytest.mark.parametrize("feed_name,cfg", list(FEEDS.items()))
+    def test_public_display_name_fits(self, feed_name, cfg):
+        # Prod publishes public feeds under the raw display_name (no prefix/sha).
+        assert len(cfg.display_name) <= MAX_DISPLAY_NAME_GRAPHEMES, (
+            f"{feed_name}: display_name {cfg.display_name!r} exceeds "
+            f"{MAX_DISPLAY_NAME_GRAPHEMES} graphemes"
+        )

--- a/src/app/routers/health.py
+++ b/src/app/routers/health.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
@@ -6,9 +8,15 @@ router = APIRouter(tags=["health"])
 
 class HealthResponse(BaseModel):
     status: str = Field(..., description="'ok' when the service is healthy")
+    git_sha: str | None = Field(
+        None,
+        description="Short git sha of the deployed code (from GE_GIT_SHA), or null "
+        "when running unstamped code (e.g. local dev). Useful for confirming which "
+        "revision is live and for choosing rollback targets.",
+    )
 
 
 @router.get("/health", response_model=HealthResponse, status_code=200)
 async def healthcheck() -> HealthResponse:
     """Returns 200 when the service is running."""
-    return HealthResponse(status="ok")
+    return HealthResponse(status="ok", git_sha=os.environ.get("GE_GIT_SHA") or None)

--- a/src/app/routers/health_test.py
+++ b/src/app/routers/health_test.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 from fastapi.testclient import TestClient
 
 from ..main import app
@@ -12,7 +15,8 @@ def test_healthcheck_returns_200():
 
 def test_healthcheck_response_body():
     response = client.get("/health")
-    assert response.json() == {"status": "ok"}
+    body = response.json()
+    assert body["status"] == "ok"
 
 
 def test_healthcheck_response_structure():
@@ -20,3 +24,16 @@ def test_healthcheck_response_structure():
     data = response.json()
     assert "status" in data
     assert isinstance(data["status"], str)
+
+
+def test_healthcheck_reports_git_sha_when_set():
+    with mock.patch.dict(os.environ, {"GE_GIT_SHA": "abc1234"}):
+        response = client.get("/health")
+    assert response.json()["git_sha"] == "abc1234"
+
+
+def test_healthcheck_git_sha_null_when_unset():
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GE_GIT_SHA", None)
+        response = client.get("/health")
+    assert response.json()["git_sha"] is None

--- a/src/app/security_test.py
+++ b/src/app/security_test.py
@@ -55,4 +55,4 @@ class TestHealthEndpointNoAuth:
 
     def test_health_returns_ok_status(self, client_invalid):
         response = client_invalid.get("/health")
-        assert response.json() == {"status": "ok"}
+        assert response.json()["status"] == "ok"


### PR DESCRIPTION
Makes it possible to tell exactly what code is live at any given point, and keeps a deployed sha from ever lying about the code behind it.

## Changes
- **Clean-tree deploys** — `deploy.sh` refuses to deploy with uncommitted changes (unpushed branches are still fine), so the stamped sha always matches what ships. It computes the short sha (`--short=7`) and exports `GE_GIT_SHA` for the feed sync.
- **Revision identification (rollbacks)** — the Cloud Run revision gets `GE_GIT_SHA=<sha>` (env var) and a `git-sha=<sha>` label.
- **Debug feed names** — `publish_feed.py` stamps the sha onto internal ("debug") feed display names and descriptions (e.g. `GE e2 S e9f07f5` / `Built by Caterpie · e9f07f5`). Public prod GreenEarth feeds stay unstamped. A guard raises if a composed name would exceed the 24-grapheme AT Protocol `displayName` limit.
- **Runtime visibility** — `GET /health` now returns `git_sha` from `GE_GIT_SHA`.
- **Docs** — README documents the clean-tree requirement, where the sha lands, and the bug-report workflow (copy the trailing sha off the feed name, or read `/health`).

The clean-tree check lives in the deploy script only, so `publish_feed.py` still works on a dirty tree for local dev (as the issue asked).

## Testing
162 tests pass across `health_test`, `feeds_test`, `main_test`, `publish_feed_test`. New tests cover sha stamping, the prod-public exclusion, the over-budget guard, env precedence, and `/health` reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)