### PR TITLE
Add eventloop.lag_ms: direct api-instance saturation signal

### DIFF
--- a/src/app/lib/eventloop_monitor.py
+++ b/src/app/lib/eventloop_monitor.py
@@ -1,0 +1,43 @@
+"""Event-loop lag monitor: the direct "api instance saturated" signal.
+
+A background task sleeps for a fixed interval and records how far past the
+deadline it actually woke up. Under a healthy loop the overshoot is ~0-2 ms;
+when coroutines or sync work monopolize the loop, every pending callback —
+including responses already received from ES/inference/Perspective — waits
+this long to run. See docs/design/load-test-regression-assessment.md §4.1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+
+
+def get_metric_collector():
+    """Indirection point so tests can monkeypatch at module level."""
+    from .metrics import get_metric_collector as _get
+    return _get()
+
+
+DEFAULT_INTERVAL_SEC = 0.25
+
+
+async def _monitor_loop(interval_sec: float) -> None:
+    while True:
+        target = time.monotonic() + interval_sec
+        await asyncio.sleep(interval_sec)
+        lag_ms = max(0.0, (time.monotonic() - target) * 1000)
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record("eventloop.lag_ms", lag_ms)
+
+
+def start_eventloop_monitor(interval_sec: float = DEFAULT_INTERVAL_SEC) -> asyncio.Task:
+    return asyncio.create_task(_monitor_loop(interval_sec), name="eventloop-monitor")
+
+
+async def stop_eventloop_monitor(task: asyncio.Task) -> None:
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/src/app/lib/eventloop_monitor.py
+++ b/src/app/lib/eventloop_monitor.py
@@ -4,7 +4,7 @@ A background task sleeps for a fixed interval and records how far past the
 deadline it actually woke up. Under a healthy loop the overshoot is ~0-2 ms;
 when coroutines or sync work monopolize the loop, every pending callback —
 including responses already received from ES/inference/Perspective — waits
-this long to run. See docs/design/load-test-regression-assessment.md §4.1.
+this long to run. See issue #343 for the attribution design.
 """
 
 from __future__ import annotations

--- a/src/app/lib/eventloop_monitor_test.py
+++ b/src/app/lib/eventloop_monitor_test.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import pytest
+
+from app.lib import eventloop_monitor
+
+
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+
+@pytest.mark.asyncio
+async def test_monitor_records_lag_samples(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
+
+    task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
+    await asyncio.sleep(0.08)
+    await eventloop_monitor.stop_eventloop_monitor(task)
+
+    lag_records = [r for r in collector.records if r[0] == "eventloop.lag_ms"]
+    assert len(lag_records) >= 3
+    for _, value, attrs in lag_records:
+        assert value >= 0
+        assert attrs == {}
+
+
+@pytest.mark.asyncio
+async def test_monitor_measures_overshoot(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
+
+    task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
+    # Block the loop synchronously for ~50ms; the next sample must see it.
+    await asyncio.sleep(0.02)
+    import time as _time
+    _time.sleep(0.05)
+    await asyncio.sleep(0.02)
+    await eventloop_monitor.stop_eventloop_monitor(task)
+
+    lags = [v for n, v, _ in collector.records if n == "eventloop.lag_ms"]
+    assert max(lags) >= 30  # ms — blocked well past the 10ms interval
+
+
+@pytest.mark.asyncio
+async def test_stop_is_clean(monkeypatch):
+    monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: None)
+    task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
+    await asyncio.sleep(0.02)
+    await eventloop_monitor.stop_eventloop_monitor(task)
+    assert task.cancelled() or task.done()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -42,6 +42,7 @@ from .security import RequireApiKey
 from .lib.atproto_auth import init_id_resolver
 from .lib.firebase_auth import init_firebase_auth
 from .lib.es_client import SlowQueryLoggingES
+from .lib.eventloop_monitor import start_eventloop_monitor, stop_eventloop_monitor
 from .lib.feed_cache import FirestoreFeedCache
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
@@ -128,6 +129,7 @@ async def lifespan(app: FastAPI):
         export_interval_sec=int(os.environ.get("GE_METRICS_EXPORT_INTERVAL_SEC", "60")),
     )
     set_metric_collector(metrics)
+    eventloop_task = start_eventloop_monitor()
 
     posthog_api_key = os.environ.get("GE_POSTHOG_API_KEY")
     posthog_host = os.environ.get("GE_POSTHOG_HOST", "https://us.i.posthog.com")
@@ -167,6 +169,10 @@ async def lifespan(app: FastAPI):
             pass
         try:
             await close_perspective_client()
+        except Exception:
+            pass
+        try:
+            await stop_eventloop_monitor(eventloop_task)
         except Exception:
             pass
         try:


### PR DESCRIPTION
Part of #343 (PR B; stacked on #350).

The 07-31 load-test burst 1 ("every stage p95 spikes together, including external calls") took manual inference across five queries to diagnose as api instance saturation. `eventloop.lag_ms` is the direct signal: a background task measures asyncio scheduling overshoot — when the loop is monopolized, every pending callback (including responses already received from ES/inference/Perspective) waits this long to run.

# This PR

- Add `src/app/lib/eventloop_monitor.py`: background task sampling scheduling overshoot every 250ms into an `eventloop.lag_ms` histogram (per-instance, no labels)
- Wire start/stop into the app lifespan around the existing MetricCollector setup/teardown

# Testing

- `pipenv run pytest -q` — 1000 passed
- New unit tests: samples recorded at the expected cadence with no labels; a 50ms synchronous loop block shows up as ≥30ms measured lag; cancellation is clean (no leaked task, suppressed CancelledError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)