### PR TITLE
Client-health metrics: dependency failure classes and queue-position signals

### DIFF
--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -161,7 +161,8 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
         raise FollowedUsersLookupError(
             f"Failed to fetch followed users for {user_did}"
         ) from exc
-    except FollowedUsersLookupError:
+    except FollowedUsersLookupError as exc:
+        _count_failure("bsky.follows.failure_count", exc)
         raise
     except (httpx.HTTPError, ValueError) as exc:
         _count_failure("bsky.follows.failure_count", exc)

--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -120,8 +120,13 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                     ValueError,
                     FollowedUsersLookupError,
                 ) as exc:
-                    _count_failure("bsky.follows.failure_count", exc)
                     if followed_dids:
+                        # Terminal outcome for this lookup (partial success) —
+                        # count it here since it never reaches the outer
+                        # handlers below. A bare re-raise, in contrast, is
+                        # counted once by whichever outer handler catches it,
+                        # so we must not double-count here.
+                        _count_failure("bsky.follows.failure_count", exc)
                         logger.warning(
                             "Returning %s partial followed users for %s after "
                             "follow lookup page failed: %s",

--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -9,6 +9,26 @@ from .http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
+
+def get_metric_collector():
+    """Indirection point so tests can monkeypatch at module level."""
+    from .metrics import get_metric_collector as _get
+    return _get()
+
+
+def _status_code_label(exc: BaseException) -> str:
+    if isinstance(exc, (TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return str(status) if status else "other"
+
+
+def _count_failure(metric: str, exc: BaseException) -> None:
+    collector = get_metric_collector()
+    if collector is not None:
+        collector.record(metric, 1, status_code=_status_code_label(exc))
+
+
 # ---------------------------------------------------------------------------
 # Parameters
 # ---------------------------------------------------------------------------
@@ -100,6 +120,7 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                     ValueError,
                     FollowedUsersLookupError,
                 ) as exc:
+                    _count_failure("bsky.follows.failure_count", exc)
                     if followed_dids:
                         logger.warning(
                             "Returning %s partial followed users for %s after "
@@ -122,6 +143,7 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                 if not isinstance(cursor, str) or not cursor:
                     break
     except TimeoutError as exc:
+        _count_failure("bsky.follows.failure_count", exc)
         if followed_dids:
             logger.warning(
                 "Returning %s partial followed users for %s after follow lookup "
@@ -137,6 +159,7 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
     except FollowedUsersLookupError:
         raise
     except (httpx.HTTPError, ValueError) as exc:
+        _count_failure("bsky.follows.failure_count", exc)
         raise FollowedUsersLookupError(
             f"Failed to fetch followed users for {user_did}"
         ) from exc

--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -19,6 +19,8 @@ def get_metric_collector():
 def _status_code_label(exc: BaseException) -> str:
     if isinstance(exc, (TimeoutError, httpx.TimeoutException)):
         return "timeout"
+    if isinstance(exc, (httpx.ConnectError, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return "connection"
     status = getattr(getattr(exc, "response", None), "status_code", None)
     return str(status) if status else "other"
 

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -46,6 +46,85 @@ def fake_http_client(monkeypatch):
     return client
 
 
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+
+class TestGetFollowedUserDidsFailureCounters:
+    """bsky.follows.failure_count is recorded with a status_code label once
+    per failed lookup, whether it raises or falls back to partial results."""
+
+    @pytest.mark.asyncio
+    async def test_counts_http_status_failures(self, fake_http_client, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        request = httpx.Request("GET", "https://example.test")
+        response = httpx.Response(503, request=request)
+        fake_http_client.response = FakeResponse(
+            status_exc=httpx.HTTPStatusError(
+                "service unavailable", request=request, response=response
+            )
+        )
+
+        with pytest.raises(FollowedUsersLookupError):
+            await get_followed_user_dids("did:plc:x", limit=10)
+
+        assert ("bsky.follows.failure_count", 1, {"status_code": "503"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_timeouts(self, fake_http_client, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        request = httpx.Request("GET", "https://example.test")
+        fake_http_client.response = FakeResponse(
+            status_exc=httpx.ConnectTimeout("connect timed out", request=request)
+        )
+
+        with pytest.raises(FollowedUsersLookupError):
+            await get_followed_user_dids("did:plc:x", limit=10)
+
+        assert ("bsky.follows.failure_count", 1, {"status_code": "timeout"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_once_for_partial_result_fallback(
+        self, fake_http_client, monkeypatch, caplog
+    ):
+        """A later-page failure that falls back to partial results still
+        counts as one external failure."""
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        async def fake_sleep(delay):
+            return None
+
+        monkeypatch.setattr(bsky_module.asyncio, "sleep", fake_sleep)
+        request = httpx.Request("GET", "https://example.test")
+        response = httpx.Response(503, request=request)
+        first_page = [{"did": f"did:plc:follow{i}"} for i in range(100)]
+        error_page = FakeResponse(
+            status_exc=httpx.HTTPStatusError(
+                "service unavailable", request=request, response=response
+            )
+        )
+        fake_http_client.responses = [
+            FakeResponse({"follows": first_page, "cursor": "next-page"}),
+            error_page,
+            error_page,
+        ]
+
+        dids = await get_followed_user_dids("did:plc:user1", limit=200)
+
+        assert dids == [f"did:plc:follow{i}" for i in range(100)]
+        failures = [r for r in collector.records if r[0] == "bsky.follows.failure_count"]
+        assert failures == [("bsky.follows.failure_count", 1, {"status_code": "503"})]
+
+
 class TestGetFollowedUserDids:
     @pytest.mark.asyncio
     async def test_returns_followed_dids_and_uses_query_params(self, fake_http_client):

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -92,6 +92,30 @@ class TestGetFollowedUserDidsFailureCounters:
         assert ("bsky.follows.failure_count", 1, {"status_code": "timeout"}) in collector.records
 
     @pytest.mark.asyncio
+    async def test_counts_exactly_once_when_first_page_fails_with_no_partials(
+        self, fake_http_client, monkeypatch
+    ):
+        """A lookup that fails on its first page (no partial data accumulated
+        yet) re-raises out of the inner per-page handler and is counted once
+        by the outer handler that catches it -- not twice."""
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        request = httpx.Request("GET", "https://example.test")
+        response = httpx.Response(503, request=request)
+        fake_http_client.response = FakeResponse(
+            status_exc=httpx.HTTPStatusError(
+                "service unavailable", request=request, response=response
+            )
+        )
+
+        with pytest.raises(FollowedUsersLookupError):
+            await get_followed_user_dids("did:plc:x", limit=10)
+
+        failures = [r for r in collector.records if r[0] == "bsky.follows.failure_count"]
+        assert failures == [("bsky.follows.failure_count", 1, {"status_code": "503"})]
+
+    @pytest.mark.asyncio
     async def test_counts_once_for_partial_result_fallback(
         self, fake_http_client, monkeypatch, caplog
     ):

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -116,6 +116,26 @@ class TestGetFollowedUserDidsFailureCounters:
         assert failures == [("bsky.follows.failure_count", 1, {"status_code": "503"})]
 
     @pytest.mark.asyncio
+    async def test_counts_malformed_first_page_with_no_partials(
+        self, fake_http_client, monkeypatch
+    ):
+        """A malformed first-page response (not a list of follows) raises
+        FollowedUsersLookupError through the inner handler's bare re-raise,
+        then through the outer `except FollowedUsersLookupError: raise`
+        clause -- it must still be counted exactly once, matching the
+        malformed-response-with-partials case."""
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        fake_http_client.response = FakeResponse({"follows": {"did": "not-a-list"}})
+
+        with pytest.raises(FollowedUsersLookupError, match="Unexpected follows response"):
+            await get_followed_user_dids("did:plc:x", limit=10)
+
+        failures = [r for r in collector.records if r[0] == "bsky.follows.failure_count"]
+        assert failures == [("bsky.follows.failure_count", 1, {"status_code": "other"})]
+
+    @pytest.mark.asyncio
     async def test_counts_once_for_partial_result_fallback(
         self, fake_http_client, monkeypatch, caplog
     ):

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -92,6 +92,25 @@ class TestGetFollowedUserDidsFailureCounters:
         assert ("bsky.follows.failure_count", 1, {"status_code": "timeout"}) in collector.records
 
     @pytest.mark.asyncio
+    async def test_counts_connection_failures(self, fake_http_client, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(bsky_module, "get_metric_collector", lambda: collector)
+
+        request = httpx.Request("GET", "https://example.test")
+        fake_http_client.response = FakeResponse(
+            status_exc=httpx.ConnectError("connection refused", request=request)
+        )
+
+        with pytest.raises(FollowedUsersLookupError):
+            await get_followed_user_dids("did:plc:x", limit=10)
+
+        assert (
+            "bsky.follows.failure_count",
+            1,
+            {"status_code": "connection"},
+        ) in collector.records
+
+    @pytest.mark.asyncio
     async def test_counts_exactly_once_when_first_page_fails_with_no_partials(
         self, fake_http_client, monkeypatch
     ):

--- a/src/app/lib/client_metrics.py
+++ b/src/app/lib/client_metrics.py
@@ -1,0 +1,84 @@
+"""Queue-position metrics for concurrency-limited clients.
+
+Any pooled client can reproduce #344's pattern: work queues client-side
+while the backend idles. Where the transport exposes queue events
+(aiohttp), record pool wait time; where it doesn't (httpx), record the
+in-flight count — a p95 pinned at the configured cap is saturation even
+before latency shows it.
+"""
+
+from __future__ import annotations
+
+import time
+
+import aiohttp
+import httpx
+
+
+def get_metric_collector():
+    """Indirection point so tests can monkeypatch at module level."""
+    from .metrics import get_metric_collector as _get
+    return _get()
+
+
+def aiohttp_trace_config(client: str) -> aiohttp.TraceConfig:
+    tc = aiohttp.TraceConfig()
+
+    async def _queued_start(session, ctx, params):
+        ctx.queued_start = time.monotonic()
+
+    async def _queued_end(session, ctx, params):
+        start = getattr(ctx, "queued_start", None)
+        if start is None:
+            return
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record(
+                "client.pool.wait_ms", (time.monotonic() - start) * 1000, client=client
+            )
+
+    async def _create_start(session, ctx, params):
+        ctx.create_start = time.monotonic()
+
+    async def _create_end(session, ctx, params):
+        start = getattr(ctx, "create_start", None)
+        if start is None:
+            return
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record(
+                "client.connect.duration_ms", (time.monotonic() - start) * 1000, client=client
+            )
+
+    tc.on_connection_queued_start.append(_queued_start)
+    tc.on_connection_queued_end.append(_queued_end)
+    tc.on_connection_create_start.append(_create_start)
+    tc.on_connection_create_end.append(_create_end)
+    return tc
+
+
+class InFlightTransport(httpx.AsyncBaseTransport):
+    """Wraps a transport, sampling concurrent requests per host.
+
+    The sample is taken before the inner transport (i.e. before pool
+    acquisition), so queued requests count — sustained samples at the
+    pool cap mean requests are waiting, not working.
+    """
+
+    def __init__(self, inner: httpx.AsyncBaseTransport) -> None:
+        self._inner = inner
+        self._counts: dict[str, int] = {}
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host or "unknown"
+        self._counts[host] = self._counts.get(host, 0) + 1
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record("client.in_flight", self._counts[host], host=host)
+        try:
+            return await self._inner.handle_async_request(request)
+        finally:
+            self._counts[host] = self._counts.get(host, 1) - 1
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()

--- a/src/app/lib/client_metrics.py
+++ b/src/app/lib/client_metrics.py
@@ -22,6 +22,23 @@ def get_metric_collector():
 
 
 def aiohttp_trace_config(client: str) -> aiohttp.TraceConfig:
+    """Build an aiohttp ``TraceConfig`` that records pool-queue signals.
+
+    ``client.pool.wait_ms`` only emits when the session's ``TCPConnector``
+    has a connection-pool limit: aiohttp only enters its
+    ``_wait_for_available_connection`` path (which fires
+    ``on_connection_queued_start``/``_end``) when a request has to wait for
+    a slot. With an unbounded connector (``limit=0``/``limit_per_host=0`` —
+    e.g. Perspective's, deliberately unbounded since issue #250 to avoid
+    head-of-line blocking) there is never a slot to wait for, so this
+    metric structurally can never fire. It stays attached anyway as a
+    tripwire: if a connection-pool limit is ever reintroduced on such a
+    client, `client.pool.wait_ms` will start reporting queueing immediately
+    without further code changes. For clients with no such hook (or an
+    unbounded connector), track in-flight request counts instead (see
+    `InFlightTransport` for httpx, or track a manual counter around the
+    call site for aiohttp — as `PerspectiveClient.score` does).
+    """
     tc = aiohttp.TraceConfig()
 
     async def _queued_start(session, ctx, params):

--- a/src/app/lib/client_metrics_test.py
+++ b/src/app/lib/client_metrics_test.py
@@ -2,11 +2,17 @@
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any, cast
 
 import httpx
 import pytest
 
 from app.lib import client_metrics
+
+
+# The trace callbacks ignore their session and params arguments; the cast
+# keeps the type checker happy without fabricating aiohttp internals.
+UNUSED = cast(Any, None)
 
 
 class _RecordingCollector:
@@ -24,8 +30,8 @@ async def test_aiohttp_trace_records_pool_wait(monkeypatch):
 
     tc = client_metrics.aiohttp_trace_config("perspective")
     ctx = SimpleNamespace()
-    await tc.on_connection_queued_start[0](None, ctx, None)
-    await tc.on_connection_queued_end[0](None, ctx, None)
+    await tc.on_connection_queued_start[0](UNUSED, ctx, UNUSED)
+    await tc.on_connection_queued_end[0](UNUSED, ctx, UNUSED)
 
     [(name, value, attrs)] = collector.records
     assert name == "client.pool.wait_ms"
@@ -40,8 +46,8 @@ async def test_aiohttp_trace_records_connect_duration(monkeypatch):
 
     tc = client_metrics.aiohttp_trace_config("perspective")
     ctx = SimpleNamespace()
-    await tc.on_connection_create_start[0](None, ctx, None)
-    await tc.on_connection_create_end[0](None, ctx, None)
+    await tc.on_connection_create_start[0](UNUSED, ctx, UNUSED)
+    await tc.on_connection_create_end[0](UNUSED, ctx, UNUSED)
 
     [(name, _, attrs)] = collector.records
     assert name == "client.connect.duration_ms"
@@ -53,7 +59,7 @@ async def test_aiohttp_trace_end_without_start_records_nothing(monkeypatch):
     collector = _RecordingCollector()
     monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
     tc = client_metrics.aiohttp_trace_config("perspective")
-    await tc.on_connection_queued_end[0](None, SimpleNamespace(), None)
+    await tc.on_connection_queued_end[0](UNUSED, SimpleNamespace(), UNUSED)
     assert collector.records == []
 
 

--- a/src/app/lib/client_metrics_test.py
+++ b/src/app/lib/client_metrics_test.py
@@ -1,0 +1,120 @@
+"""Tests for client queue-position metrics."""
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from app.lib import client_metrics
+
+
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_trace_records_pool_wait(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
+
+    tc = client_metrics.aiohttp_trace_config("perspective")
+    ctx = SimpleNamespace()
+    await tc.on_connection_queued_start[0](None, ctx, None)
+    await tc.on_connection_queued_end[0](None, ctx, None)
+
+    [(name, value, attrs)] = collector.records
+    assert name == "client.pool.wait_ms"
+    assert value >= 0
+    assert attrs == {"client": "perspective"}
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_trace_records_connect_duration(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
+
+    tc = client_metrics.aiohttp_trace_config("perspective")
+    ctx = SimpleNamespace()
+    await tc.on_connection_create_start[0](None, ctx, None)
+    await tc.on_connection_create_end[0](None, ctx, None)
+
+    [(name, _, attrs)] = collector.records
+    assert name == "client.connect.duration_ms"
+    assert attrs == {"client": "perspective"}
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_trace_end_without_start_records_nothing(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
+    tc = client_metrics.aiohttp_trace_config("perspective")
+    await tc.on_connection_queued_end[0](None, SimpleNamespace(), None)
+    assert collector.records == []
+
+
+class _BlockingTransport(httpx.AsyncBaseTransport):
+    """Inner transport that parks until released, to overlap requests."""
+
+    def __init__(self):
+        self.release = asyncio.Event()
+
+    async def handle_async_request(self, request):
+        await self.release.wait()
+        return httpx.Response(200, request=request)
+
+
+@pytest.mark.asyncio
+async def test_in_flight_transport_counts_concurrent_requests(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
+
+    inner = _BlockingTransport()
+    transport = client_metrics.InFlightTransport(inner)
+    client = httpx.AsyncClient(transport=transport)
+
+    async def _get():
+        return await client.get("http://inference.test/x")
+
+    t1 = asyncio.create_task(_get())
+    t2 = asyncio.create_task(_get())
+    await asyncio.sleep(0.01)  # let both reach the transport
+    inner.release.set()
+    await asyncio.gather(t1, t2)
+    await client.aclose()
+
+    values = [v for n, v, a in collector.records
+              if n == "client.in_flight" and a == {"host": "inference.test"}]
+    assert sorted(values) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_in_flight_transport_decrements_on_error(monkeypatch):
+    collector = _RecordingCollector()
+    monkeypatch.setattr(client_metrics, "get_metric_collector", lambda: collector)
+
+    class _FailingTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request):
+            raise httpx.ConnectError("boom", request=request)
+
+    transport = client_metrics.InFlightTransport(_FailingTransport())
+    client = httpx.AsyncClient(transport=transport)
+    with pytest.raises(httpx.ConnectError):
+        await client.get("http://inference.test/x")
+
+    # After the failure the counter must be back at zero: a fresh request
+    # records in-flight 1, not 2.
+    inner = _BlockingTransport()
+    transport2 = client_metrics.InFlightTransport(inner)
+    # same tracker instance matters — reuse transport, swap inner:
+    transport._inner = inner
+    inner.release.set()
+    await client.get("http://inference.test/x")
+    await client.aclose()
+
+    values = [v for n, v, a in collector.records if n == "client.in_flight"]
+    assert values == [1, 1]

--- a/src/app/lib/es_client.py
+++ b/src/app/lib/es_client.py
@@ -10,6 +10,9 @@ Records metrics:
 - ``es.query.took_ms``: server-side time from ES response (histogram, labeled by ``op``; omitted if missing)
 - ``es.query.error_count``: counted on any exception, labeled by ``op`` and
   ``error`` (``"timeout"`` | ``"connection"`` | ``"other"``)
+- ``es.client.in_flight``: concurrent in-flight ``.search()`` calls sampled
+  per call (histogram, labeled by ``op``) — the queue-position signal for
+  this wrapper (see issue #344)
 
 Other attributes (e.g. ``close``, ``indices``) are exposed transparently
 via ``__getattr__`` so the wrapper is a drop-in for the underlying
@@ -75,6 +78,7 @@ class SlowQueryLoggingES:
 
     def __init__(self, wrapped) -> None:
         self._wrapped = wrapped
+        self._in_flight = 0
 
     def __getattr__(self, name: str):
         # Delegated for every attribute other than the ones explicitly
@@ -86,6 +90,10 @@ class SlowQueryLoggingES:
         start = time.monotonic()
         timed_out = False
         took_ms: float | None = None
+        self._in_flight += 1
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record("es.client.in_flight", self._in_flight, op=op)
         try:
             resp = await self._wrapped.search(*args, **kwargs)
             took_ms = _extract_took(resp)
@@ -104,6 +112,7 @@ class SlowQueryLoggingES:
             _record_query_error(op, "other")
             raise
         finally:
+            self._in_flight -= 1
             if not timed_out:
                 elapsed_ms = (time.monotonic() - start) * 1000
                 _record_query_metrics(op, elapsed_ms, took_ms)

--- a/src/app/lib/es_client.py
+++ b/src/app/lib/es_client.py
@@ -8,6 +8,8 @@ curl or Kibana to reproduce.
 Records metrics:
 - ``es.query.duration_ms``: client-side elapsed time (histogram, labeled by ``op``)
 - ``es.query.took_ms``: server-side time from ES response (histogram, labeled by ``op``; omitted if missing)
+- ``es.query.error_count``: counted on any exception, labeled by ``op`` and
+  ``error`` (``"timeout"`` | ``"connection"`` | ``"other"``)
 
 Other attributes (e.g. ``close``, ``indices``) are exposed transparently
 via ``__getattr__`` so the wrapper is a drop-in for the underlying
@@ -22,6 +24,7 @@ import os
 import time
 
 from elastic_transport import ConnectionTimeout
+from elastic_transport import ConnectionError as EsConnectionError
 
 from .request_context import get_request_id
 
@@ -50,6 +53,13 @@ def _record_query_metrics(op: str, elapsed_ms: float, took_ms: float | None) -> 
     collector.record("es.query.duration_ms", elapsed_ms, op=op)
     if took_ms is not None:
         collector.record("es.query.took_ms", took_ms, op=op)
+
+
+def _record_query_error(op: str, error: str) -> None:
+    collector = get_metric_collector()
+    if collector is None:
+        return
+    collector.record("es.query.error_count", 1, op=op, error=error)
 
 
 def _slow_threshold_ms() -> float:
@@ -85,6 +95,13 @@ class SlowQueryLoggingES:
             elapsed_ms = (time.monotonic() - start) * 1000
             _log_timeout_search(elapsed_ms, args, kwargs)
             _record_query_metrics(op, elapsed_ms, None)
+            _record_query_error(op, "timeout")
+            raise
+        except EsConnectionError:
+            _record_query_error(op, "connection")
+            raise
+        except Exception:
+            _record_query_error(op, "other")
             raise
         finally:
             if not timed_out:

--- a/src/app/lib/es_client_test.py
+++ b/src/app/lib/es_client_test.py
@@ -5,6 +5,7 @@ import json
 import logging
 
 import pytest
+from elastic_transport import ConnectionError as EsConnectionError
 from elastic_transport import ConnectionTimeout
 
 from . import es_client as es_client_module
@@ -277,3 +278,54 @@ async def test_search_records_duration_on_timeout(monkeypatch):
     names = [n for n, _, _ in collector.records]
     assert "es.query.duration_ms" in names
     assert "es.query.took_ms" not in names
+
+
+@pytest.mark.asyncio
+async def test_search_records_error_count_on_timeout(monkeypatch):
+    class _FakeES:
+        async def search(self, **kwargs):
+            raise ConnectionTimeout("boom")
+
+    collector = _RecordingCollector()
+    monkeypatch.setattr(es_client_module, "get_metric_collector", lambda: collector)
+
+    wrapped = SlowQueryLoggingES(_FakeES())
+    with pytest.raises(ConnectionTimeout):
+        await wrapped.search(index="posts", op="knn")
+
+    assert ("es.query.error_count", 1, {"op": "knn", "error": "timeout"}) in collector.records
+
+
+@pytest.mark.asyncio
+async def test_search_records_error_count_on_connection_error(monkeypatch):
+    class _FakeES:
+        async def search(self, **kwargs):
+            raise EsConnectionError("connection refused")
+
+    collector = _RecordingCollector()
+    monkeypatch.setattr(es_client_module, "get_metric_collector", lambda: collector)
+
+    wrapped = SlowQueryLoggingES(_FakeES())
+    with pytest.raises(EsConnectionError):
+        await wrapped.search(index="posts", op="knn")
+
+    assert ("es.query.error_count", 1, {"op": "knn", "error": "connection"}) in collector.records
+    # An errored query still consumed client-side time.
+    names = [n for n, _, _ in collector.records]
+    assert "es.query.duration_ms" in names
+
+
+@pytest.mark.asyncio
+async def test_search_records_error_count_on_other_exception(monkeypatch):
+    class _FakeES:
+        async def search(self, **kwargs):
+            raise ValueError("boom")
+
+    collector = _RecordingCollector()
+    monkeypatch.setattr(es_client_module, "get_metric_collector", lambda: collector)
+
+    wrapped = SlowQueryLoggingES(_FakeES())
+    with pytest.raises(ValueError):
+        await wrapped.search(index="posts", op="likes")
+
+    assert ("es.query.error_count", 1, {"op": "likes", "error": "other"}) in collector.records

--- a/src/app/lib/es_client_test.py
+++ b/src/app/lib/es_client_test.py
@@ -329,3 +329,26 @@ async def test_search_records_error_count_on_other_exception(monkeypatch):
         await wrapped.search(index="posts", op="likes")
 
     assert ("es.query.error_count", 1, {"op": "likes", "error": "other"}) in collector.records
+
+
+@pytest.mark.asyncio
+async def test_search_records_in_flight_count(monkeypatch):
+    release = asyncio.Event()
+
+    class _BlockingES:
+        async def search(self, **kwargs):
+            await release.wait()
+            return {"took": 1, "hits": {"hits": []}}
+
+    collector = _RecordingCollector()
+    monkeypatch.setattr(es_client_module, "get_metric_collector", lambda: collector)
+
+    wrapped = SlowQueryLoggingES(_BlockingES())
+    t1 = asyncio.create_task(wrapped.search(index="posts", op="knn"))
+    t2 = asyncio.create_task(wrapped.search(index="posts", op="likes"))
+    await asyncio.sleep(0.01)
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    in_flight = sorted(v for n, v, _ in collector.records if n == "es.client.in_flight")
+    assert in_flight == [1, 2]

--- a/src/app/lib/http_client.py
+++ b/src/app/lib/http_client.py
@@ -10,11 +10,22 @@ The lifespan handler calls :func:`init_http_client` at startup and
 client via :func:`get_http_client`; outside of app lifetime (e.g.
 tests that bypass lifespan) it lazily creates a client so callers
 never get ``None``.
+
+The client is wrapped in :class:`~app.lib.client_metrics.InFlightTransport`,
+which samples ``client.in_flight`` per host — the queue-position signal for
+this pool (see issue #344). ``GE_HTTP_MAX_CONNECTIONS`` makes the pool cap
+explicit and chartable; it must be set on the inner transport because the
+client-level ``limits=`` kwarg is ignored once a custom ``transport=`` is
+supplied.
 """
 
 from __future__ import annotations
 
+import os
+
 import httpx
+
+from .client_metrics import InFlightTransport
 
 _client: httpx.AsyncClient | None = None
 
@@ -22,7 +33,12 @@ _client: httpx.AsyncClient | None = None
 def init_http_client() -> httpx.AsyncClient:
     global _client
     if _client is None:
-        _client = httpx.AsyncClient(timeout=30.0)
+        max_connections = int(os.environ.get("GE_HTTP_MAX_CONNECTIONS", "100"))
+        limits = httpx.Limits(max_connections=max_connections, max_keepalive_connections=20)
+        _client = httpx.AsyncClient(
+            timeout=30.0,
+            transport=InFlightTransport(httpx.AsyncHTTPTransport(limits=limits)),
+        )
     return _client
 
 

--- a/src/app/lib/inference.py
+++ b/src/app/lib/inference.py
@@ -10,6 +10,8 @@ import os
 import time
 from typing import Literal, assert_never
 
+import httpx
+
 from .elasticsearch import (
     fetch_recent_liked_post_uris_and_times,
     fetch_post_embeddings_and_metadata,
@@ -20,6 +22,27 @@ from .request_context import get_request_id
 from .http_client import get_http_client
 
 logger = logging.getLogger(__name__)
+
+
+def get_metric_collector():
+    """Indirection point so tests can monkeypatch at module level."""
+    from .metrics import get_metric_collector as _get
+    return _get()
+
+
+def _status_code_label(exc: BaseException) -> str:
+    if isinstance(exc, (TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(exc, (httpx.ConnectError, httpx.NetworkError, httpx.RemoteProtocolError)):
+        return "connection"
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    return str(status) if status else "other"
+
+
+def _count_failure(metric: str, exc: BaseException) -> None:
+    collector = get_metric_collector()
+    if collector is not None:
+        collector.record(metric, 1, status_code=_status_code_label(exc))
 
 # Keep the post-tower UUID fresh, but allow transient /ready failures to use
 # the last known UUID briefly instead of disabling two-tower candidates.
@@ -148,13 +171,20 @@ async def predict_user_tower_single(
 
     client = get_http_client()
     async with timed(logger, "user_tower_http", n_history=len(history_embeddings)):
-        resp = await client.post(url, json=payload, headers=headers)
+        try:
+            resp = await client.post(url, json=payload, headers=headers)
+        except httpx.HTTPError as exc:
+            _count_failure("rank.model.failure_count", exc)
+            raise
     if resp.is_error:
         logger.error(
             "user-tower predict failed status=%s body=%s",
             resp.status_code,
             resp.text,
         )
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record("rank.model.failure_count", 1, status_code=str(resp.status_code))
         raise_inference_response_error("user-tower", resp.status_code, resp.text)
     payload = _decode_inference_json("user-tower", resp)
     return _extract_inference_outputs("user-tower", payload)
@@ -191,13 +221,20 @@ async def predict_heavy_ranker_single_user(
         n_history=len(history_embeddings),
         n_candidates=len(candidate_post_embeddings)
     ):
-        resp = await client.post(url, json=payload, headers=headers)
+        try:
+            resp = await client.post(url, json=payload, headers=headers)
+        except httpx.HTTPError as exc:
+            _count_failure("rank.model.failure_count", exc)
+            raise
     if resp.is_error:
         logger.error(
             "ranker predict failed status=%s body=%s",
             resp.status_code,
             resp.text,
         )
+        collector = get_metric_collector()
+        if collector is not None:
+            collector.record("rank.model.failure_count", 1, status_code=str(resp.status_code))
         raise_inference_response_error("ranker", resp.status_code, resp.text)
     payload = _decode_inference_json("ranker", resp)
     return _extract_inference_outputs("ranker", payload)

--- a/src/app/lib/inference_test.py
+++ b/src/app/lib/inference_test.py
@@ -3,9 +3,18 @@
 import asyncio
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from . import inference as inference_module
+
+
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
 
 
 @pytest.fixture(autouse=True)
@@ -154,6 +163,136 @@ async def test_predict_heavy_ranker_single_user_raises_for_http_error(monkeypatc
             base_url="https://inference.example",
             api_key="secret",
         )
+
+
+class TestPredictFailureCounters:
+    """rank.model.failure_count is recorded with a status_code label for
+    both prediction call paths."""
+
+    @pytest.mark.asyncio
+    async def test_ranker_counts_non_2xx_status(self, monkeypatch):
+        class FakeResponse:
+            is_error = True
+            status_code = 500
+            text = "ranker down"
+
+        class FakeClient:
+            async def post(self, url, json, headers):
+                return FakeResponse()
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(inference_module, "get_metric_collector", lambda: collector)
+        monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+        with pytest.raises(RuntimeError, match="ranker inference failed status=500"):
+            await inference_module.predict_heavy_ranker_single_user(
+                history_embeddings=[],
+                history_author_dids=[],
+                history_liked_at_times=[],
+                history_like_counts=[],
+                candidate_post_embeddings=[[0.0, 1.0]],
+                candidate_author_dids=["did:plc:candidate"],
+                candidate_like_counts=[0],
+                base_url="https://inference.example",
+                api_key="secret",
+            )
+
+        assert ("rank.model.failure_count", 1, {"status_code": "500"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_ranker_counts_connect_errors(self, monkeypatch):
+        class FakeClient:
+            async def post(self, url, json, headers):
+                raise httpx.ConnectError("boom", request=httpx.Request("POST", url))
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(inference_module, "get_metric_collector", lambda: collector)
+        monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+        with pytest.raises(httpx.ConnectError):
+            await inference_module.predict_heavy_ranker_single_user(
+                history_embeddings=[],
+                history_author_dids=[],
+                history_liked_at_times=[],
+                history_like_counts=[],
+                candidate_post_embeddings=[[0.0, 1.0]],
+                candidate_author_dids=["did:plc:candidate"],
+                candidate_like_counts=[0],
+                base_url="https://inference.example",
+                api_key="secret",
+            )
+
+        assert ("rank.model.failure_count", 1, {"status_code": "connection"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_ranker_counts_read_timeout(self, monkeypatch):
+        class FakeClient:
+            async def post(self, url, json, headers):
+                raise httpx.ReadTimeout("boom", request=httpx.Request("POST", url))
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(inference_module, "get_metric_collector", lambda: collector)
+        monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+        with pytest.raises(httpx.ReadTimeout):
+            await inference_module.predict_heavy_ranker_single_user(
+                history_embeddings=[],
+                history_author_dids=[],
+                history_liked_at_times=[],
+                history_like_counts=[],
+                candidate_post_embeddings=[[0.0, 1.0]],
+                candidate_author_dids=["did:plc:candidate"],
+                candidate_like_counts=[0],
+                base_url="https://inference.example",
+                api_key="secret",
+            )
+
+        assert ("rank.model.failure_count", 1, {"status_code": "timeout"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_user_tower_counts_non_2xx_status(self, monkeypatch):
+        class FakeResponse:
+            is_error = True
+            status_code = 503
+            text = "user-tower down"
+
+        class FakeClient:
+            async def post(self, url, json, headers):
+                return FakeResponse()
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(inference_module, "get_metric_collector", lambda: collector)
+        monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+        with pytest.raises(RuntimeError, match="user-tower inference failed status=503"):
+            await inference_module.predict_user_tower_single(
+                history_embeddings=[],
+                history_author_dids=[],
+                base_url="https://inference.example",
+                api_key="secret",
+            )
+
+        assert ("rank.model.failure_count", 1, {"status_code": "503"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_user_tower_counts_connect_errors(self, monkeypatch):
+        class FakeClient:
+            async def post(self, url, json, headers):
+                raise httpx.ConnectError("boom", request=httpx.Request("POST", url))
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(inference_module, "get_metric_collector", lambda: collector)
+        monkeypatch.setattr(inference_module, "get_http_client", lambda: FakeClient())
+
+        with pytest.raises(httpx.ConnectError):
+            await inference_module.predict_user_tower_single(
+                history_embeddings=[],
+                history_author_dids=[],
+                base_url="https://inference.example",
+                api_key="secret",
+            )
+
+        assert ("rank.model.failure_count", 1, {"status_code": "connection"}) in collector.records
 
 
 @pytest.mark.asyncio

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import time
+from urllib.parse import urlsplit
 
 import aiohttp
 
@@ -47,6 +48,13 @@ def _perspective_url() -> str:
     """Perspective API endpoint URL, overridable via GE_PERSPECTIVE_HOST for local profiling."""
     host = os.environ.get("GE_PERSPECTIVE_HOST", _PERSPECTIVE_HOST_DEFAULT)
     return f"{host}/v1alpha1/comments:analyze"
+
+
+def _perspective_host_label() -> str:
+    """Host label for the `client.in_flight` metric, matching the httpx
+    transport's host-label semantics (InFlightTransport uses
+    `request.url.host`)."""
+    return urlsplit(_perspective_url()).hostname or "unknown"
 
 
 class PerspectiveLanguageNotSupportedError(Exception):
@@ -146,6 +154,7 @@ class PerspectiveClient:
             raise RuntimeError("GE_PERSPECTIVE_API_KEY environment variable is not set")
         self._api_key = key
         self._session: aiohttp.ClientSession | None = None
+        self._in_flight = 0
 
     def _get_session(self) -> aiohttp.ClientSession:
         """Lazily build the dedicated aiohttp session.
@@ -221,29 +230,46 @@ class PerspectiveClient:
         session = self._get_session()
         timeout = aiohttp.ClientTimeout(total=_SCORE_TIMEOUT_SECONDS)
 
-        for attempt in range(_SCORE_ATTEMPTS):
-            try:
-                async with timed(logger, "perspective.score.duration_ms", record_metric=True):
-                    async with session.post(
-                        _perspective_url(),
-                        params={"key": self._api_key},
-                        json=payload,
-                        timeout=timeout,
-                    ) as response:
-                        if response.status != 200:
-                            await self._handle_error_response(response, content)
-                        data = await response.json()
-                return self._extract_score(data)
-            except TimeoutError:
-                if attempt == _SCORE_ATTEMPTS - 1:
-                    raise
-                logger.warning(
-                    "Perspective API timeout (%ss) scoring content %.80r; retrying",
-                    _SCORE_TIMEOUT_SECONDS,
-                    content,
+        # `client.in_flight` is the saturation signal for this session: the
+        # connector is unbounded (limit=0/limit_per_host=0, see
+        # _get_session), so `client.pool.wait_ms` can structurally never
+        # fire here -- there's no pool cap to queue behind. This counter
+        # tracks concurrent score() calls instead. Increment/record happen
+        # inside the try so the `finally` decrement always runs, even if
+        # `collector.record` itself raises.
+        self._in_flight += 1
+        try:
+            collector = get_metric_collector()
+            if collector is not None:
+                collector.record(
+                    "client.in_flight", self._in_flight, host=_perspective_host_label()
                 )
 
-        raise AssertionError("unreachable: loop above always returns or raises")
+            for attempt in range(_SCORE_ATTEMPTS):
+                try:
+                    async with timed(logger, "perspective.score.duration_ms", record_metric=True):
+                        async with session.post(
+                            _perspective_url(),
+                            params={"key": self._api_key},
+                            json=payload,
+                            timeout=timeout,
+                        ) as response:
+                            if response.status != 200:
+                                await self._handle_error_response(response, content)
+                            data = await response.json()
+                    return self._extract_score(data)
+                except TimeoutError:
+                    if attempt == _SCORE_ATTEMPTS - 1:
+                        raise
+                    logger.warning(
+                        "Perspective API timeout (%ss) scoring content %.80r; retrying",
+                        _SCORE_TIMEOUT_SECONDS,
+                        content,
+                    )
+
+            raise AssertionError("unreachable: loop above always returns or raises")
+        finally:
+            self._in_flight -= 1
 
 
 # Client-side rate limiter tracking usage within the current calendar-minute

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -32,7 +32,7 @@ def get_metric_collector():
 def _status_code_label(exc: BaseException) -> str:
     if isinstance(exc, TimeoutError):
         return "timeout"
-    if isinstance(exc, (aiohttp.ClientOSError, aiohttp.ClientConnectorError)):
+    if isinstance(exc, aiohttp.ClientConnectionError):
         return "connection"
     status = getattr(exc, "status", None) or getattr(getattr(exc, "response", None), "status_code", None)
     return str(status) if status else "other"

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -10,6 +10,7 @@ import time
 import aiohttp
 
 from ..models import CandidatePost
+from .client_metrics import aiohttp_trace_config
 from .http_client import get_http_client
 from .pipeline_context import DegradationEvent, DegradationStage, current_pipeline_context
 from .telemetry import timed
@@ -164,7 +165,10 @@ class PerspectiveClient:
                 enable_cleanup_closed=True,
                 keepalive_timeout=45,
             )
-            self._session = aiohttp.ClientSession(connector=connector)
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                trace_configs=[aiohttp_trace_config("perspective")],
+            )
         return self._session
 
     async def close(self) -> None:

--- a/src/app/lib/perspective.py
+++ b/src/app/lib/perspective.py
@@ -21,6 +21,27 @@ _SCORE_TIMEOUT_SECONDS = 1.0
 _SCORE_ATTEMPTS = 2
 
 
+def get_metric_collector():
+    """Indirection point so tests can monkeypatch at module level."""
+    from .metrics import get_metric_collector as _get
+    return _get()
+
+
+def _status_code_label(exc: BaseException) -> str:
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, (aiohttp.ClientOSError, aiohttp.ClientConnectorError)):
+        return "connection"
+    status = getattr(exc, "status", None) or getattr(getattr(exc, "response", None), "status_code", None)
+    return str(status) if status else "other"
+
+
+def _count_failure(metric: str, exc: BaseException) -> None:
+    collector = get_metric_collector()
+    if collector is not None:
+        collector.record(metric, 1, status_code=_status_code_label(exc))
+
+
 def _perspective_url() -> str:
     """Perspective API endpoint URL, overridable via GE_PERSPECTIVE_HOST for local profiling."""
     host = os.environ.get("GE_PERSPECTIVE_HOST", _PERSPECTIVE_HOST_DEFAULT)
@@ -279,6 +300,9 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
             return None
         if not await _rate_limit_acquire():
             logger.warning("Perspective API minute quota exhausted; using missing score for post %s", c.at_uri)
+            collector = get_metric_collector()
+            if collector is not None:
+                collector.record("perspective.score.failure_count", 1, status_code="quota")
             return None
         try:
             return await client.score(c.content)
@@ -290,6 +314,7 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
             )
             return None  # expected — not a degradation
         except aiohttp.ClientResponseError as exc:
+            _count_failure("perspective.score.failure_count", exc)
             if exc.status == 429:
                 logger.warning(
                     "Perspective API rate limited for post %s; using missing score", c.at_uri
@@ -305,6 +330,7 @@ async def score_candidates(candidates: list[CandidatePost]) -> dict[str, float |
                 ))
             return None
         except Exception as exc:
+            _count_failure("perspective.score.failure_count", exc)
             logger.exception("Perspective API scoring failed for post %s", c.at_uri)
             ctx = current_pipeline_context()
             if ctx is not None:

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -615,6 +615,23 @@ class TestScoreCandidatesFailureCounters:
         assert ("perspective.score.failure_count", 1, {"status_code": "connection"}) in collector.records
 
     @pytest.mark.asyncio
+    async def test_counts_server_disconnected_as_connection(self, monkeypatch):
+        """aiohttp.ServerDisconnectedError is a ClientConnectionError but not
+        a ClientOSError/ClientConnectorError -- it must still classify as
+        "connection" now that the branch is broadened to the common
+        ancestor."""
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(side_effect=aiohttp.ServerDisconnectedError())
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert ("perspective.score.failure_count", 1, {"status_code": "connection"}) in collector.records
+
+    @pytest.mark.asyncio
     async def test_counts_other_500_failures(self, monkeypatch):
         collector = _RecordingCollector()
         monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -475,6 +475,108 @@ class TestClosePerspectiveClient:
 # ---------------------------------------------------------------------------
 
 
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+
+class TestScoreCandidatesFailureCounters:
+    """perspective.score.failure_count is recorded with a status_code label
+    for every external-reason scoring failure, but not for expected content
+    behavior (unsupported language)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_perspective_client(self, monkeypatch):
+        monkeypatch.setattr(perspective_module, "_client", None)
+
+    @pytest.mark.asyncio
+    async def test_counts_429_failures(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(
+            side_effect=aiohttp.ClientResponseError(MagicMock(), (), status=429)
+        )
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        result = await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert result == {"at://a": None}
+        assert ("perspective.score.failure_count", 1, {"status_code": "429"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_timeout_failures(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(side_effect=TimeoutError())
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert ("perspective.score.failure_count", 1, {"status_code": "timeout"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_connection_errors(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(side_effect=aiohttp.ClientOSError(9, "Bad file descriptor"))
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert ("perspective.score.failure_count", 1, {"status_code": "connection"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_other_500_failures(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(
+            side_effect=aiohttp.ClientResponseError(MagicMock(), (), status=500)
+        )
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert ("perspective.score.failure_count", 1, {"status_code": "500"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_counts_quota_exhaustion(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        fake = _fake_client([0.9])
+        perspective_module._rate_bucket_minute = int(__import__("time").time()) // 60
+        perspective_module._rate_count = perspective_module._QUOTA_RPM
+        monkeypatch.setattr(perspective_module, "_client", fake)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert ("perspective.score.failure_count", 1, {"status_code": "quota"}) in collector.records
+
+    @pytest.mark.asyncio
+    async def test_does_not_count_language_not_supported(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        mock_client = MagicMock()
+        mock_client.score = AsyncMock(side_effect=PerspectiveLanguageNotSupportedError("ja"))
+        monkeypatch.setattr(perspective_module, "_client", mock_client)
+
+        await score_candidates([_make_candidate("at://a", content="hi")])
+
+        assert not [r for r in collector.records if r[0] == "perspective.score.failure_count"]
+
+
 class TestScoreCandidatesDegradation:
     """Unexpected Perspective errors record DegradationEvent; expected errors don't."""
 

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -148,6 +148,22 @@ class _FakeResponseCM:
         return False
 
 
+class _BlockingResponseCM:
+    """Async context manager whose __aenter__ blocks on an asyncio.Event,
+    to overlap concurrent score() calls in flight-tracking tests."""
+
+    def __init__(self, event: "asyncio.Event", response):
+        self._event = event
+        self._response = response
+
+    async def __aenter__(self):
+        await self._event.wait()
+        return self._response
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
 class _TimeoutCM:
     """Async context manager that raises TimeoutError on entry, simulating a
     request that blew past aiohttp.ClientTimeout."""
@@ -322,6 +338,49 @@ class TestPerspectiveClientScore:
             client = PerspectiveClient()
 
         asyncio.run(client.close())  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_score_records_in_flight_and_resets_after_completion(self, monkeypatch):
+        """client.in_flight is the saturation signal for Perspective's
+        unbounded connector: two concurrent score() calls against a blocked
+        session record samples [1, 2]; a later, non-overlapping call
+        records 1 again -- the counter doesn't leak across calls."""
+        import asyncio
+
+        from .perspective import PerspectiveClient
+
+        collector = _RecordingCollector()
+        monkeypatch.setattr(perspective_module, "get_metric_collector", lambda: collector)
+
+        release = asyncio.Event()
+        response = _fake_response(status=200, json_body=_SUCCESS_BODY)
+        session = MagicMock()
+        session.post = MagicMock(return_value=_BlockingResponseCM(release, response))
+
+        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+            client = PerspectiveClient()
+
+        with patch.object(PerspectiveClient, "_get_session", return_value=session):
+            t1 = asyncio.create_task(client.score("hi"))
+            t2 = asyncio.create_task(client.score("there"))
+            await asyncio.sleep(0.01)  # let both reach the blocked response
+            release.set()
+            await asyncio.gather(t1, t2)
+
+            concurrent_samples = [
+                (v, a) for n, v, a in collector.records if n == "client.in_flight"
+            ]
+            assert sorted(v for v, _ in concurrent_samples) == [1, 2]
+            assert all(a == {"host": "commentanalyzer.googleapis.com"} for _, a in concurrent_samples)
+
+            # A later, non-overlapping call starts from a reset counter.
+            release2 = asyncio.Event()
+            release2.set()
+            session.post = MagicMock(return_value=_BlockingResponseCM(release2, response))
+            await client.score("again")
+
+        later_samples = [v for n, v, _ in collector.records if n == "client.in_flight"]
+        assert later_samples[-1] == 1
 
 
 class TestScoreCandidates:

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -357,10 +357,19 @@ class TestPerspectiveClientScore:
         session = MagicMock()
         session.post = MagicMock(return_value=_BlockingResponseCM(release, response))
 
-        with patch.dict("os.environ", {"GE_PERSPECTIVE_API_KEY": "test-key"}):
+        # Pin the host: the label is derived from GE_PERSPECTIVE_HOST, which is
+        # set to a stub in the local dev environment, so asserting the
+        # production hostname would make this test environment-dependent.
+        env = {
+            "GE_PERSPECTIVE_API_KEY": "test-key",
+            "GE_PERSPECTIVE_HOST": "https://perspective.test",
+        }
+        with patch.dict("os.environ", env):
             client = PerspectiveClient()
 
-        with patch.object(PerspectiveClient, "_get_session", return_value=session):
+        with patch.dict("os.environ", env), patch.object(
+            PerspectiveClient, "_get_session", return_value=session
+        ):
             t1 = asyncio.create_task(client.score("hi"))
             t2 = asyncio.create_task(client.score("there"))
             await asyncio.sleep(0.01)  # let both reach the blocked response
@@ -371,7 +380,7 @@ class TestPerspectiveClientScore:
                 (v, a) for n, v, a in collector.records if n == "client.in_flight"
             ]
             assert sorted(v for v, _ in concurrent_samples) == [1, 2]
-            assert all(a == {"host": "commentanalyzer.googleapis.com"} for _, a in concurrent_samples)
+            assert all(a == {"host": "perspective.test"} for _, a in concurrent_samples)
 
             # A later, non-overlapping call starts from a reset counter.
             release2 = asyncio.Event()

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -1,5 +1,6 @@
 """Tests for PRC scoring and Perspective API candidate scoring."""
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/src/app/lib/perspective_test.py
+++ b/src/app/lib/perspective_test.py
@@ -291,7 +291,8 @@ class TestPerspectiveClientScore:
                     enable_cleanup_closed=True,
                     keepalive_timeout=45,
                 )
-                mock_session_cls.assert_called_once_with(connector=mock_connector.return_value)
+                assert mock_session_cls.call_args.kwargs["connector"] == mock_connector.return_value
+                assert len(mock_session_cls.call_args.kwargs["trace_configs"]) == 1
 
         asyncio.run(_build())
 
@@ -481,6 +482,26 @@ class _RecordingCollector:
 
     def record(self, name, value, **attrs):
         self.records.append((name, value, attrs))
+
+
+def test_get_session_attaches_trace_config(monkeypatch):
+    import asyncio
+
+    captured = {}
+
+    class _FakeSession:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(perspective_module.aiohttp, "ClientSession", _FakeSession)
+    client = perspective_module.PerspectiveClient.__new__(perspective_module.PerspectiveClient)
+    client._session = None
+
+    async def _build():
+        client._get_session()
+
+    asyncio.run(_build())
+    assert len(captured["trace_configs"]) == 1
 
 
 class TestScoreCandidatesFailureCounters:


### PR DESCRIPTION
Part of #343 (PR C; stacked on #351). Generalizes the detectors for #344-class bottlenecks per review of PR #346's root causes.

Every dependency client now exposes (1) failure counts classified by cause and (2) its queue position, so client-side queuing is distinguishable from backend slowness for any pooled client or capped parallel workflow — not just the ES pool that bit us in #344.

# This PR

- `perspective.score.failure_count`, `bsky.follows.failure_count`, `rank.model.failure_count` — `status_code` label: HTTP status / `timeout` / `connection` / `other` (+ `quota` for Perspective). A simultaneous multi-dependency `connection` spike is the uvloop-fd-race signature from #344
- `es.query.error_count` (`op` + `error` labels) in the ES search wrapper
- `client_metrics.py`: aiohttp trace config recording `client.pool.wait_ms` + `client.connect.duration_ms` (Perspective session; pool-wait is an inert tripwire while the connector stays uncapped per #250 — documented); httpx `InFlightTransport` recording `client.in_flight` per host on the shared client (explicit `GE_HTTP_MAX_CONNECTIONS` cap, default 100)
- `es.client.in_flight` sampled per search in the ES wrapper; Perspective in-flight sampled per score() — p95 pinned at a cap = pool saturation before latency shows it
- bsky follow-lookup failures counted exactly once per lookup across all paths

# Testing

- `pipenv run pytest -q` — 1030 passed, on the host and **inside the devenv container**
- Per-class classification tests (429/500/timeout/connection/other/quota) for each module; concurrency tests for all three in-flight counters; bsky single-count invariant pinned across first-page, partial, malformed, and budget-timeout paths
- **Verified against real services in devenv** (not just mocks): a real ES query through the wrapper with `op=` succeeds and records `took_ms` from the real response (`op` never reaches the ES client); concurrent real searches drive `es.client.in_flight` to 1→2→3; a real ES failure records `es.query.error_count`; the shared httpx client wraps `InFlightTransport` and real inference calls succeed with no counter leak; a real aiohttp request with the trace config records `client.connect.duration_ms`; a full `random` feed renders clean with no tracebacks
- devenv testing also caught an environment-dependent test here: the in-flight test hard-coded the production Perspective hostname and failed against the devenv stub — now pinned via `GE_PERSPECTIVE_HOST`

🤖 Generated with [Claude Code](https://claude.com/claude-code)