### PR TITLE
Annotate PostHog events with surface and schema_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,34 @@ Disable when done (full capture has storage/perf cost):
 pipenv run scripts/feed_debug.py [username].bsky.social --environment stage --disable
 ```
 
+## Analytics (PostHog)
+
+This service and the frontend write to the **same PostHog project**, so every
+event this service emits is annotated to identify its producer. Annotations are
+applied centrally in `src/app/lib/posthog_client.py` — call sites never set them.
+
+| Property | Value here | Purpose |
+|---|---|---|
+| `surface` | `greenearth_api` | Which producer emitted the event. The frontend stamps `greenearth_web`. |
+| `schema_version` | `1` | Version of *this surface's* event schema; scoped to `surface`, versioned independently of the frontend. |
+
+Conventions:
+
+- **Filter on `surface`** in any insight that should cover one producer rather
+  than both. Event names are not namespaced, so a name collision between the two
+  surfaces is possible and only `surface` separates them.
+- `schema_version` is only meaningful alongside `surface` — the two surfaces'
+  version numbers are unrelated. Bump it when an existing event's properties
+  change shape in a way that would break a saved insight.
+- Annotations are applied *after* caller-supplied properties, so an event
+  property can never overwrite the partition key.
+- `scripts/backfill_posthog.py` stamps the same annotations, so historical
+  API-origin events are not a gap in the partition.
+
+`distinct_id` is the user's `did:plc:…` on both surfaces (the frontend's Firebase
+`uid` is that same DID), so a user is one PostHog person across both. Feature
+flags are evaluated on the DID for the same reason.
+
 ## Elasticsearch Query Profiling
 
 The API logs any ES query that exceeds `GE_SLOW_ES_THRESHOLD_MS` (default 500 ms) to Cloud Run as a

--- a/scripts/backfill_posthog.py
+++ b/scripts/backfill_posthog.py
@@ -43,7 +43,7 @@ from app.lib.firestore import (
     init_firestore_client,
     user_doc_id,
 )
-from app.lib.posthog_client import init_posthog_client
+from app.lib.posthog_client import annotate_event_properties, init_posthog_client
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +148,9 @@ async def backfill_users(
                 ph.capture(
                     distinct_id=user_did,
                     event="feedLoaded",
-                    properties={"feed_name": feed_name, "$set": set_props},
+                    properties=annotate_event_properties(
+                        {"feed_name": feed_name, "$set": set_props}
+                    ),
                     timestamp=first_seen_at,
                 )
 
@@ -204,7 +206,7 @@ async def backfill_interactions(
             ph.capture(
                 distinct_id=user_did,
                 event=event,
-                properties=properties,
+                properties=annotate_event_properties(properties),
                 timestamp=created_at,
             )
 

--- a/scripts/backfill_posthog_test.py
+++ b/scripts/backfill_posthog_test.py
@@ -17,6 +17,10 @@ NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
 EARLIER = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
 USER_DID = "did:plc:abc123"
 
+# Backfilled events are API-origin, so they carry the same annotations as live
+# ones -- otherwise historical data would be a hole in the surface partition.
+ANNOTATIONS = {"surface": "greenearth_api", "schema_version": 1}
+
 
 def _make_user_doc(user_did=USER_DID, username="alice.bsky.app", created_at=NOW):
     doc = MagicMock()
@@ -95,6 +99,7 @@ async def test_backfill_users_emits_feed_loaded_per_feed():
                 "username": "alice.bsky.app",
                 "posthog_created_at": NOW.isoformat(),
             },
+            **ANNOTATIONS,
         },
         timestamp=EARLIER,
     )
@@ -145,7 +150,7 @@ async def test_backfill_interactions_emits_one_event_per_doc():
     ph.capture.assert_called_once_with(
         distinct_id=USER_DID,
         event="interactionLike",
-        properties={"feed_name": "your-feed", "item_uri": "at://did/post/1"},
+        properties={"feed_name": "your-feed", "item_uri": "at://did/post/1", **ANNOTATIONS},
         timestamp=NOW,
     )
 

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -11,6 +11,21 @@ PostHog events emitted:
   feedLoaded       — one per getFeedSkeleton call (drives DAU/MAU/session counts)
   <interaction>    — behavioural events forwarded from sendInteractions
                      e.g. interactionLike, clickthroughItem, requestMore
+  redirectClicked  — UTM click counting. Keyed on the ``redirect_service``
+                     pseudo-user rather than a real DID: the click happens
+                     before we know who it was.
+
+Every event carries two annotations, applied by :func:`annotate_event_properties`:
+
+  surface         — which producer emitted the event. The frontend writes to the
+                    same PostHog project and stamps ``greenearth_web``; this
+                    service stamps ``greenearth_api``. Filter on it whenever an
+                    insight should cover one producer rather than both.
+  schema_version  — version of *this surface's* event schema. It is scoped to
+                    the surface, so it is only meaningful alongside it — the
+                    frontend versions its own schema independently. Bump it when
+                    an existing event's properties change shape in a way that
+                    would break a saved insight.
 """
 
 from __future__ import annotations
@@ -26,6 +41,24 @@ _posthog_client: Posthog | None = None
 
 FAIL_FAST_FLAG = "fail-fast-feed"
 NETWORK_LIKES_FLAG = "network-likes-in-your-feed"
+
+EVENT_SURFACE = "greenearth_api"
+EVENT_SCHEMA_VERSION = 1
+
+
+def annotate_event_properties(properties: dict) -> dict:
+    """Return *properties* stamped with the surface and schema version.
+
+    The annotations are applied last so a caller-supplied property can never
+    overwrite them — ``surface`` partitions this service's events from the
+    frontend's inside a shared PostHog project, and an event that could quietly
+    reassign itself to another producer would corrupt every insight built on it.
+    """
+    return {
+        **properties,
+        "surface": EVENT_SURFACE,
+        "schema_version": EVENT_SCHEMA_VERSION,
+    }
 
 
 def set_posthog_client(client: Posthog | None) -> None:
@@ -63,7 +96,7 @@ def track_session(
     client.capture(
         distinct_id=user_did,
         event="feedLoaded",
-        properties=properties,
+        properties=annotate_event_properties(properties),
         timestamp=timestamp,
     )
 
@@ -90,7 +123,7 @@ def track_interaction(
     client.capture(
         distinct_id=user_did,
         event=event,
-        properties=properties,
+        properties=annotate_event_properties(properties),
         timestamp=timestamp,
     )
 
@@ -107,7 +140,7 @@ def track_redirect(
     client.capture(
         distinct_id="redirect_service",
         event="redirectClicked",
-        properties={"slug": slug, "to": to, **utm_params},
+        properties=annotate_event_properties({"slug": slug, "to": to, **utm_params}),
     )
 
 

--- a/src/app/lib/posthog_client_test.py
+++ b/src/app/lib/posthog_client_test.py
@@ -6,18 +6,23 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.lib.posthog_client import (
+    EVENT_SCHEMA_VERSION,
+    EVENT_SURFACE,
     FAIL_FAST_FLAG,
     NETWORK_LIKES_FLAG,
+    annotate_event_properties,
     evaluate_feature_flags,
     get_posthog_client,
     init_posthog_client,
     set_posthog_client,
     track_interaction,
+    track_redirect,
     track_session,
 )
 
 NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
 USER_DID = "did:plc:abc123"
+ANNOTATIONS = {"surface": EVENT_SURFACE, "schema_version": EVENT_SCHEMA_VERSION}
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +68,7 @@ def test_track_session_captures_feed_loaded():
         properties={
             "feed_name": "your-feed",
             "$set": {"username": "alice.bsky.app"},
+            **ANNOTATIONS,
         },
         timestamp=NOW,
     )
@@ -76,7 +82,7 @@ def test_track_session_without_a_handle_still_captures_the_event():
     mock.capture.assert_called_once_with(
         distinct_id=USER_DID,
         event="feedLoaded",
-        properties={"feed_name": "your-feed"},
+        properties={"feed_name": "your-feed", **ANNOTATIONS},
         timestamp=NOW,
     )
 
@@ -99,7 +105,11 @@ def test_track_interaction_captures_event_with_uri():
     mock.capture.assert_called_once_with(
         distinct_id=USER_DID,
         event="interactionLike",
-        properties={"feed_name": "your-feed", "item_uri": "at://did/post/1"},
+        properties={
+            "feed_name": "your-feed",
+            "item_uri": "at://did/post/1",
+            **ANNOTATIONS,
+        },
         timestamp=NOW,
     )
 
@@ -110,9 +120,78 @@ def test_track_interaction_captures_event_without_uri():
     mock.capture.assert_called_once_with(
         distinct_id=USER_DID,
         event="requestMore",
-        properties={"feed_name": "your-feed"},
+        properties={"feed_name": "your-feed", **ANNOTATIONS},
         timestamp=NOW,
     )
+
+
+# ---------------------------------------------------------------------------
+# Event annotations (surface / schema_version)
+# ---------------------------------------------------------------------------
+
+
+def test_surface_identifies_this_service():
+    # The frontend stamps "greenearth_web" (see frontend PostHogAnalyticsService);
+    # both producers share one PostHog project, so the values must not collide.
+    assert EVENT_SURFACE == "greenearth_api"
+
+
+def test_annotate_adds_surface_and_schema_version():
+    assert annotate_event_properties({"feed_name": "your-feed"}) == {
+        "feed_name": "your-feed",
+        "surface": "greenearth_api",
+        "schema_version": EVENT_SCHEMA_VERSION,
+    }
+
+
+def test_annotate_does_not_mutate_the_callers_dict():
+    properties = {"feed_name": "your-feed"}
+    annotate_event_properties(properties)
+    assert properties == {"feed_name": "your-feed"}
+
+
+def test_annotations_win_over_caller_supplied_properties():
+    # The partition key must be un-overwritable: an event property named
+    # "surface" can't be allowed to silently move events to another producer.
+    annotated = annotate_event_properties({"surface": "not_the_api", "schema_version": 99})
+    assert annotated["surface"] == "greenearth_api"
+    assert annotated["schema_version"] == EVENT_SCHEMA_VERSION
+
+
+def test_every_captured_event_carries_the_annotations():
+    mock = MagicMock()
+    track_session(mock, USER_DID, "alice.bsky.app", "your-feed", NOW)
+    track_session(mock, USER_DID, None, "your-feed", NOW)
+    track_interaction(mock, USER_DID, "interactionLike", "your-feed", "at://did/post/1", NOW)
+    track_interaction(mock, USER_DID, "requestMore", "your-feed", None, NOW)
+    track_redirect(mock, "slug", "https://example.com", {"utm_source": "bsky"})
+
+    assert mock.capture.call_count == 5
+    for call in mock.capture.call_args_list:
+        properties = call.kwargs["properties"]
+        assert properties["surface"] == "greenearth_api"
+        assert properties["schema_version"] == EVENT_SCHEMA_VERSION
+
+
+def test_track_redirect_is_annotated_and_keeps_its_utm_params():
+    # redirectClicked is keyed on a pseudo-user rather than a DID, but it is
+    # still API-origin and must land on the same side of the surface partition.
+    mock = MagicMock()
+    track_redirect(mock, "launch", "https://example.com", {"utm_source": "bsky"})
+    mock.capture.assert_called_once_with(
+        distinct_id="redirect_service",
+        event="redirectClicked",
+        properties={
+            "slug": "launch",
+            "to": "https://example.com",
+            "utm_source": "bsky",
+            **ANNOTATIONS,
+        },
+    )
+
+
+def test_track_redirect_none_client_is_noop():
+    track_redirect(None, "launch", "https://example.com", {})
 
 
 def test_real_posthog_client_is_disabled_in_tests():


### PR DESCRIPTION
Closes #357

The frontend is adding PostHog instrumentation (greenearth-social/frontend#63) that writes to the same PostHog project this service already uses. Frontend events are stamped with `surface: "greenearth_web"` and `schema_version` at a single chokepoint; API events carried neither, so the only thing separating the two producers was PostHog's automatic `$lib` property (`web` vs `posthog-python`) — an SDK implementation detail rather than a convention we control, and one that can't express a third producer or schema evolution.

# This PR

Stamps every event this service emits with `surface: "greenearth_api"` and `schema_version: 1`. Specifically:

- Add `EVENT_SURFACE` / `EVENT_SCHEMA_VERSION` and `annotate_event_properties()` to `src/app/lib/posthog_client.py`
- Apply the annotations inside `track_session` and `track_interaction`, so no call site can forget them
- Apply annotations *after* caller-supplied properties, so an event property named `surface` can't silently reassign the event to another producer — the frontend spreads in the opposite order, which is a footgun worth not copying
- Stamp the same annotations in `scripts/backfill_posthog.py`, so historical API-origin events aren't a hole in the partition
- Document the cross-repo convention in `README.md` (new "Analytics (PostHog)" section), including that event names are *not* namespaced across surfaces so insights must filter on `surface`

`schema_version` is scoped to the surface — the frontend versions its own schema independently, so the number is only meaningful alongside `surface`.

No changes to event names, `distinct_id`, or feature-flag evaluation.

# Testing

- `pipenv run pytest` — 996 passed
- New tests in `src/app/lib/posthog_client_test.py`: annotations present on all four capture paths, caller properties can't override them, and `annotate_event_properties` doesn't mutate the caller's dict
- Updated existing assertions in `posthog_client_test.py` and `scripts/backfill_posthog_test.py` to expect the annotations
- `pipenv run ruff check` / `ruff format --check` on the touched files — clean (the repo has ~408 pre-existing lint errors across 83 files; the one `E402` reported in `posthog_client_test.py` is a pre-existing mid-file import, untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)