### PR TITLE
Add slugs for `/r` with admin CRUD endpoints

### DIFF
--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -444,6 +444,7 @@ class RedirectDocument(BaseModel):
 
     slug: str = Field(..., description="Short identifier (also the document ID)")
     url: str = Field(..., description="Destination https:// URL")
+    description: str | None = Field(default=None, description="Human-readable label for this redirect")
     created_at: datetime = Field(
         default_factory=_utcnow, description="When this mapping was created"
     )

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -434,3 +434,16 @@ class FeedSnapshotDocument(BaseModel):
     generator_diagnostics: list[GeneratorDiagnostic] = Field(default_factory=list)
     applied_social_radius: int | None = None
     items_meta: list[PipelineItemMeta] = Field(default_factory=list)
+
+
+class RedirectDocument(BaseModel):
+    """A slug → URL mapping stored in the ``redirects`` collection.
+
+    The document ID in Firestore is the slug itself (e.g. ``bsky-profile``).
+    """
+
+    slug: str = Field(..., description="Short identifier (also the document ID)")
+    url: str = Field(..., description="Destination https:// URL")
+    created_at: datetime = Field(
+        default_factory=_utcnow, description="When this mapping was created"
+    )

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -24,6 +24,7 @@ from ..documents import (
     FeedDebugDocument,
     FeedSnapshotDocument,
     InteractionDocument,
+    RedirectDocument,
     UserDocument,
 )
 
@@ -775,3 +776,54 @@ async def get_newer_feed_snapshot_uris(
             feed_name,
         )
         return set()
+
+
+# ---------------------------------------------------------------------------
+# Redirects
+# ---------------------------------------------------------------------------
+
+REDIRECTS_COLLECTION = "redirects"
+
+
+async def get_redirect(db: AsyncClient, slug: str) -> RedirectDocument | None:
+    """Fetch a redirect document by slug, or return ``None`` if not found."""
+    doc = await db.collection(REDIRECTS_COLLECTION).document(slug).get()
+    if not doc.exists:
+        return None
+    data = doc.to_dict()
+    if data is None:
+        return None
+    return RedirectDocument.model_validate(data)
+
+
+async def create_redirect(db: AsyncClient, slug: str, url: str) -> RedirectDocument:
+    """Create a new redirect document. Raises ``ValueError`` if slug already exists."""
+    ref = db.collection(REDIRECTS_COLLECTION).document(slug)
+    existing = await ref.get()
+    if existing.exists:
+        raise ValueError(f"Slug '{slug}' already exists")
+    record = RedirectDocument(slug=slug, url=url)
+    await ref.set(record.model_dump())
+    return record
+
+
+async def update_redirect(db: AsyncClient, slug: str, url: str) -> RedirectDocument | None:
+    """Update the URL for an existing slug. Returns ``None`` if the slug does not exist."""
+    ref = db.collection(REDIRECTS_COLLECTION).document(slug)
+    existing = await ref.get()
+    if not existing.exists:
+        return None
+    await ref.update({"url": url})
+    data = existing.to_dict() or {}
+    data["url"] = url
+    return RedirectDocument.model_validate(data)
+
+
+async def delete_redirect(db: AsyncClient, slug: str) -> bool:
+    """Delete a redirect document. Returns ``True`` if deleted, ``False`` if not found."""
+    ref = db.collection(REDIRECTS_COLLECTION).document(slug)
+    existing = await ref.get()
+    if not existing.exists:
+        return False
+    await ref.delete()
+    return True

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -796,26 +796,33 @@ async def get_redirect(db: AsyncClient, slug: str) -> RedirectDocument | None:
     return RedirectDocument.model_validate(data)
 
 
-async def create_redirect(db: AsyncClient, slug: str, url: str) -> RedirectDocument:
+async def create_redirect(
+    db: AsyncClient, slug: str, url: str, description: str | None = None
+) -> RedirectDocument:
     """Create a new redirect document. Raises ``ValueError`` if slug already exists."""
     ref = db.collection(REDIRECTS_COLLECTION).document(slug)
     existing = await ref.get()
     if existing.exists:
         raise ValueError(f"Slug '{slug}' already exists")
-    record = RedirectDocument(slug=slug, url=url)
+    record = RedirectDocument(slug=slug, url=url, description=description)
     await ref.set(record.model_dump())
     return record
 
 
-async def update_redirect(db: AsyncClient, slug: str, url: str) -> RedirectDocument | None:
-    """Update the URL for an existing slug. Returns ``None`` if the slug does not exist."""
+async def update_redirect(
+    db: AsyncClient, slug: str, url: str, description: str | None = None
+) -> RedirectDocument | None:
+    """Update the URL (and optionally description) for an existing slug. Returns ``None`` if not found."""
     ref = db.collection(REDIRECTS_COLLECTION).document(slug)
     existing = await ref.get()
     if not existing.exists:
         return None
-    await ref.update({"url": url})
+    updates: dict = {"url": url}
+    if description is not None:
+        updates["description"] = description
+    await ref.update(updates)
     data = existing.to_dict() or {}
-    data["url"] = url
+    data.update(updates)
     return RedirectDocument.model_validate(data)
 
 

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -94,6 +94,7 @@ def track_interaction(
 
 def track_redirect(
     client: Posthog | None,
+    slug: str,
     to: str,
     utm_params: dict[str, str],
 ) -> None:
@@ -103,7 +104,7 @@ def track_redirect(
     client.capture(
         distinct_id="redirect_service",
         event="redirectClicked",
-        properties={"to": to, **utm_params},
+        properties={"slug": slug, "to": to, **utm_params},
     )
 
 

--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -1,17 +1,77 @@
 from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 
+from ..lib.firestore import create_redirect, delete_redirect, get_redirect, update_redirect
 from ..lib.posthog_client import get_posthog_client, track_redirect
+from ..security import RequireApiKey
 
 router = APIRouter(tags=["redirect"])
 
-_UTM_KEYS = ("utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term")
+
+def _build_destination(base_url: str, utm_params: dict[str, str]) -> str:
+    """Append utm_params to base_url, preserving any existing query params."""
+    parsed: ParseResult = urlparse(base_url)
+    existing = parse_qs(parsed.query, keep_blank_values=False)
+    existing.update({k: [v] for k, v in utm_params.items()})
+    new_query = urlencode({k: v[0] for k, v in existing.items()})
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def _extract_utm(
+    utm_source: str | None,
+    utm_medium: str | None,
+    utm_campaign: str | None,
+    utm_content: str | None,
+    utm_term: str | None,
+) -> dict[str, str]:
+    return {
+        k: v
+        for k, v in {
+            "utm_source": utm_source,
+            "utm_medium": utm_medium,
+            "utm_campaign": utm_campaign,
+            "utm_content": utm_content,
+            "utm_term": utm_term,
+        }.items()
+        if v
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public redirect endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/r/{slug}", status_code=302, include_in_schema=True)
+async def redirect_slug(
+    request: Request,
+    slug: str,
+    utm_source: str | None = Query(None),
+    utm_medium: str | None = Query(None),
+    utm_campaign: str | None = Query(None),
+    utm_content: str | None = Query(None),
+    utm_term: str | None = Query(None),
+) -> RedirectResponse:
+    """302-redirect to the URL registered for *slug* with UTM params appended."""
+    db = getattr(request.app.state, "firestore", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Firestore unavailable")
+
+    record = await get_redirect(db, slug)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Slug '{slug}' not found")
+
+    utm_params = _extract_utm(utm_source, utm_medium, utm_campaign, utm_content, utm_term)
+    destination = _build_destination(record.url, utm_params)
+    track_redirect(get_posthog_client(), slug, record.url, utm_params)
+    return RedirectResponse(url=destination, status_code=302)
 
 
 @router.get("/r", status_code=302, include_in_schema=True)
-async def redirect(
+async def redirect_to(
     to: str | None = Query(None, description="Destination URL (must be https://)"),
     utm_source: str | None = Query(None),
     utm_medium: str | None = Query(None),
@@ -26,19 +86,81 @@ async def redirect(
     if parsed.scheme != "https" or not parsed.netloc:
         raise HTTPException(status_code=400, detail="to must be a valid https:// URL")
 
-    utm_values = {
-        "utm_source": utm_source,
-        "utm_medium": utm_medium,
-        "utm_campaign": utm_campaign,
-        "utm_content": utm_content,
-        "utm_term": utm_term,
-    }
-    extra = {k: v for k, v in utm_values.items() if v}
-
-    existing = parse_qs(parsed.query, keep_blank_values=False)
-    existing.update({k: [v] for k, v in extra.items()})
-    new_query = urlencode({k: v[0] for k, v in existing.items()})
-
-    destination = urlunparse(parsed._replace(query=new_query))
-    track_redirect(get_posthog_client(), to, extra)
+    utm_params = _extract_utm(utm_source, utm_medium, utm_campaign, utm_content, utm_term)
+    destination = _build_destination(to, utm_params)
+    track_redirect(get_posthog_client(), "direct", to, utm_params)
     return RedirectResponse(url=destination, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# Admin CRUD endpoints (require API key)
+# ---------------------------------------------------------------------------
+
+
+class RedirectCreateRequest(BaseModel):
+    slug: str
+    url: str
+
+
+class RedirectUpdateRequest(BaseModel):
+    url: str
+
+
+class RedirectResponse_(BaseModel):
+    slug: str
+    url: str
+
+
+@router.post("/admin/redirects", status_code=201)
+async def admin_create_redirect(
+    body: RedirectCreateRequest,
+    request: Request,
+    _key: RequireApiKey,
+) -> RedirectResponse_:
+    """Create a new slug → URL mapping."""
+    db = getattr(request.app.state, "firestore", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Firestore unavailable")
+    parsed = urlparse(body.url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="url must be a valid https:// URL")
+    try:
+        record = await create_redirect(db, body.slug, body.url)
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    return RedirectResponse_(slug=record.slug, url=record.url)
+
+
+@router.put("/admin/redirects/{slug}", status_code=200)
+async def admin_update_redirect(
+    slug: str,
+    body: RedirectUpdateRequest,
+    request: Request,
+    _key: RequireApiKey,
+) -> RedirectResponse_:
+    """Update the destination URL for an existing slug."""
+    db = getattr(request.app.state, "firestore", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Firestore unavailable")
+    parsed = urlparse(body.url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="url must be a valid https:// URL")
+    record = await update_redirect(db, slug, body.url)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Slug '{slug}' not found")
+    return RedirectResponse_(slug=record.slug, url=record.url)
+
+
+@router.delete("/admin/redirects/{slug}", status_code=204)
+async def admin_delete_redirect(
+    slug: str,
+    request: Request,
+    _key: RequireApiKey,
+) -> None:
+    """Delete a slug → URL mapping."""
+    db = getattr(request.app.state, "firestore", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="Firestore unavailable")
+    deleted = await delete_redirect(db, slug)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Slug '{slug}' not found")

--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -100,15 +100,18 @@ async def redirect_to(
 class RedirectCreateRequest(BaseModel):
     slug: str
     url: str
+    description: str | None = None
 
 
 class RedirectUpdateRequest(BaseModel):
     url: str
+    description: str | None = None
 
 
 class RedirectResponse_(BaseModel):
     slug: str
     url: str
+    description: str | None = None
 
 
 @router.post("/admin/redirects", status_code=201)
@@ -125,10 +128,10 @@ async def admin_create_redirect(
     if parsed.scheme != "https" or not parsed.netloc:
         raise HTTPException(status_code=400, detail="url must be a valid https:// URL")
     try:
-        record = await create_redirect(db, body.slug, body.url)
+        record = await create_redirect(db, body.slug, body.url, body.description)
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-    return RedirectResponse_(slug=record.slug, url=record.url)
+    return RedirectResponse_(slug=record.slug, url=record.url, description=record.description)
 
 
 @router.put("/admin/redirects/{slug}", status_code=200)
@@ -145,10 +148,10 @@ async def admin_update_redirect(
     parsed = urlparse(body.url)
     if parsed.scheme != "https" or not parsed.netloc:
         raise HTTPException(status_code=400, detail="url must be a valid https:// URL")
-    record = await update_redirect(db, slug, body.url)
+    record = await update_redirect(db, slug, body.url, body.description)
     if record is None:
         raise HTTPException(status_code=404, detail=f"Slug '{slug}' not found")
-    return RedirectResponse_(slug=record.slug, url=record.url)
+    return RedirectResponse_(slug=record.slug, url=record.url, description=record.description)
 
 
 @router.delete("/admin/redirects/{slug}", status_code=204)

--- a/src/app/routers/redirect_test.py
+++ b/src/app/routers/redirect_test.py
@@ -1,7 +1,26 @@
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
+
+from ..documents import RedirectDocument
 from ..main import app
 
 client = TestClient(app, follow_redirects=False)
+
+_VALID_API_KEY = "test-api-key"
+
+
+def _make_record(slug: str, url: str) -> RedirectDocument:
+    return RedirectDocument(slug=slug, url=url)
+
+
+def _auth() -> dict:
+    return {"X-API-Key": _VALID_API_KEY}
+
+
+# ---------------------------------------------------------------------------
+# GET /r?to=... (existing behaviour — must not regress)
+# ---------------------------------------------------------------------------
 
 
 def test_redirect_basic():
@@ -23,9 +42,7 @@ def test_redirect_appends_utm_params():
 
 
 def test_redirect_preserves_existing_query_params():
-    response = client.get(
-        "/r?to=https://example.com/page%3Ffoo%3Dbar&utm_source=bluesky"
-    )
+    response = client.get("/r?to=https://example.com/page%3Ffoo%3Dbar&utm_source=bluesky")
     assert response.status_code == 302
     location = response.headers["location"]
     assert "utm_source=bluesky" in location
@@ -47,10 +64,166 @@ def test_redirect_invalid_url_returns_400():
 
 
 def test_redirect_omits_empty_utm_params():
-    response = client.get(
-        "/r?to=https://bsky.app&utm_source=bluesky&utm_medium="
-    )
+    response = client.get("/r?to=https://bsky.app&utm_source=bluesky&utm_medium=")
     assert response.status_code == 302
     location = response.headers["location"]
     assert "utm_source=bluesky" in location
     assert "utm_medium" not in location
+
+
+# ---------------------------------------------------------------------------
+# GET /r/{slug}
+# ---------------------------------------------------------------------------
+
+
+def test_slug_redirect_resolves_and_redirects():
+    record = _make_record("bsky-profile", "https://bsky.app/profile/greenearth.social")
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.get_redirect", return_value=record):
+        response = client.get("/r/bsky-profile")
+    assert response.status_code == 302
+    assert response.headers["location"] == "https://bsky.app/profile/greenearth.social"
+
+
+def test_slug_redirect_appends_utm_params():
+    record = _make_record("bsky-profile", "https://bsky.app/profile/greenearth.social")
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.get_redirect", return_value=record):
+        response = client.get("/r/bsky-profile?utm_source=slack&utm_medium=chat")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "utm_source=slack" in location
+    assert "utm_medium=chat" in location
+
+
+def test_slug_redirect_unknown_slug_returns_404():
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.get_redirect", return_value=None):
+        response = client.get("/r/nonexistent")
+    assert response.status_code == 404
+
+
+def test_slug_redirect_no_firestore_returns_503():
+    original = getattr(app.state, "firestore", None)
+    try:
+        app.state.firestore = None
+        response = client.get("/r/bsky-profile")
+    finally:
+        if original is not None:
+            app.state.firestore = original
+        elif hasattr(app.state, "firestore"):
+            delattr(app.state, "firestore")
+    assert response.status_code == 503
+
+
+def test_slug_redirect_preserves_existing_query_params():
+    record = _make_record("search", "https://bsky.app/search?q=greenearth")
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.get_redirect", return_value=record):
+        response = client.get("/r/search?utm_source=twitter")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert "q=greenearth" in location
+    assert "utm_source=twitter" in location
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/redirects
+# ---------------------------------------------------------------------------
+
+
+def test_admin_create_redirect():
+    app.state.firestore = AsyncMock()
+    record = _make_record("new-slug", "https://example.com")
+    with patch("app.routers.redirect.create_redirect", return_value=record), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.post(
+            "/admin/redirects",
+            json={"slug": "new-slug", "url": "https://example.com"},
+            headers=_auth(),
+        )
+    assert response.status_code == 201
+    assert response.json()["slug"] == "new-slug"
+    assert response.json()["url"] == "https://example.com"
+
+
+def test_admin_create_redirect_conflict():
+    app.state.firestore = AsyncMock()
+    err = ValueError("Slug 'x' already exists")
+    with patch("app.routers.redirect.create_redirect", side_effect=err), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.post(
+            "/admin/redirects",
+            json={"slug": "x", "url": "https://example.com"},
+            headers=_auth(),
+        )
+    assert response.status_code == 409
+
+
+def test_admin_create_redirect_invalid_url():
+    app.state.firestore = AsyncMock()
+    with patch("app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")):
+        response = client.post(
+            "/admin/redirects",
+            json={"slug": "x", "url": "http://not-https.com"},
+            headers=_auth(),
+        )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/redirects/{slug}
+# ---------------------------------------------------------------------------
+
+
+def test_admin_update_redirect():
+    app.state.firestore = AsyncMock()
+    record = _make_record("bsky-profile", "https://new.example.com")
+    with patch("app.routers.redirect.update_redirect", return_value=record), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.put(
+            "/admin/redirects/bsky-profile",
+            json={"url": "https://new.example.com"},
+            headers=_auth(),
+        )
+    assert response.status_code == 200
+    assert response.json()["url"] == "https://new.example.com"
+
+
+def test_admin_update_redirect_not_found():
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.update_redirect", return_value=None), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.put(
+            "/admin/redirects/nonexistent",
+            json={"url": "https://example.com"},
+            headers=_auth(),
+        )
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /admin/redirects/{slug}
+# ---------------------------------------------------------------------------
+
+
+def test_admin_delete_redirect():
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.delete_redirect", return_value=True), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.delete("/admin/redirects/bsky-profile", headers=_auth())
+    assert response.status_code == 204
+
+
+def test_admin_delete_redirect_not_found():
+    app.state.firestore = AsyncMock()
+    with patch("app.routers.redirect.delete_redirect", return_value=False), patch(
+        "app.security.authenticate_api_key", return_value=AsyncMock(key_id="k1")
+    ):
+        response = client.delete("/admin/redirects/nonexistent", headers=_auth())
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Add `GET /r/{slug}` endpoint: looks up slug in Firestore `redirects` collection, appends UTM params, and 302-redirects. Returns 404 for unknown slugs, 503 if Firestore is unavailable.
- Add admin CRUD endpoints (`POST/PUT/DELETE /admin/redirects`) behind `X-API-Key` auth for managing slug → URL mappings without Firebase Console.
- Add `RedirectDocument` Pydantic model and Firestore helpers (`get/create/update/delete_redirect`).
- Keep existing `GET /r?to=...` endpoint unchanged (backward compatible).
- Update `track_redirect` to include `slug` property in PostHog events for cleaner breakdown.

## URLs available after this deploy
| Channel | URL |
|---|---|
| DemocracyLab slack | https://go.greenearth.social/r/dl |
| Prosocial Tech Collab slack | https://go.greenearth.social/r/ptc |
| SF Civic Tech slack | https://go.greenearth.social/r/sfct |
| RTH Community slack | https://go.greenearth.social/r/rth |
| Prosocial Design Network slack | https://go.greenearth.social/r/pdn |
| Digital Peacebuilding whatsapp | https://go.greenearth.social/r/dpwa |
| Peace Tech Ecosystem whatsapp | https://go.greenearth.social/r/pte |
| All Tech is Human slack | https://go.greenearth.social/r/atih |
| The Commons | https://go.greenearth.social/r/tc |
| Safe AI for Humanity | https://go.greenearth.social/r/safh |