### PR TITLE
Extract UTM params for PostHog tracking in slug redirect

### DIFF
--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -66,7 +66,15 @@ async def redirect_slug(
 
     utm_params = _extract_utm(utm_source, utm_medium, utm_campaign, utm_content, utm_term)
     destination = _build_destination(record.url, utm_params)
-    track_redirect(get_posthog_client(), slug, record.url, utm_params)
+
+    # Merge UTMs baked into stored URL with any request-level overrides for PostHog
+    stored_utm = {
+        k: v[0]
+        for k, v in parse_qs(urlparse(record.url).query).items()
+        if k.startswith("utm_")
+    }
+    stored_utm.update(utm_params)
+    track_redirect(get_posthog_client(), slug, record.url, stored_utm)
     return RedirectResponse(url=destination, status_code=302)
 
 


### PR DESCRIPTION
## Problem
<img width="956" height="291" alt="Screenshot 2026-08-04 at 11 05 47 AM" src="https://github.com/user-attachments/assets/08a81473-725d-4431-ad22-27e1956d72f3" />


## Summary

- PostHog was receiving `utm_source=None` for slug redirects because `track_redirect` only captured query params passed directly, so UTM params embedded in the stored `/r/{slug}` target URL were never being forwarded.
- Fix: parse UTM params from the stored URL in Firestore and merge them with request-level overrides before calling `track_redirect`.