### PR TITLE
Remove TWO_TOWER_MAX_AGE_CAP_HOURS; honor freshness window up to the current preset ceiling

### DIFF
--- a/src/app/lib/candidates/es_candidates.py
+++ b/src/app/lib/candidates/es_candidates.py
@@ -45,8 +45,7 @@ async def knn_search_posts(
 
     ``max_age_hours`` bounds candidates to recently created posts. It is typed
     ``int`` rather than ``MaxAgeHours`` because callers may pass a value off the
-    user-facing freshness ladder — ``two_tower`` caps its window below the
-    7-day default (see ``TWO_TOWER_MAX_AGE_CAP_HOURS``).
+    user-facing freshness ladder.
     """
     # Freshness filters returned candidate posts only. Actual availability can
     # be shorter when posts_recent retains less data than the requested bound.

--- a/src/app/lib/candidates/quality_index_test.py
+++ b/src/app/lib/candidates/quality_index_test.py
@@ -20,7 +20,7 @@ from ..elasticsearch import (
 from ..embeddings import GE_POST_EMBEDDING_FIELD
 from .es_candidates import knn_search_posts
 from .es_candidates_test import FakeEs
-from .two_tower import MIN_LIKE_COUNT, TWO_TOWER_MAX_AGE_CAP_HOURS, TwoTowerCandidateGenerator
+from .two_tower import MIN_LIKE_COUNT, TwoTowerCandidateGenerator
 
 INFERENCE_SETTINGS = ("https://inference", "api-key")
 GET_INFERENCE_SETTINGS = "app.lib.candidates.two_tower.get_inference_settings"
@@ -131,7 +131,7 @@ class TestTwoTowerUsesQualityIndex:
         # cross-repo constant that has to track ingex's own promotion
         # threshold for no behavioral benefit.
         assert kwargs["min_like_count"] is None
-        assert kwargs["max_age_hours"] == TWO_TOWER_MAX_AGE_CAP_HOURS
+        assert kwargs["max_age_hours"] == 168
 
     @pytest.mark.asyncio
     async def test_generate_honours_the_index_override(self, monkeypatch):

--- a/src/app/lib/candidates/two_tower.py
+++ b/src/app/lib/candidates/two_tower.py
@@ -32,20 +32,6 @@ logger = logging.getLogger(__name__)
 # values are intentionally independent: this one describes what bar the api
 # wants on an *unfiltered* corpus, not ingex's corpus-entry criterion.
 MIN_LIKE_COUNT = 20
-# Hard cap on the freshness window for two-tower, independent of the user's
-# freshness preference.
-#
-# This cap was introduced to bound a brute-force scan: against posts_recent the
-# selective MIN_LIKE_COUNT filter made Lucene abandon the HNSW graph and scan
-# every matching vector, so cost scaled with how many posts passed
-# like_count>=20 inside the window (~928k over the 7-day default, a ~30s cold
-# scan on prod, versus ~320k at 96h). Searching posts_recent_quality removes
-# that scan — membership *is* the like filter there, so the graph is used —
-# which removes this cap's original justification. It is left in place so the
-# index switch lands as a single variable; retiring it is greenearth-social/api#324.
-# Freshness preferences below this cap (6h-72h) pass through unchanged; only the
-# 7-day preset is clamped here.
-TWO_TOWER_MAX_AGE_CAP_HOURS = 96
 
 
 class TwoTowerCandidateGenerator(CandidateGenerator):
@@ -111,10 +97,6 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
                 reason="no_user_like_history",
             )
 
-        # Freshness filters returned candidates, not the interaction history
-        # used above to compute the user embedding. Cap the requested window at
-        # TWO_TOWER_MAX_AGE_CAP_HOURS to bound the brute-force vector scan.
-        effective_max_age_hours = min(max_age_hours, TWO_TOWER_MAX_AGE_CAP_HOURS)
         resolved_index = two_tower_knn_index()
         # Only apply the traction filter on the posts_recent fallback — see
         # MIN_LIKE_COUNT's docstring for why it would be redundant against the
@@ -124,7 +106,7 @@ class TwoTowerCandidateGenerator(CandidateGenerator):
             es, user_embedding, num_candidates, search_field=GE_POST_EMBEDDING_FIELD,
             generator_name=self.name, video_only=video_only, exclude_uris=exclude_uris,
             ge_post_embedding_model_uuid=post_tower_uuid, min_like_count=min_like_count,
-            max_age_hours=effective_max_age_hours,
+            max_age_hours=max_age_hours,
             index=resolved_index,
         )
 

--- a/src/app/lib/candidates/two_tower_test.py
+++ b/src/app/lib/candidates/two_tower_test.py
@@ -6,10 +6,7 @@ import pytest
 
 from ...models import CandidatePost
 from ..candidates import get_generator, list_generators
-from ..candidates.two_tower import (
-    TWO_TOWER_MAX_AGE_CAP_HOURS,
-    TwoTowerCandidateGenerator,
-)
+from ..candidates.two_tower import TwoTowerCandidateGenerator
 from ..elasticsearch import POSTS_QUALITY_KNN_INDEX
 from ..embeddings import GE_POST_EMBEDDING_FIELD
 
@@ -111,7 +108,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=["at://old/1", "at://old/2"],
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=None,
-            max_age_hours=TWO_TOWER_MAX_AGE_CAP_HOURS,
+            max_age_hours=168,
             index=POSTS_QUALITY_KNN_INDEX,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
@@ -225,18 +222,16 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=None,
-            max_age_hours=TWO_TOWER_MAX_AGE_CAP_HOURS,
+            max_age_hours=168,
             index=POSTS_QUALITY_KNN_INDEX,
         )
         assert result.generator_name == TWO_TOWER_GENERATOR_NAME
         assert result.candidates == []
 
     @pytest.mark.asyncio
-    async def test_generate_passes_fresher_window_below_cap_through(self, generator):
-        # A freshness preset below the cap is honored as-is; only windows above
-        # TWO_TOWER_MAX_AGE_CAP_HOURS get clamped.
-        fresh_hours = 24
-        assert fresh_hours < TWO_TOWER_MAX_AGE_CAP_HOURS
+    async def test_generate_passes_max_age_hours_through_unclamped(self, generator):
+        # The requested window is honored as-is, with no serving-side cap.
+        fresh_hours = 168
         es = object()
         user_embedding = [0.5, 0.6]
 
@@ -300,7 +295,7 @@ class TestTwoTowerCandidateGenerator:
             exclude_uris=None,
             ge_post_embedding_model_uuid="post-tower-uuid",
             min_like_count=None,
-            max_age_hours=TWO_TOWER_MAX_AGE_CAP_HOURS,
+            max_age_hours=168,
             index=POSTS_QUALITY_KNN_INDEX,
         )
         assert result.candidates == []


### PR DESCRIPTION
Closes #324

`TWO_TOWER_MAX_AGE_CAP_HOURS = 96` (#311) was an emergency bound while the two_tower kNN query ran as a 30s cold brute-force scan (#310). #312's capacity work (heap/memory rebalance) has landed, so the serving-side cap can come out per product direction: candidate generators should honor the default (7d) or the user's chosen freshness window, not a hard-coded cap.

# This PR

- Remove `TWO_TOWER_MAX_AGE_CAP_HOURS` and the `effective_max_age_hours = min(...)` clamp in `two_tower.py` — `max_age_hours` now passes straight through to `knn_search_posts` like every other generator.
- Drop the now-stale `TWO_TOWER_MAX_AGE_CAP_HOURS` docstring reference in `es_candidates.py`.
- Update `two_tower_test.py` / `quality_index_test.py` to assert pass-through instead of clamping.

Out of scope (per issue, gated on the 14d preset shipping separately): extending `MaxAgeHours`/`documents.py` with a 336h option, and widening the `posts_recent` alias's weekly-index coverage.

# Testing

- `pipenv run pyright` — 0 errors
- `pipenv run pytest -v` — 1150 passed
- Verified in a dedicated devenv instance (`devctl up --name issue324`): api test suite green inside the container (1150 passed), and rendered `your-feed`/`random` feeds confirming `two_tower_user_side` runs cleanly with no errors, then `devctl nuke --name issue324`.