### PR TITLE
Network Likes Candidate Generator in Your Feed

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -317,7 +317,9 @@ FEEDS: dict[str, FeedConfig] = {
     ),
     "cold-start": FeedConfig(
         display_name="Cold Start",
-        description="Main Green Earth feed for a user with no like history and no followed accounts.",
+        description=(
+            "Main Green Earth feed for a user with no like history and no followed accounts."
+        ),
         public=False,
         internal_rkey="mf-cs",
         internal_display_name="mf CS",

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -92,7 +92,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="e2 S",
         avatar="assets/icons/unranked-your-feed.png",
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
+            generators=SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill="popularity",
             num_candidates=30,
             video_only=False,
@@ -138,7 +138,7 @@ FEEDS: dict[str, FeedConfig] = {
         min_rank_score=0.425,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
+            generators=SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill=None,
             num_candidates=30,
             video_only=False,
@@ -191,7 +191,7 @@ FEEDS: dict[str, FeedConfig] = {
         # Same generator mix as your-feed, so cutoff behavior here previews what
         # real users would see.
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
+            generators=SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill=None,
             num_candidates=30,
             video_only=False,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -28,24 +28,28 @@ SOCIAL_RADIUS_PRESETS: dict[int, list[GeneratorSpec]] = {
         GeneratorSpec(name="followed_users", weight=1.00),
     ],
     1: [  # Closer
-        GeneratorSpec(name="followed_users", weight=0.80),
+        GeneratorSpec(name="followed_users", weight=0.70),
         GeneratorSpec(name="two_tower", weight=0.10),
         GeneratorSpec(name="popularity", weight=0.10),
+        GeneratorSpec(name="network_likes", weight=0.10),
     ],
     2: [
-        GeneratorSpec(name="followed_users", weight=0.60),
-        GeneratorSpec(name="two_tower", weight=0.20),
-        GeneratorSpec(name="popularity", weight=0.20),
+        GeneratorSpec(name="followed_users", weight=0.50),
+        GeneratorSpec(name="two_tower", weight=0.15),
+        GeneratorSpec(name="popularity", weight=0.15),
+        GeneratorSpec(name="network_likes", weight=0.20),
     ],
     3: [  # Balanced — same as your-feed defaults
-        GeneratorSpec(name="followed_users", weight=0.40),
-        GeneratorSpec(name="two_tower", weight=0.30),
-        GeneratorSpec(name="popularity", weight=0.30),
+        GeneratorSpec(name="followed_users", weight=0.30),
+        GeneratorSpec(name="two_tower", weight=0.25),
+        GeneratorSpec(name="popularity", weight=0.25),
+        GeneratorSpec(name="network_likes", weight=0.20),
     ],
     4: [  # Everyone — mostly discovery
-        GeneratorSpec(name="followed_users", weight=0.20),
+        GeneratorSpec(name="followed_users", weight=0.10),
         GeneratorSpec(name="two_tower", weight=0.40),
         GeneratorSpec(name="popularity", weight=0.40),
+        GeneratorSpec(name="network_likes", weight=0.10),
     ],
 }
 
@@ -111,9 +115,10 @@ FEEDS: dict[str, FeedConfig] = {
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="followed_users", weight=0.40),
-                GeneratorSpec(name="two_tower", weight=0.30),
-                GeneratorSpec(name="popularity", weight=0.30),
+                GeneratorSpec(name="followed_users", weight=0.30),
+                GeneratorSpec(name="two_tower", weight=0.25),
+                GeneratorSpec(name="popularity", weight=0.25),
+                GeneratorSpec(name="network_likes", weight=0.20),
             ],
             infill=None,
             num_candidates=30,
@@ -168,9 +173,10 @@ FEEDS: dict[str, FeedConfig] = {
         # real users would see.
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="followed_users", weight=0.40),
-                GeneratorSpec(name="two_tower", weight=0.30),
-                GeneratorSpec(name="popularity", weight=0.30),
+                GeneratorSpec(name="followed_users", weight=0.30),
+                GeneratorSpec(name="two_tower", weight=0.25),
+                GeneratorSpec(name="popularity", weight=0.25),
+                GeneratorSpec(name="network_likes", weight=0.20),
             ],
             infill=None,
             num_candidates=30,
@@ -278,9 +284,26 @@ FEEDS: dict[str, FeedConfig] = {
             exclude_uris=[],
         ),
     ),
+    "two-tower-empty-history": FeedConfig(
+        display_name="TwoTower Cold Start",
+        description="Development feed — two-tower candidates for a user with no like history.",
+        internal_rkey="tt-eh",
+        internal_display_name="tt EH",
+        avatar="assets/icons/two-tower.png",
+        diversify=False,
+        exclude_seen_posts=False,
+        gen_request_template=CandidateGenerateRequest.model_construct(
+            generators=[
+                GeneratorSpec(name="two_tower_empty_history", weight=1.0),
+            ],
+            num_candidates=30,
+            video_only=False,
+            exclude_uris=[],
+        ),
+    ),
     "cold-start": FeedConfig(
         display_name="Cold Start",
-        description="Main Green Earth feed for a user with no like history.",
+        description="Main Green Earth feed for a user with no like history and no followed accounts.",
         public=False,
         internal_rkey="mf-cs",
         internal_display_name="mf CS",
@@ -290,9 +313,7 @@ FEEDS: dict[str, FeedConfig] = {
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[
-                GeneratorSpec(name="followed_users", weight=0.40),
-                GeneratorSpec(name="two_tower_empty_history", weight=0.30),
-                GeneratorSpec(name="popularity", weight=0.30),
+                GeneratorSpec(name="popularity", weight=1.0),
             ],
             infill=None,
             num_candidates=30,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -20,10 +20,12 @@ from .models import (
     RankPredictRequest,
 )
 
+DEFAULT_SOCIAL_RADIUS: int = 3
+
 # Social-radius preset generator weights for your-feed.
 # Index 3 (balanced) matches the default weights defined in the "your-feed"
 # FeedConfig below — keep them in sync when tuning.
-SOCIAL_RADIUS_PRESETS: dict[int, list[GeneratorSpec]] = {
+SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES: dict[int, list[GeneratorSpec]] = {
     0: [  # Friends — only from people you follow
         GeneratorSpec(name="followed_users", weight=1.00),
     ],
@@ -53,6 +55,32 @@ SOCIAL_RADIUS_PRESETS: dict[int, list[GeneratorSpec]] = {
     ],
 }
 
+SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES: dict[int, list[GeneratorSpec]] = {
+    0: [  # Friends — only from people you follow
+        GeneratorSpec(name="followed_users", weight=1.00),
+    ],
+    1: [  # Closer
+        GeneratorSpec(name="followed_users", weight=0.80),
+        GeneratorSpec(name="two_tower", weight=0.10),
+        GeneratorSpec(name="popularity", weight=0.10),
+    ],
+    2: [
+        GeneratorSpec(name="followed_users", weight=0.60),
+        GeneratorSpec(name="two_tower", weight=0.20),
+        GeneratorSpec(name="popularity", weight=0.20),
+    ],
+    3: [  # Balanced — same as your-feed defaults
+        GeneratorSpec(name="followed_users", weight=0.40),
+        GeneratorSpec(name="two_tower", weight=0.30),
+        GeneratorSpec(name="popularity", weight=0.30),
+    ],
+    4: [  # Everyone — mostly discovery
+        GeneratorSpec(name="followed_users", weight=0.20),
+        GeneratorSpec(name="two_tower", weight=0.40),
+        GeneratorSpec(name="popularity", weight=0.40),
+    ],
+}
+
 # NOTE: published display names are limited to 24 graphemes. Internal ("debug")
 # feeds are published as "GE <internal_display_name> <git_sha>" (see issue #228),
 # so keep internal_display_name to 13 chars or fewer. feeds_test.py enforces this.
@@ -64,11 +92,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="e2 S",
         avatar="assets/icons/unranked-your-feed.png",
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[
-                GeneratorSpec(name="two_tower", weight=0.35),
-                GeneratorSpec(name="followed_users", weight=0.35),
-                GeneratorSpec(name="popularity", weight=0.3),
-            ],
+            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill="popularity",
             num_candidates=30,
             video_only=False,
@@ -114,12 +138,7 @@ FEEDS: dict[str, FeedConfig] = {
         min_rank_score=0.425,
         min_mmr_score=-0.05,
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[
-                GeneratorSpec(name="followed_users", weight=0.30),
-                GeneratorSpec(name="two_tower", weight=0.25),
-                GeneratorSpec(name="popularity", weight=0.25),
-                GeneratorSpec(name="network_likes", weight=0.20),
-            ],
+            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill=None,
             num_candidates=30,
             video_only=False,
@@ -172,12 +191,7 @@ FEEDS: dict[str, FeedConfig] = {
         # Same generator mix as your-feed, so cutoff behavior here previews what
         # real users would see.
         gen_request_template=CandidateGenerateRequest.model_construct(
-            generators=[
-                GeneratorSpec(name="followed_users", weight=0.30),
-                GeneratorSpec(name="two_tower", weight=0.25),
-                GeneratorSpec(name="popularity", weight=0.25),
-                GeneratorSpec(name="network_likes", weight=0.20),
-            ],
+            generators=SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill=None,
             num_candidates=30,
             video_only=False,

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -57,7 +57,7 @@ class TestFeedsRegistry:
             == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
         )
 
-    def test_network_likes_treatment_only_adds_network_likes_outside_friends(self):
+    def test_network_likes_enabled_presets_add_network_likes_outside_friends(self):
         for radius in range(1, 5):
             with_network_likes = {
                 generator.name

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -51,10 +51,10 @@ class TestFeedsRegistry:
                 for generator in presets[0]
             ] == [("followed_users", 1.0)]
 
-    def test_static_feed_defaults_fail_closed_without_network_likes(self):
+    def test_static_feed_defaults_include_network_likes(self):
         assert (
             FEEDS["your-feed"].gen_request_template.generators
-            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
+            == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
         )
 
     def test_network_likes_treatment_only_adds_network_likes_outside_friends(self):

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -1,12 +1,18 @@
 import pytest
 
-from app.feeds import FEEDS, SOCIAL_RADIUS_PRESETS
+from app.feeds import (
+    DEFAULT_SOCIAL_RADIUS,
+    FEEDS,
+    SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+)
 
 CANDIDATE_ONLY_FEEDS = {
     "followed-users": "followed_users",
     "network-likes": "network_likes",
     "popularity": "popularity",
     "two-tower": "two_tower",
+    "two-tower-empty-history": "two_tower_empty_history",
 }
 
 # AT Protocol app.bsky.feed.generator caps displayName at 24 graphemes. Published
@@ -22,23 +28,47 @@ GIT_SHA_SUFFIX_LEN = len(" ") + 7  # " " + 7-char short git sha
 
 class TestFeedsRegistry:
     def test_social_radius_splits_everyone_weight_evenly(self):
-        for generators in SOCIAL_RADIUS_PRESETS.values():
-            weights = {generator.name: generator.weight for generator in generators}
-            assert weights.get("two_tower", 0.0) == pytest.approx(
-                weights.get("popularity", 0.0)
-            )
-            assert sum(weights.values()) == pytest.approx(1.0)
+        for presets in (
+            SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+        ):
+            for generators in presets.values():
+                weights = {
+                    generator.name: generator.weight for generator in generators
+                }
+                assert weights.get("two_tower", 0.0) == pytest.approx(
+                    weights.get("popularity", 0.0)
+                )
+                assert sum(weights.values()) == pytest.approx(1.0)
 
     def test_friends_social_radius_has_no_everyone_generators(self):
-        assert [(generator.name, generator.weight) for generator in SOCIAL_RADIUS_PRESETS[0]] == [
-            ("followed_users", 1.0)
-        ]
+        for presets in (
+            SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+        ):
+            assert [
+                (generator.name, generator.weight)
+                for generator in presets[0]
+            ] == [("followed_users", 1.0)]
 
-    def test_balanced_social_radius_matches_your_feed_defaults(self):
+    def test_static_feed_defaults_fail_closed_without_network_likes(self):
         assert (
             FEEDS["your-feed"].gen_request_template.generators
-            == SOCIAL_RADIUS_PRESETS[3]
+            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
         )
+
+    def test_network_likes_treatment_only_adds_network_likes_outside_friends(self):
+        for radius in range(1, 5):
+            with_network_likes = {
+                generator.name
+                for generator in SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[radius]
+            }
+            without_network_likes = {
+                generator.name
+                for generator in SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[radius]
+            }
+            assert "network_likes" in with_network_likes
+            assert "network_likes" not in without_network_likes
 
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
         primary_rkeys = set(FEEDS.keys())
@@ -82,9 +112,7 @@ class TestFeedsRegistry:
             (spec.name, spec.weight)
             for spec in cfg.gen_request_template.generators
         ] == [
-            ("followed_users", 0.40),
-            ("two_tower_empty_history", 0.30),
-            ("popularity", 0.30),
+            ("popularity", 1.0),
         ]
         assert cfg.rank_request_template is not None
         assert [

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -39,6 +39,9 @@ LIKED_POSTS_PAGE_SIZE = 100
 # Hard cap on how many like documents to scan while looking for post hits.
 MAX_LIKES_SCANNED = 5_000
 
+# Lookback window for finding the matching posts
+MAX_AGE_HOURS = 168
+
 
 # ---------------------------------------------------------------------------
 # Query helper
@@ -56,6 +59,7 @@ async def fetch_recent_liked_post_uri_page(
     user_dids: list[str],
     size: int,
     search_after: list[Any] | None = None,
+    max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
 ) -> LikedPostUriPage:
     """Return one page of recently liked post URIs for the given users."""
     if not user_dids or size <= 0:
@@ -63,7 +67,10 @@ async def fetch_recent_liked_post_uri_page(
 
     query = {
         "bool": {
-            "filter": [{"terms": {"author_did": user_dids}}],
+            "filter": [
+                {"terms": {"author_did": user_dids}},
+                {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
+            ],
         }
     }
 
@@ -106,14 +113,12 @@ async def fetch_posts_by_uris(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
-    max_age_hours: MaxAgeHours = 168,
+    max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
 ) -> list[CandidatePost]:
     """Fetch posts for the supplied URIs, preserving the requested URI order."""
     if not at_uris:
         return []
 
-    # Freshness applies to candidate post created_at, not the timestamp of the
-    # followed user's like event.
     filters: list[dict] = [
         {"range": {"created_at": {"gte": f"now-{max_age_hours}h"}}},
     ]
@@ -130,7 +135,7 @@ async def fetch_posts_by_uris(
     }
 
     resp = await es.search(
-        index="posts",
+        index="posts_recent",
         op="hydrate",
         query=posts_query,
         size=len(at_uris),
@@ -157,7 +162,7 @@ async def network_likes_search(
     generator_name: str | None = None,
     video_only: bool = False,
     exclude_uris: list[str] | None = None,
-    max_age_hours: MaxAgeHours = 168,
+    max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
 ) -> list[CandidatePost]:
     """Fetch posts liked by users followed by user_did."""
 
@@ -199,6 +204,7 @@ async def network_likes_search(
             followed_dids,
             size=min(page_size, remaining_budget),
             search_after=search_after,
+            max_age_hours=max_age_hours,
         )
 
         if page.hit_count == 0:
@@ -258,7 +264,7 @@ class NetworkLikesCandidateGenerator(CandidateGenerator):
         num_candidates: int = 100,
         video_only: bool = False,
         exclude_uris: list[str] | None = None,
-        max_age_hours: MaxAgeHours = 168,
+        max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
     ) -> CandidateResult:
         candidates = await network_likes_search(
             es,

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -20,6 +20,7 @@ from ...models import CandidatePost, MaxAgeHours
 from ..bsky import FollowedUsersLookupError, get_followed_user_dids
 from ..config import fail_fast
 from ..elasticsearch import unwrap_es_response
+from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
@@ -167,10 +168,11 @@ async def network_likes_search(
     """Fetch posts liked by users followed by user_did."""
 
     try:
-        followed_dids: list[str] = await get_followed_user_dids(
-            user_did,
-            limit=MAX_FOLLOWED_USERS,
-        )
+        async with timed(logger, "bsky_get_follows", user_did=user_did):
+            followed_dids: list[str] = await get_followed_user_dids(
+                user_did,
+                limit=MAX_FOLLOWED_USERS,
+            )
     except FollowedUsersLookupError as exc:
         logger.warning(
             "Skipping network_likes candidate generation for %s after follow "
@@ -197,44 +199,50 @@ async def network_likes_search(
     liked_uri_order = 0
     candidates_by_uri: dict[str, CandidatePost] = {}
 
-    while len(candidates_by_uri) < num_candidates and scanned_likes < MAX_LIKES_SCANNED:
-        remaining_budget = MAX_LIKES_SCANNED - scanned_likes
-        page = await fetch_recent_liked_post_uri_page(
-            es,
-            followed_dids,
-            size=min(page_size, remaining_budget),
-            search_after=search_after,
-            max_age_hours=max_age_hours,
-        )
+    async with timed(
+        logger,
+        "es_network_likes_search",
+        n_followed=len(followed_dids),
+        num_candidates=num_candidates,
+    ):
+        while len(candidates_by_uri) < num_candidates and scanned_likes < MAX_LIKES_SCANNED:
+            remaining_budget = MAX_LIKES_SCANNED - scanned_likes
+            page = await fetch_recent_liked_post_uri_page(
+                es,
+                followed_dids,
+                size=min(page_size, remaining_budget),
+                search_after=search_after,
+                max_age_hours=max_age_hours,
+            )
 
-        if page.hit_count == 0:
-            break
+            if page.hit_count == 0:
+                break
 
-        scanned_likes += page.hit_count
+            scanned_likes += page.hit_count
 
-        new_uris: list[str] = []
-        for uri in page.uris:
-            like_counts[uri] = like_counts.get(uri, 0) + 1
-            last_seen_order[uri] = liked_uri_order
-            liked_uri_order += 1
-            if uri not in queried_uris:
-                queried_uris.add(uri)
-                new_uris.append(uri)
+            new_uris: list[str] = []
+            for uri in page.uris:
+                like_counts[uri] = like_counts.get(uri, 0) + 1
+                last_seen_order[uri] = liked_uri_order
+                liked_uri_order += 1
+                if uri not in queried_uris:
+                    queried_uris.add(uri)
+                    new_uris.append(uri)
 
-        for candidate in await fetch_posts_by_uris(
-            es,
-            new_uris,
-            generator_name=generator_name,
-            video_only=video_only,
-            exclude_uris=exclude_uris,
-            max_age_hours=max_age_hours,
-        ):
-            if candidate.at_uri:
-                candidates_by_uri[candidate.at_uri] = candidate
+            for candidate in await fetch_posts_by_uris(
+                es,
+                new_uris,
+                generator_name=generator_name,
+                video_only=video_only,
+                exclude_uris=exclude_uris,
+                max_age_hours=max_age_hours,
+            ):
+                if candidate.at_uri:
+                    candidates_by_uri[candidate.at_uri] = candidate
 
-        if page.next_search_after is None or page.hit_count < min(page_size, remaining_budget):
-            break
-        search_after = page.next_search_after
+            if page.next_search_after is None or page.hit_count < min(page_size, remaining_budget):
+                break
+            search_after = page.next_search_after
 
     candidates = [
         candidate.model_copy(update={"score": float(like_counts[at_uri])})

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -61,6 +61,7 @@ async def fetch_recent_liked_post_uri_page(
     size: int,
     search_after: list[Any] | None = None,
     max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
+    exclude_uris: list[str] | None = None,
 ) -> LikedPostUriPage:
     """Return one page of recently liked post URIs for the given users."""
     if not user_dids or size <= 0:
@@ -74,6 +75,10 @@ async def fetch_recent_liked_post_uri_page(
             ],
         }
     }
+    if exclude_uris:
+        query["bool"]["must_not"] = [
+            {"terms": {"subject_uri": exclude_uris}},
+        ]
 
     search_kwargs: dict[str, Any] = {}
     if search_after is not None:
@@ -213,6 +218,7 @@ async def network_likes_search(
                 size=min(page_size, remaining_budget),
                 search_after=search_after,
                 max_age_hours=max_age_hours,
+                exclude_uris=exclude_uris,
             )
 
             if page.hit_count == 0:

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -87,7 +87,22 @@ class FakeEs:
 
         if index == "likes":
             if self.likes_pages:
-                return self.likes_pages.pop(0)
+                response = self.likes_pages.pop(0)
+                query_body = query if isinstance(query, dict) else {}
+                excluded_uris = {
+                    uri
+                    for clause in query_body.get("bool", {}).get("must_not", [])
+                    for uri in clause.get("terms", {}).get("subject_uri", [])
+                }
+                if excluded_uris:
+                    hits = response.get("hits", {}).get("hits", [])
+                    return likes_response([
+                        hit
+                        for hit in hits
+                        if (hit.get("_source") or {}).get("subject_uri")
+                        not in excluded_uris
+                    ])
+                return response
             return likes_response([])
 
         if index == "posts_recent":
@@ -338,6 +353,8 @@ class TestNetworkLikesSearch:
         assert likes_call["query"]["bool"]["must_not"] == [
             {"terms": {"subject_uri": ["at://post/seen"]}},
         ]
+        posts_call = next(call for call in es.calls if call["index"] == "posts_recent")
+        assert post_terms_from_query(posts_call["query"]) == ["at://post/a"]
 
     @pytest.mark.asyncio
     async def test_respects_hard_likes_scan_cap(self, monkeypatch):

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -90,7 +90,7 @@ class FakeEs:
                 return self.likes_pages.pop(0)
             return likes_response([])
 
-        if index == "posts":
+        if index == "posts_recent":
             assert query is not None
             requested_uris = post_terms_from_query(query)
             return_order = self.posts_return_order or requested_uris
@@ -133,6 +133,7 @@ class TestFetchRecentLikedPostUriPage:
             ["did:plc:follow1"],
             size=50,
             search_after=["cursor"],
+            max_age_hours=48,
         )
 
         assert page.uris == ["at://post/1", "at://post/2"]
@@ -143,7 +144,10 @@ class TestFetchRecentLikedPostUriPage:
         assert call["index"] == "likes"
         assert call["query"] == {
             "bool": {
-                "filter": [{"terms": {"author_did": ["did:plc:follow1"]}}],
+                "filter": [
+                    {"terms": {"author_did": ["did:plc:follow1"]}},
+                    {"range": {"created_at": {"gte": "now-48h"}}},
+                ],
             }
         }
         assert call["size"] == 50
@@ -187,6 +191,7 @@ class TestFetchPostsByUris:
         assert candidates[0].generator_name == "network_likes"
         assert candidates[0].score == 99.0
         assert candidates[0].minilm_l12_embedding is not None
+        assert es.calls[0]["index"] == "posts_recent"
 
     @pytest.mark.asyncio
     async def test_applies_video_filter_in_es_and_exclude_filter_in_python(self):
@@ -269,7 +274,7 @@ class TestNetworkLikesSearch:
         likes_calls = [call for call in es.calls if call["index"] == "likes"]
         assert [call["search_after"] for call in likes_calls] == [None, [10]]
 
-        posts_calls = [call for call in es.calls if call["index"] == "posts"]
+        posts_calls = [call for call in es.calls if call["index"] == "posts_recent"]
         assert post_terms_from_query(posts_calls[0]["query"]) == [
             "at://post/a",
             "at://missing/1",
@@ -278,6 +283,28 @@ class TestNetworkLikesSearch:
             "at://missing/4",
         ]
         assert post_terms_from_query(posts_calls[1]["query"]) == ["at://post/b"]
+
+    @pytest.mark.asyncio
+    async def test_applies_requested_freshness_to_likes_and_posts(self, monkeypatch):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        es = FakeEs(
+            likes_pages=[likes_response([like_hit("at://post/a", 1)])],
+            posts_by_uri={"at://post/a": post_hit("at://post/a")},
+        )
+
+        candidates = await network_likes_search(
+            es,
+            "did:plc:user1",
+            num_candidates=1,
+            max_age_hours=48,
+        )
+
+        assert [candidate.at_uri for candidate in candidates] == ["at://post/a"]
+        expected_range = {"range": {"created_at": {"gte": "now-48h"}}}
+        likes_call = next(call for call in es.calls if call["index"] == "likes")
+        posts_call = next(call for call in es.calls if call["index"] == "posts_recent")
+        assert expected_range in likes_call["query"]["bool"]["filter"]
+        assert expected_range in posts_call["query"]["bool"]["filter"]
 
     @pytest.mark.asyncio
     async def test_respects_hard_likes_scan_cap(self, monkeypatch):

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -134,6 +134,7 @@ class TestFetchRecentLikedPostUriPage:
             size=50,
             search_after=["cursor"],
             max_age_hours=48,
+            exclude_uris=["at://post/seen"],
         )
 
         assert page.uris == ["at://post/1", "at://post/2"]
@@ -147,6 +148,9 @@ class TestFetchRecentLikedPostUriPage:
                 "filter": [
                     {"terms": {"author_did": ["did:plc:follow1"]}},
                     {"range": {"created_at": {"gte": "now-48h"}}},
+                ],
+                "must_not": [
+                    {"terms": {"subject_uri": ["at://post/seen"]}},
                 ],
             }
         }
@@ -305,6 +309,35 @@ class TestNetworkLikesSearch:
         posts_call = next(call for call in es.calls if call["index"] == "posts_recent")
         assert expected_range in likes_call["query"]["bool"]["filter"]
         assert expected_range in posts_call["query"]["bool"]["filter"]
+
+    @pytest.mark.asyncio
+    async def test_excludes_seen_uris_from_likes_query(self, monkeypatch):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        es = FakeEs(
+            likes_pages=[
+                likes_response([
+                    like_hit("at://post/seen", 2),
+                    like_hit("at://post/a", 1),
+                ])
+            ],
+            posts_by_uri={
+                "at://post/seen": post_hit("at://post/seen"),
+                "at://post/a": post_hit("at://post/a"),
+            },
+        )
+
+        candidates = await network_likes_search(
+            es,
+            "did:plc:user1",
+            num_candidates=1,
+            exclude_uris=["at://post/seen"],
+        )
+
+        assert [candidate.at_uri for candidate in candidates] == ["at://post/a"]
+        likes_call = next(call for call in es.calls if call["index"] == "likes")
+        assert likes_call["query"]["bool"]["must_not"] == [
+            {"terms": {"subject_uri": ["at://post/seen"]}},
+        ]
 
     @pytest.mark.asyncio
     async def test_respects_hard_likes_scan_cap(self, monkeypatch):

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 _posthog_client: Posthog | None = None
 
+FAIL_FAST_FLAG = "fail-fast-feed"
+NETWORK_LIKES_FLAG = "network-likes-in-your-feed"
+
 
 def set_posthog_client(client: Posthog | None) -> None:
     global _posthog_client
@@ -108,33 +111,18 @@ def track_redirect(
     )
 
 
-def evaluate_fail_fast_flag(client: Posthog | None, user_did: str) -> bool:
-    """Evaluate the fail-fast-feed PostHog feature flag for this user.
-
-    Returns True only when the client is present and the flag is enabled for
-    user_did. Soft-fails to False on any SDK exception so a PostHog outage
-    never breaks feed serving.
-    """
+def evaluate_feature_flags(
+    client: Posthog | None,
+    user_did: str,
+    flag_keys: list[str],
+) -> dict[str, bool]:
+    """Evaluate the requested flags in one PostHog request, defaulting to False."""
+    values = {key: False for key in flag_keys}
     if client is None:
-        return False
+        return values
     try:
-        return bool(client.feature_enabled("fail-fast-feed", user_did))
+        evaluated = client.evaluate_flags(user_did, flag_keys=flag_keys)
+        return {key: evaluated.is_enabled(key) for key in flag_keys}
     except Exception:
         logger.warning("PostHog feature flag evaluation failed for %s", user_did)
-        return False
-
-
-def evaluate_network_likes_flag(client: Posthog | None, user_did: str) -> bool:
-    """Evaluate the network-likes PostHog feature flag for this user.
-
-    Returns True only when the client is present and the flag is enabled for
-    user_did. Soft-fails to False on any SDK exception so a PostHog outage
-    never breaks feed serving.
-    """
-    if client is None:
-        return False
-    try:
-        return bool(client.feature_enabled("network-likes-in-your-feed", user_did))
-    except Exception:
-        logger.warning("PostHog feature flag evaluation failed for %s", user_did)
-        return False
+        return values

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -121,8 +121,12 @@ def evaluate_feature_flags(
     if client is None:
         return values
     try:
-        evaluated = client.evaluate_flags(user_did, flag_keys=flag_keys)
-        return {key: evaluated.is_enabled(key) for key in flag_keys}
+        # The batch API does not emit $feature_flag_called exposure events.
+        evaluated = client.get_all_flags(
+            user_did,
+            flag_keys_to_evaluate=flag_keys,
+        ) or {}
+        return {key: bool(evaluated.get(key, False)) for key in flag_keys}
     except Exception:
         logger.warning("PostHog feature flag evaluation failed for %s", user_did)
         return values

--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -122,3 +122,19 @@ def evaluate_fail_fast_flag(client: Posthog | None, user_did: str) -> bool:
     except Exception:
         logger.warning("PostHog feature flag evaluation failed for %s", user_did)
         return False
+
+
+def evaluate_network_likes_flag(client: Posthog | None, user_did: str) -> bool:
+    """Evaluate the network-likes PostHog feature flag for this user.
+
+    Returns True only when the client is present and the flag is enabled for
+    user_did. Soft-fails to False on any SDK exception so a PostHog outage
+    never breaks feed serving.
+    """
+    if client is None:
+        return False
+    try:
+        return bool(client.feature_enabled("network-likes-in-your-feed", user_did))
+    except Exception:
+        logger.warning("PostHog feature flag evaluation failed for %s", user_did)
+        return False

--- a/src/app/lib/posthog_client_test.py
+++ b/src/app/lib/posthog_client_test.py
@@ -136,8 +136,10 @@ def test_evaluate_feature_flags_none_client_returns_false_values():
 
 def test_evaluate_feature_flags_uses_one_sdk_request():
     mock = MagicMock()
-    evaluated = mock.evaluate_flags.return_value
-    evaluated.is_enabled.side_effect = lambda key: key == NETWORK_LIKES_FLAG
+    mock.get_all_flags.return_value = {
+        FAIL_FAST_FLAG: False,
+        NETWORK_LIKES_FLAG: True,
+    }
 
     result = evaluate_feature_flags(
         mock,
@@ -149,15 +151,15 @@ def test_evaluate_feature_flags_uses_one_sdk_request():
         FAIL_FAST_FLAG: False,
         NETWORK_LIKES_FLAG: True,
     }
-    mock.evaluate_flags.assert_called_once_with(
+    mock.get_all_flags.assert_called_once_with(
         "did:plc:abc123",
-        flag_keys=[FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
+        flag_keys_to_evaluate=[FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
     )
 
 
 def test_evaluate_feature_flags_sdk_exception_returns_false_values():
     mock = MagicMock()
-    mock.evaluate_flags.side_effect = RuntimeError("network error")
+    mock.get_all_flags.side_effect = RuntimeError("network error")
     assert evaluate_feature_flags(
         mock,
         "did:plc:abc123",

--- a/src/app/lib/posthog_client_test.py
+++ b/src/app/lib/posthog_client_test.py
@@ -6,8 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.lib.posthog_client import (
-    evaluate_fail_fast_flag,
-    evaluate_network_likes_flag,
+    FAIL_FAST_FLAG,
+    NETWORK_LIKES_FLAG,
+    evaluate_feature_flags,
     get_posthog_client,
     init_posthog_client,
     set_posthog_client,
@@ -122,63 +123,46 @@ def test_real_posthog_client_is_disabled_in_tests():
     assert client.disabled is True
 
 
-def test_evaluate_fail_fast_flag_none_client_returns_false():
-    assert evaluate_fail_fast_flag(None, "did:plc:abc123") is False
+def test_evaluate_feature_flags_none_client_returns_false_values():
+    assert evaluate_feature_flags(
+        None,
+        "did:plc:abc123",
+        [FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
+    ) == {
+        FAIL_FAST_FLAG: False,
+        NETWORK_LIKES_FLAG: False,
+    }
 
 
-def test_evaluate_fail_fast_flag_enabled_returns_true():
+def test_evaluate_feature_flags_uses_one_sdk_request():
     mock = MagicMock()
-    mock.feature_enabled.return_value = True
-    result = evaluate_fail_fast_flag(mock, "did:plc:abc123")
-    assert result is True
-    mock.feature_enabled.assert_called_once_with("fail-fast-feed", "did:plc:abc123")
+    evaluated = mock.evaluate_flags.return_value
+    evaluated.is_enabled.side_effect = lambda key: key == NETWORK_LIKES_FLAG
 
+    result = evaluate_feature_flags(
+        mock,
+        "did:plc:abc123",
+        [FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
+    )
 
-def test_evaluate_fail_fast_flag_disabled_returns_false():
-    mock = MagicMock()
-    mock.feature_enabled.return_value = False
-    assert evaluate_fail_fast_flag(mock, "did:plc:abc123") is False
-
-
-def test_evaluate_fail_fast_flag_sdk_exception_returns_false():
-    mock = MagicMock()
-    mock.feature_enabled.side_effect = RuntimeError("network error")
-    assert evaluate_fail_fast_flag(mock, "did:plc:abc123") is False
-
-
-def test_evaluate_fail_fast_flag_sdk_returns_none_returns_false():
-    mock = MagicMock()
-    mock.feature_enabled.return_value = None
-    assert evaluate_fail_fast_flag(mock, "did:plc:abc123") is False
-
-
-def test_evaluate_network_likes_flag_none_client_returns_false():
-    assert evaluate_network_likes_flag(None, "did:plc:abc123") is False
-
-
-def test_evaluate_network_likes_flag_enabled_returns_true():
-    mock = MagicMock()
-    mock.feature_enabled.return_value = True
-    result = evaluate_network_likes_flag(mock, "did:plc:abc123")
-    assert result is True
-    mock.feature_enabled.assert_called_once_with(
-        "network-likes-in-your-feed", "did:plc:abc123"
+    assert result == {
+        FAIL_FAST_FLAG: False,
+        NETWORK_LIKES_FLAG: True,
+    }
+    mock.evaluate_flags.assert_called_once_with(
+        "did:plc:abc123",
+        flag_keys=[FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
     )
 
 
-def test_evaluate_network_likes_flag_disabled_returns_false():
+def test_evaluate_feature_flags_sdk_exception_returns_false_values():
     mock = MagicMock()
-    mock.feature_enabled.return_value = False
-    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False
-
-
-def test_evaluate_network_likes_flag_sdk_exception_returns_false():
-    mock = MagicMock()
-    mock.feature_enabled.side_effect = RuntimeError("network error")
-    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False
-
-
-def test_evaluate_network_likes_flag_sdk_returns_none_returns_false():
-    mock = MagicMock()
-    mock.feature_enabled.return_value = None
-    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False
+    mock.evaluate_flags.side_effect = RuntimeError("network error")
+    assert evaluate_feature_flags(
+        mock,
+        "did:plc:abc123",
+        [FAIL_FAST_FLAG, NETWORK_LIKES_FLAG],
+    ) == {
+        FAIL_FAST_FLAG: False,
+        NETWORK_LIKES_FLAG: False,
+    }

--- a/src/app/lib/posthog_client_test.py
+++ b/src/app/lib/posthog_client_test.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.lib.posthog_client import (
+    evaluate_fail_fast_flag,
+    evaluate_network_likes_flag,
     get_posthog_client,
     init_posthog_client,
     set_posthog_client,
@@ -120,9 +122,6 @@ def test_real_posthog_client_is_disabled_in_tests():
     assert client.disabled is True
 
 
-from app.lib.posthog_client import evaluate_fail_fast_flag
-
-
 def test_evaluate_fail_fast_flag_none_client_returns_false():
     assert evaluate_fail_fast_flag(None, "did:plc:abc123") is False
 
@@ -151,3 +150,35 @@ def test_evaluate_fail_fast_flag_sdk_returns_none_returns_false():
     mock = MagicMock()
     mock.feature_enabled.return_value = None
     assert evaluate_fail_fast_flag(mock, "did:plc:abc123") is False
+
+
+def test_evaluate_network_likes_flag_none_client_returns_false():
+    assert evaluate_network_likes_flag(None, "did:plc:abc123") is False
+
+
+def test_evaluate_network_likes_flag_enabled_returns_true():
+    mock = MagicMock()
+    mock.feature_enabled.return_value = True
+    result = evaluate_network_likes_flag(mock, "did:plc:abc123")
+    assert result is True
+    mock.feature_enabled.assert_called_once_with(
+        "network-likes-in-your-feed", "did:plc:abc123"
+    )
+
+
+def test_evaluate_network_likes_flag_disabled_returns_false():
+    mock = MagicMock()
+    mock.feature_enabled.return_value = False
+    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False
+
+
+def test_evaluate_network_likes_flag_sdk_exception_returns_false():
+    mock = MagicMock()
+    mock.feature_enabled.side_effect = RuntimeError("network error")
+    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False
+
+
+def test_evaluate_network_likes_flag_sdk_returns_none_returns_false():
+    mock = MagicMock()
+    mock.feature_enabled.return_value = None
+    assert evaluate_network_likes_flag(mock, "did:plc:abc123") is False

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -77,8 +77,9 @@ from ..lib.pipeline_context import (
     pipeline_context_scope,
 )
 from ..lib.posthog_client import (
-    evaluate_fail_fast_flag,
-    evaluate_network_likes_flag,
+    FAIL_FAST_FLAG,
+    NETWORK_LIKES_FLAG,
+    evaluate_feature_flags,
     get_posthog_client,
     track_interaction,
     track_session,
@@ -1408,7 +1409,27 @@ async def get_feed_skeleton(
         _record_session(request, user_did, feed_name, db, is_load_test=is_load_test)
     )
 
-    set_fail_fast_for_request(evaluate_fail_fast_flag(get_posthog_client(), user_did))
+    uses_network_likes_flag = feed_name in (
+        "your-feed",
+        "unranked-your-feed",
+        "cutoff-preview",
+    )
+    flag_keys = [FAIL_FAST_FLAG]
+    if uses_network_likes_flag:
+        flag_keys.append(NETWORK_LIKES_FLAG)
+
+    posthog_client = get_posthog_client()
+    feature_flags = (
+        await asyncio.to_thread(
+            evaluate_feature_flags,
+            posthog_client,
+            user_did,
+            flag_keys,
+        )
+        if posthog_client is not None
+        else {}
+    )
+    set_fail_fast_for_request(feature_flags.get(FAIL_FAST_FLAG, False))
 
     # Per-user opt-in: capture pipeline debugging info for this feed load. This
     # costs one extra Firestore read per request; fail-soft so a hiccup degrades
@@ -1426,16 +1447,15 @@ async def get_feed_skeleton(
     # Apply its preference override to personalized-feed generator weights.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if feed_name in ("your-feed", "unranked-your-feed", "cutoff-preview"):
+    if uses_network_likes_flag:
         if user_doc is not None:
             applied_social_radius = user_doc.social_radius
         else:
             applied_social_radius = DEFAULT_SOCIAL_RADIUS
-        posthog_client = get_posthog_client()
         network_likes_in_your_feed = (
             True
             if posthog_client is None
-            else evaluate_network_likes_flag(posthog_client, user_did)
+            else feature_flags.get(NETWORK_LIKES_FLAG, False)
         )
         if network_likes_in_your_feed:
             social_radius_presets = SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -39,10 +39,10 @@ from ..documents import (
     PipelineItemMeta,
 )
 from ..feeds import (
-    FEEDS,
-    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
-    SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
     DEFAULT_SOCIAL_RADIUS,
+    FEEDS,
+    SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
 )
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.candidates import run_generate
@@ -53,7 +53,6 @@ from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import DEFAULT_TTL_SECONDS, FeedCache
 from ..lib.feed_context import FeedContextPayload, decode_feed_context, encode_feed_context
 from ..lib.feed_debug import FeedDebugRecorder, current_recorder, feed_debug_scope
-from ..lib.freshness import DEFAULT_FRESHNESS_INDEX, max_age_hours_for_freshness
 from ..lib.firestore import (
     FEED_DEBUG_RETENTION_DAYS,
     delete_feed_snapshot,
@@ -68,6 +67,7 @@ from ..lib.firestore import (
     upsert_user,
     write_feed_debug,
 )
+from ..lib.freshness import DEFAULT_FRESHNESS_INDEX, max_age_hours_for_freshness
 from ..lib.metrics import get_metric_collector
 from ..lib.pipeline_context import (
     DegradationEvent,
@@ -84,8 +84,8 @@ from ..lib.posthog_client import (
     track_interaction,
     track_session,
 )
-from ..lib.release import api_release_sha
 from ..lib.rankers import run_predict
+from ..lib.release import api_release_sha
 from ..lib.request_cache import request_cache_scope
 from ..lib.request_context import set_traffic
 from ..lib.telemetry import timed

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1431,7 +1431,12 @@ async def get_feed_skeleton(
             applied_social_radius = user_doc.social_radius
         else:
             applied_social_radius = DEFAULT_SOCIAL_RADIUS
-        network_likes_in_your_feed = evaluate_network_likes_flag(get_posthog_client(), user_did)
+        posthog_client = get_posthog_client()
+        network_likes_in_your_feed = (
+            True
+            if posthog_client is None
+            else evaluate_network_likes_flag(posthog_client, user_did)
+        )
         if network_likes_in_your_feed:
             social_radius_presets = SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES
         else:

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -38,10 +38,15 @@ from ..documents import (
     InteractionDocument,
     PipelineItemMeta,
 )
-from ..feeds import FEEDS, SOCIAL_RADIUS_PRESETS
+from ..feeds import (
+    FEEDS,
+    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+    SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+    DEFAULT_SOCIAL_RADIUS,
+)
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.candidates import run_generate
-from ..lib.config import fail_fast, set_fail_fast_for_request
+from ..lib.config import set_fail_fast_for_request
 from ..lib.diversify import mmr_rerank
 from ..lib.elasticsearch import fetch_post_embeddings
 from ..lib.embeddings import encode_float32_b64
@@ -73,6 +78,7 @@ from ..lib.pipeline_context import (
 )
 from ..lib.posthog_client import (
     evaluate_fail_fast_flag,
+    evaluate_network_likes_flag,
     get_posthog_client,
     track_interaction,
     track_session,
@@ -1420,9 +1426,17 @@ async def get_feed_skeleton(
     # Apply its preference override to personalized-feed generator weights.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if feed_name == "your-feed":
-        applied_social_radius = user_doc.social_radius if user_doc is not None else 3
-        preset = SOCIAL_RADIUS_PRESETS.get(applied_social_radius)
+    if feed_name in ("your-feed", "unranked-your-feed", "cutoff-preview"):
+        if user_doc is not None:
+            applied_social_radius = user_doc.social_radius
+        else:
+            applied_social_radius = DEFAULT_SOCIAL_RADIUS
+        network_likes_in_your_feed = evaluate_network_likes_flag(get_posthog_client(), user_did)
+        if network_likes_in_your_feed:
+            social_radius_presets = SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES
+        else:
+            social_radius_presets = SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES
+        preset = social_radius_presets.get(applied_social_radius)
         if preset is not None:
             generators_override = {"generators": preset}
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1418,23 +1418,12 @@ async def get_feed_skeleton(
     # Social Radius only reallocates the fixed candidate batch among sources;
     # it never increases the total candidate count or per-request batch cap.
     # Apply its preference override to personalized-feed generator weights.
-    # Cold-start uses the same source mix as your-feed, but forces the
-    # empty-history two-tower variant.
-    # The override is computed once and threaded through model_copy in both
-    # generation paths so the shared module-level template is never mutated.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if feed_name in ("your-feed", "cold-start"):
+    if feed_name == "your-feed":
         applied_social_radius = user_doc.social_radius if user_doc is not None else 3
         preset = SOCIAL_RADIUS_PRESETS.get(applied_social_radius)
         if preset is not None:
-            if feed_name == "cold-start":
-                preset = [
-                    spec.model_copy(update={"name": "two_tower_empty_history"})
-                    if spec.name == "two_tower"
-                    else spec
-                    for spec in preset
-                ]
             generators_override = {"generators": preset}
 
     freshness_index = (

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -3262,7 +3262,7 @@ class TestSocialRadiusOverride:
     @patch("app.routers.xrpc.get_posthog_client")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
-    def test_network_likes_flag_uses_treatment_presets(
+    def test_enabled_network_likes_flag_uses_network_likes_presets(
         self,
         mock_pipeline,
         mock_get_user,

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -3139,14 +3139,14 @@ class TestSocialRadiusOverride:
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[4]
 
-    @patch("app.routers.xrpc.evaluate_network_likes_flag")
+    @patch("app.routers.xrpc.evaluate_feature_flags")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
     def test_cold_start_ignores_social_radius(
         self,
         mock_pipeline,
         mock_get_user,
-        mock_network_likes_flag,
+        mock_feature_flags,
     ):
         """Cold-start always uses popularity for a brand-new user."""
         from ..documents import UserDocument
@@ -3171,7 +3171,7 @@ class TestSocialRadiusOverride:
         ] == [
             ("popularity", 1.0),
         ]
-        mock_network_likes_flag.assert_not_called()
+        mock_feature_flags.assert_not_called()
 
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -3255,7 +3255,10 @@ class TestSocialRadiusOverride:
         "feed_uri",
         (RANKED_FEED_URI, FEED_URI, CUTOFF_PREVIEW_FEED_URI),
     )
-    @patch("app.routers.xrpc.evaluate_network_likes_flag", return_value=True)
+    @patch(
+        "app.routers.xrpc.evaluate_feature_flags",
+        return_value={"fail-fast-feed": False, "network-likes-in-your-feed": True},
+    )
     @patch("app.routers.xrpc.get_posthog_client")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -3264,7 +3267,7 @@ class TestSocialRadiusOverride:
         mock_pipeline,
         mock_get_user,
         mock_get_posthog_client,
-        mock_network_likes_flag,
+        mock_feature_flags,
         feed_uri,
     ):
         from ..documents import UserDocument
@@ -3274,7 +3277,6 @@ class TestSocialRadiusOverride:
             user_did="did:plc:testuser",
             social_radius=3,
         )
-        mock_get_posthog_client.return_value.feature_enabled.return_value = False
         mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
 
         resp = client.get(
@@ -3285,16 +3287,17 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3]
-        mock_network_likes_flag.assert_called_once_with(
+        mock_feature_flags.assert_called_once_with(
             mock_get_posthog_client.return_value,
             "did:plc:testuser",
+            ["fail-fast-feed", "network-likes-in-your-feed"],
         )
 
     @pytest.mark.parametrize(
         "feed_uri",
         (RANKED_FEED_URI, FEED_URI, CUTOFF_PREVIEW_FEED_URI),
     )
-    @patch("app.routers.xrpc.evaluate_network_likes_flag")
+    @patch("app.routers.xrpc.evaluate_feature_flags")
     @patch("app.routers.xrpc.get_posthog_client", return_value=None)
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -3303,7 +3306,7 @@ class TestSocialRadiusOverride:
         mock_pipeline,
         mock_get_user,
         mock_get_posthog_client,
-        mock_network_likes_flag,
+        mock_feature_flags,
         feed_uri,
     ):
         from ..documents import UserDocument
@@ -3324,9 +3327,12 @@ class TestSocialRadiusOverride:
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3]
         mock_get_posthog_client.assert_any_call()
-        mock_network_likes_flag.assert_not_called()
+        mock_feature_flags.assert_not_called()
 
-    @patch("app.routers.xrpc.evaluate_network_likes_flag", return_value=False)
+    @patch(
+        "app.routers.xrpc.evaluate_feature_flags",
+        return_value={"fail-fast-feed": False, "network-likes-in-your-feed": False},
+    )
     @patch("app.routers.xrpc.get_posthog_client")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -3335,7 +3341,7 @@ class TestSocialRadiusOverride:
         mock_pipeline,
         mock_get_user,
         mock_get_posthog_client,
-        mock_network_likes_flag,
+        mock_feature_flags,
     ):
         from ..documents import UserDocument
         from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
@@ -3344,7 +3350,6 @@ class TestSocialRadiusOverride:
             user_did="did:plc:testuser",
             social_radius=3,
         )
-        mock_get_posthog_client.return_value.feature_enabled.return_value = False
         mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
 
         resp = client.get(
@@ -3355,9 +3360,10 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[3]
-        mock_network_likes_flag.assert_called_once_with(
+        mock_feature_flags.assert_called_once_with(
             mock_get_posthog_client.return_value,
             "did:plc:testuser",
+            ["fail-fast-feed", "network-likes-in-your-feed"],
         )
 
 
@@ -3719,10 +3725,16 @@ class TestFailFastFeatureFlag:
     def test_flag_enabled_calls_set_fail_fast_true(self):
         """When PostHog returns True for the user, set_fail_fast_for_request(True) is called."""
         mock_ph = MagicMock()
-        mock_ph.feature_enabled.return_value = True
 
         with (
             patch("app.routers.xrpc.get_posthog_client", return_value=mock_ph),
+            patch(
+                "app.routers.xrpc.evaluate_feature_flags",
+                return_value={
+                    "fail-fast-feed": True,
+                    "network-likes-in-your-feed": False,
+                },
+            ),
             patch("app.routers.xrpc.set_fail_fast_for_request") as mock_set,
         ):
             client.get(
@@ -3735,10 +3747,16 @@ class TestFailFastFeatureFlag:
     def test_flag_disabled_calls_set_fail_fast_false(self):
         """When PostHog returns False, set_fail_fast_for_request(False) is called."""
         mock_ph = MagicMock()
-        mock_ph.feature_enabled.return_value = False
 
         with (
             patch("app.routers.xrpc.get_posthog_client", return_value=mock_ph),
+            patch(
+                "app.routers.xrpc.evaluate_feature_flags",
+                return_value={
+                    "fail-fast-feed": False,
+                    "network-likes-in-your-feed": True,
+                },
+            ),
             patch("app.routers.xrpc.set_fail_fast_for_request") as mock_set,
         ):
             client.get(

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -44,6 +44,9 @@ RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
 RANKED_FEED_RKEY = "your-feed"
 RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
+CUTOFF_PREVIEW_FEED_URI = (
+    f"at://{SERVICE_DID}/app.bsky.feed.generator/cutoff-preview"
+)
 COLD_START_FEED_RKEY = "cold-start"
 COLD_START_FEED_URI = (
     f"at://{SERVICE_DID}/app.bsky.feed.generator/{COLD_START_FEED_RKEY}"
@@ -58,6 +61,7 @@ CANDIDATE_ONLY_FEEDS = (
     ("network-likes", "network_likes"),
     ("popularity", "popularity"),
     ("two-tower", "two_tower"),
+    ("two-tower-empty-history", "two_tower_empty_history"),
 )
 TEST_EMBEDDING = encode_float32_b64([1.0, 0.0, 0.0])
 
@@ -3056,7 +3060,7 @@ class TestSocialRadiusOverride:
     def test_applies_social_radius_preset_0(self, mock_pipeline, mock_get_user):
         """social_radius=0 (Friends) → followed_users-heavy weights."""
         from ..documents import UserDocument
-        from .xrpc import SOCIAL_RADIUS_PRESETS, PipelineResult
+        from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
 
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
@@ -3072,7 +3076,7 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS[0]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[0]
         assert gen_request.max_age_hours == 12
 
     @patch("app.routers.xrpc.get_user")
@@ -3080,7 +3084,7 @@ class TestSocialRadiusOverride:
     def test_applies_social_radius_preset_4(self, mock_pipeline, mock_get_user):
         """social_radius=4 (Everyone) → popularity-heavy weights."""
         from ..documents import UserDocument
-        from .xrpc import SOCIAL_RADIUS_PRESETS, PipelineResult
+        from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
 
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
@@ -3095,12 +3099,18 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS[4]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[4]
 
+    @patch("app.routers.xrpc.evaluate_network_likes_flag")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
-    def test_applies_social_radius_to_cold_start(self, mock_pipeline, mock_get_user):
-        """Cold-start keeps the radius mix but uses empty-history two-tower."""
+    def test_cold_start_ignores_social_radius(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        mock_network_likes_flag,
+    ):
+        """Cold-start always uses popularity for a brand-new user."""
         from ..documents import UserDocument
         from .xrpc import PipelineResult
 
@@ -3121,17 +3131,20 @@ class TestSocialRadiusOverride:
             (generator.name, generator.weight)
             for generator in gen_request.generators
         ] == [
-            ("followed_users", 0.20),
-            ("two_tower_empty_history", 0.40),
-            ("popularity", 0.40),
+            ("popularity", 1.0),
         ]
+        mock_network_likes_flag.assert_not_called()
 
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
     def test_default_radius_when_missing(self, mock_pipeline, mock_get_user):
         """User doc without social_radius field → defaults to 3 (balanced)."""
         from ..documents import UserDocument
-        from .xrpc import SOCIAL_RADIUS_PRESETS, PipelineResult
+        from .xrpc import (
+            DEFAULT_SOCIAL_RADIUS,
+            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+            PipelineResult,
+        )
 
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
@@ -3145,7 +3158,10 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS[3]
+        assert (
+            gen_request.generators
+            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
+        )
         assert gen_request.max_age_hours == 168
 
     @patch("app.routers.xrpc.get_user")
@@ -3176,7 +3192,11 @@ class TestSocialRadiusOverride:
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
     def test_fallen_back_to_defaults_when_user_has_no_doc(self, mock_pipeline, mock_get_user):
         """User doc is None → no override, defaults used."""
-        from .xrpc import SOCIAL_RADIUS_PRESETS, PipelineResult
+        from .xrpc import (
+            DEFAULT_SOCIAL_RADIUS,
+            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+            PipelineResult,
+        )
 
         mock_get_user.return_value = None
         mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
@@ -3188,7 +3208,43 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS[3]
+        assert (
+            gen_request.generators
+            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
+        )
+
+    @pytest.mark.parametrize(
+        "feed_uri",
+        (RANKED_FEED_URI, FEED_URI, CUTOFF_PREVIEW_FEED_URI),
+    )
+    @patch("app.routers.xrpc.evaluate_network_likes_flag", return_value=True)
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_network_likes_flag_uses_treatment_presets(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        mock_network_likes_flag,
+        feed_uri,
+    ):
+        from ..documents import UserDocument
+        from .xrpc import SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES, PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            social_radius=3,
+        )
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": feed_uri, "limit": 30},
+        )
+
+        assert resp.status_code == 200
+        gen_request = mock_pipeline.call_args.args[1]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3]
+        mock_network_likes_flag.assert_called_once()
 
 
 class TestGetFeedSkeletonMetrics:

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -100,6 +100,11 @@ def _patch_unranked_your_feed_generators(
             else followed_users_candidates
         ),
     )
+    network_likes_gen = AsyncMock()
+    network_likes_gen.generate.return_value = CandidateResult(
+        generator_name="network_likes",
+        candidates=two_tower_candidates,
+    )
     infill_gen = AsyncMock()
     infill_gen.generate.return_value = CandidateResult(
         generator_name="popularity",
@@ -111,6 +116,8 @@ def _patch_unranked_your_feed_generators(
             return two_tower_gen
         if name == "followed_users":
             return followed_users_gen
+        if name == "network_likes":
+            return network_likes_gen
         if name == "popularity":
             return infill_gen
         return None
@@ -364,6 +371,10 @@ class TestGetFeedSkeleton:
         followed_gen.generate.return_value = CandidateResult(
             generator_name="followed_users", candidates=[],
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes", candidates=[],
+        )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[],
@@ -373,6 +384,7 @@ class TestGetFeedSkeleton:
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -406,6 +418,10 @@ class TestGetFeedSkeleton:
         followed_gen.generate.return_value = CandidateResult(
             generator_name="followed_users", candidates=[],
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes", candidates=[],
+        )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[],
@@ -415,6 +431,7 @@ class TestGetFeedSkeleton:
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -673,11 +690,17 @@ class TestGetFeedSkeleton:
             generator_name="followed_users",
             candidates=[],
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes",
+            candidates=[],
+        )
 
         def fake_get(name):
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_users_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -1097,11 +1120,16 @@ class TestFeedSkeletonCursor:
         followed_users_gen.generate.return_value = CandidateResult(
             generator_name="followed_users", candidates=[],
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes", candidates=[],
+        )
 
         def fake_get(name):
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_users_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -1426,6 +1454,10 @@ class TestRankedFeed:
         followed_gen.generate.return_value = CandidateResult(
             generator_name="followed_users", candidates=[]
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes", candidates=[]
+        )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[]
@@ -1435,6 +1467,7 @@ class TestRankedFeed:
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -1632,6 +1665,10 @@ class TestSlateCutoffs:
         followed_gen.generate.return_value = CandidateResult(
             generator_name="followed_users", candidates=[]
         )
+        network_likes_gen = AsyncMock()
+        network_likes_gen.generate.return_value = CandidateResult(
+            generator_name="network_likes", candidates=[]
+        )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
             generator_name="popularity", candidates=[]
@@ -1641,6 +1678,7 @@ class TestSlateCutoffs:
             return {
                 "two_tower": primary_gen,
                 "followed_users": followed_gen,
+                "network_likes": network_likes_gen,
                 "popularity": infill_gen,
             }.get(name)
 
@@ -3060,7 +3098,7 @@ class TestSocialRadiusOverride:
     def test_applies_social_radius_preset_0(self, mock_pipeline, mock_get_user):
         """social_radius=0 (Friends) → followed_users-heavy weights."""
         from ..documents import UserDocument
-        from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
+        from .xrpc import SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES, PipelineResult
 
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
@@ -3076,7 +3114,7 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[0]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[0]
         assert gen_request.max_age_hours == 12
 
     @patch("app.routers.xrpc.get_user")
@@ -3084,7 +3122,7 @@ class TestSocialRadiusOverride:
     def test_applies_social_radius_preset_4(self, mock_pipeline, mock_get_user):
         """social_radius=4 (Everyone) → popularity-heavy weights."""
         from ..documents import UserDocument
-        from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
+        from .xrpc import SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES, PipelineResult
 
         mock_get_user.return_value = UserDocument(
             user_did="did:plc:testuser",
@@ -3099,7 +3137,7 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[4]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[4]
 
     @patch("app.routers.xrpc.evaluate_network_likes_flag")
     @patch("app.routers.xrpc.get_user")
@@ -3142,7 +3180,7 @@ class TestSocialRadiusOverride:
         from ..documents import UserDocument
         from .xrpc import (
             DEFAULT_SOCIAL_RADIUS,
-            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+            SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
             PipelineResult,
         )
 
@@ -3160,7 +3198,7 @@ class TestSocialRadiusOverride:
         gen_request = mock_pipeline.call_args.args[1]
         assert (
             gen_request.generators
-            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
+            == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
         )
         assert gen_request.max_age_hours == 168
 
@@ -3194,7 +3232,7 @@ class TestSocialRadiusOverride:
         """User doc is None → no override, defaults used."""
         from .xrpc import (
             DEFAULT_SOCIAL_RADIUS,
-            SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
+            SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
             PipelineResult,
         )
 
@@ -3210,7 +3248,7 @@ class TestSocialRadiusOverride:
         gen_request = mock_pipeline.call_args.args[1]
         assert (
             gen_request.generators
-            == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
+            == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[DEFAULT_SOCIAL_RADIUS]
         )
 
     @pytest.mark.parametrize(
@@ -3218,12 +3256,53 @@ class TestSocialRadiusOverride:
         (RANKED_FEED_URI, FEED_URI, CUTOFF_PREVIEW_FEED_URI),
     )
     @patch("app.routers.xrpc.evaluate_network_likes_flag", return_value=True)
+    @patch("app.routers.xrpc.get_posthog_client")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
     def test_network_likes_flag_uses_treatment_presets(
         self,
         mock_pipeline,
         mock_get_user,
+        mock_get_posthog_client,
+        mock_network_likes_flag,
+        feed_uri,
+    ):
+        from ..documents import UserDocument
+        from .xrpc import SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES, PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            social_radius=3,
+        )
+        mock_get_posthog_client.return_value.feature_enabled.return_value = False
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": feed_uri, "limit": 30},
+        )
+
+        assert resp.status_code == 200
+        gen_request = mock_pipeline.call_args.args[1]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3]
+        mock_network_likes_flag.assert_called_once_with(
+            mock_get_posthog_client.return_value,
+            "did:plc:testuser",
+        )
+
+    @pytest.mark.parametrize(
+        "feed_uri",
+        (RANKED_FEED_URI, FEED_URI, CUTOFF_PREVIEW_FEED_URI),
+    )
+    @patch("app.routers.xrpc.evaluate_network_likes_flag")
+    @patch("app.routers.xrpc.get_posthog_client", return_value=None)
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_missing_posthog_client_uses_network_likes_defaults(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        mock_get_posthog_client,
         mock_network_likes_flag,
         feed_uri,
     ):
@@ -3244,7 +3323,42 @@ class TestSocialRadiusOverride:
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3]
-        mock_network_likes_flag.assert_called_once()
+        mock_get_posthog_client.assert_any_call()
+        mock_network_likes_flag.assert_not_called()
+
+    @patch("app.routers.xrpc.evaluate_network_likes_flag", return_value=False)
+    @patch("app.routers.xrpc.get_posthog_client")
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_disabled_network_likes_flag_uses_rollback_presets(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        mock_get_posthog_client,
+        mock_network_likes_flag,
+    ):
+        from ..documents import UserDocument
+        from .xrpc import SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES, PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            social_radius=3,
+        )
+        mock_get_posthog_client.return_value.feature_enabled.return_value = False
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": RANKED_FEED_URI, "limit": 30},
+        )
+
+        assert resp.status_code == 200
+        gen_request = mock_pipeline.call_args.args[1]
+        assert gen_request.generators == SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[3]
+        mock_network_likes_flag.assert_called_once_with(
+            mock_get_posthog_client.return_value,
+            "did:plc:testuser",
+        )
 
 
 class TestGetFeedSkeletonMetrics:


### PR DESCRIPTION
Closes #348 

## This PR
Added the network_likes candidate generator to your-feed, unranked-your-feed, and cutoff-preview, behind a PostHog feature flag: "network-likes-in-your-feed". The default is for this to be enabled. This turns on the network_likes generator for local development, which in the general case doesn't connect to PostHog (I think). 

unranked-your-feed and cutoff-preview used the same candidate generators so it seemed to make sense to have them follow the behavior wrt network_likes.

Updated the config values of the social radius presets. The network_likes generator is somewhere between "friends" and "everyone", so it is most prevalent in the middle of the slider, and least prevalent on the ends.

We now call PostHog to get both feature flags asynchronously - I think this is the best way to do it vs calling PostHog twice, where each call is blocking.

I attempted to make the network_likes CG more efficient via: 
- Pass the exclude_uris into the likes query. This also prevents them from being hydrated in the next step. 
- Use `posts_recent`, since we have a one week lookback window anyway.
- Apply the one week lookback window to the likes, since if we're applying it to the posts query, we shouldn't care about any likes older than a week anyway.
- Added timed() wrappers for logging

The cold-start feed was previously using the social radius presets functionality. It would have made the code more complicated to wire through the feature flag stuff, so instead I made a change I'd been wanting to make anyway: make the cold-start feed show what a user with no likes AND no follows would see (so I removed the followed_users and two_tower_empty_history cg's). And I added a feed that just shows two_tower_empty_history candidates. Each answers its own question - the first: what does a real brand-new user see? and the second: what does the two tower model return for a user with no like history? Neither is dependent on the social radius control.

## Testing
- Added unit tests
- Ran locally
- Deployed to stage
  - Confirmed feature flag turns network_likes on and off