### PR TITLE
Admin API endpoints should require additional permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ gea_<8-char key_id><48-char secret>
 The plaintext key is shown **once** at generation and never stored.
 Authenticate requests by passing the key in the `X-API-Key` header.
 
+Keys also carry an `admin` flag, required to access `/admin/*` endpoints.
+Existing keys default to non-admin. Only issue admin keys to the greenearth
+team.
+
 ### CLI commands
 
 Run all commands from the `api/` directory:
@@ -133,6 +137,9 @@ Run all commands from the `api/` directory:
 ```bash
 # Issue a new key
 pipenv run python scripts/apikeys.py generate alice@example.com
+
+# Issue an admin key (greenearth team only)
+pipenv run python scripts/apikeys.py generate alice@greenearth.social --admin
 
 # List all keys
 pipenv run python scripts/apikeys.py list

--- a/scripts/apikeys.py
+++ b/scripts/apikeys.py
@@ -23,11 +23,12 @@ from app.lib.api_keys import create_api_key, get_api_key_doc, list_api_keys, rev
 from app.lib.firestore import init_firestore_client
 
 
-async def cmd_generate(email: str) -> None:
+async def cmd_generate(email: str, admin: bool) -> None:
     db = init_firestore_client()
-    doc, full_key = await create_api_key(db, email)
+    doc, full_key = await create_api_key(db, email, is_admin=admin)
     print(f"Key ID : {doc.key_id}")
     print(f"Email  : {doc.email}")
+    print(f"Admin  : {doc.is_admin}")
     print(f"Key    : {full_key}")
     print()
     print("IMPORTANT: This is the only time the plaintext key will be shown.")
@@ -39,11 +40,14 @@ async def cmd_list() -> None:
     if not keys:
         print("No API keys found.")
         return
-    print(f"{'key_id':<10} {'email':<30} {'active':<8} {'calls/mo':<10} {'last_used_at'}")
-    print("-" * 80)
+    print(f"{'key_id':<10} {'email':<30} {'active':<8} {'admin':<7} {'calls/mo':<10} {'last_used_at'}")
+    print("-" * 90)
     for k in keys:
         last_used = k.last_used_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-        print(f"{k.key_id:<10} {k.email:<30} {str(k.is_active):<8} {k.monthly_call_count:<10} {last_used}")
+        print(
+            f"{k.key_id:<10} {k.email:<30} {str(k.is_active):<8} {str(k.is_admin):<7} "
+            f"{k.monthly_call_count:<10} {last_used}"
+        )
 
 
 async def cmd_revoke(key_id: str) -> None:
@@ -77,6 +81,11 @@ def main() -> None:
 
     gen = sub.add_parser("generate", help="Issue a new API key")
     gen.add_argument("email", help="Owner email address")
+    gen.add_argument(
+        "--admin",
+        action="store_true",
+        help="Issue an admin key with access to /admin/* endpoints (greenearth team only)",
+    )
 
     sub.add_parser("list", help="List all API keys")
 
@@ -89,7 +98,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "generate":
-        asyncio.run(cmd_generate(args.email))
+        asyncio.run(cmd_generate(args.email, args.admin))
     elif args.command == "list":
         asyncio.run(cmd_list())
     elif args.command == "revoke":

--- a/src/app/conftest.py
+++ b/src/app/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from posthog import Posthog
 
 from .main import app
-from .security import verify_api_key
+from .security import verify_admin_api_key, verify_api_key
 
 
 @pytest.fixture(autouse=True)
@@ -14,8 +14,10 @@ def _default_api_key_override():
     one and win because they also call app.dependency_overrides[verify_api_key].
     """
     app.dependency_overrides.setdefault(verify_api_key, lambda: "test-key-id")
+    app.dependency_overrides.setdefault(verify_admin_api_key, lambda: "test-key-id")
     yield
     app.dependency_overrides.pop(verify_api_key, None)
+    app.dependency_overrides.pop(verify_admin_api_key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -156,6 +156,9 @@ class ApiKeyDocument(BaseModel):
     key_hash: str = Field(..., description="SHA-256(full_key.encode()) as hex")
     email: str = Field(..., description="Owner email address")
     is_active: bool = Field(default=True, description="Whether this API key is valid and usable")
+    is_admin: bool = Field(
+        default=False, description="Whether this key may access /admin/* endpoints"
+    )
     created_at: datetime = Field(default_factory=_utcnow, description="When the key was created")
     last_used_at: datetime = Field(
         default_factory=_utcnow, description="Last time this key was used for an API request"

--- a/src/app/lib/api_keys.py
+++ b/src/app/lib/api_keys.py
@@ -75,7 +75,9 @@ async def get_api_key_doc(db: AsyncClient, key_id: str) -> ApiKeyDocument | None
     return ApiKeyDocument.model_validate(data)
 
 
-async def create_api_key(db: AsyncClient, email: str) -> tuple[ApiKeyDocument, str]:
+async def create_api_key(
+    db: AsyncClient, email: str, is_admin: bool = False
+) -> tuple[ApiKeyDocument, str]:
     """Issue a new API key. Returns (document, plaintext_full_key).
 
     The plaintext key is returned exactly once and never stored.
@@ -87,6 +89,7 @@ async def create_api_key(db: AsyncClient, email: str) -> tuple[ApiKeyDocument, s
         key_hash=key_hash,
         email=email,
         is_active=True,
+        is_admin=is_admin,
         created_at=now,
         last_used_at=now,
         monthly_call_count=0,

--- a/src/app/lib/api_keys_test.py
+++ b/src/app/lib/api_keys_test.py
@@ -138,6 +138,18 @@ class TestGetApiKeyDoc:
         db.collection.assert_called_with(API_KEYS_COLLECTION)
 
     @pytest.mark.asyncio
+    async def test_existing_key_without_is_admin_field_defaults_to_non_admin(self):
+        """Keys written before the admin flag existed have no is_admin field in Firestore."""
+        data = _make_doc_data()
+        assert "is_admin" not in data
+        db, _ = _mock_firestore(data, exists=True)
+
+        result = await get_api_key_doc(db, "a1b2c3d4")
+
+        assert result is not None
+        assert result.is_admin is False
+
+    @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
         db, _ = _mock_firestore(exists=False)
 
@@ -164,6 +176,24 @@ class TestCreateApiKey:
         assert full_key.startswith("gea_")
         assert len(full_key) == FULL_KEY_LEN
         doc_ref.set.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_non_admin(self):
+        db, _ = _mock_firestore(exists=False)
+
+        doc, _ = await create_api_key(db, "alice@example.com")
+
+        assert doc.is_admin is False
+
+    @pytest.mark.asyncio
+    async def test_can_issue_admin_key(self):
+        db, doc_ref = _mock_firestore(exists=False)
+
+        doc, _ = await create_api_key(db, "alice@greenearth.social", is_admin=True)
+
+        assert doc.is_admin is True
+        written = doc_ref.set.call_args[0][0]
+        assert written["is_admin"] is True
 
     @pytest.mark.asyncio
     async def test_written_data_contains_hash_not_plaintext(self):

--- a/src/app/routers/redirect.py
+++ b/src/app/routers/redirect.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from ..lib.firestore import create_redirect, delete_redirect, get_redirect, update_redirect
 from ..lib.posthog_client import get_posthog_client, track_redirect
-from ..security import RequireApiKey
+from ..security import RequireAdminApiKey
 
 router = APIRouter(tags=["redirect"])
 
@@ -126,7 +126,7 @@ class RedirectResponse_(BaseModel):
 async def admin_create_redirect(
     body: RedirectCreateRequest,
     request: Request,
-    _key: RequireApiKey,
+    _key: RequireAdminApiKey,
 ) -> RedirectResponse_:
     """Create a new slug → URL mapping."""
     db = getattr(request.app.state, "firestore", None)
@@ -147,7 +147,7 @@ async def admin_update_redirect(
     slug: str,
     body: RedirectUpdateRequest,
     request: Request,
-    _key: RequireApiKey,
+    _key: RequireAdminApiKey,
 ) -> RedirectResponse_:
     """Update the destination URL for an existing slug."""
     db = getattr(request.app.state, "firestore", None)
@@ -166,7 +166,7 @@ async def admin_update_redirect(
 async def admin_delete_redirect(
     slug: str,
     request: Request,
-    _key: RequireApiKey,
+    _key: RequireAdminApiKey,
 ) -> None:
     """Delete a slug → URL mapping."""
     db = getattr(request.app.state, "firestore", None)

--- a/src/app/routers/redirect_test.py
+++ b/src/app/routers/redirect_test.py
@@ -1,9 +1,12 @@
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
 from ..documents import RedirectDocument
 from ..main import app
+from ..security import verify_admin_api_key
 
 client = TestClient(app, follow_redirects=False)
 
@@ -227,3 +230,46 @@ def test_admin_delete_redirect_not_found():
     ):
         response = client.delete("/admin/redirects/nonexistent", headers=_auth())
     assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints require an admin API key
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _non_admin_override():
+    def _raise():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Admin API key required"
+        )
+
+    app.dependency_overrides[verify_admin_api_key] = _raise
+    yield
+    app.dependency_overrides.pop(verify_admin_api_key, None)
+
+
+def test_admin_create_redirect_forbidden_for_non_admin_key(_non_admin_override):
+    app.state.firestore = AsyncMock()
+    response = client.post(
+        "/admin/redirects",
+        json={"slug": "x", "url": "https://example.com"},
+        headers=_auth(),
+    )
+    assert response.status_code == 403
+
+
+def test_admin_update_redirect_forbidden_for_non_admin_key(_non_admin_override):
+    app.state.firestore = AsyncMock()
+    response = client.put(
+        "/admin/redirects/bsky-profile",
+        json={"url": "https://example.com"},
+        headers=_auth(),
+    )
+    assert response.status_code == 403
+
+
+def test_admin_delete_redirect_forbidden_for_non_admin_key(_non_admin_override):
+    app.state.firestore = AsyncMock()
+    response = client.delete("/admin/redirects/bsky-profile", headers=_auth())
+    assert response.status_code == 403

--- a/src/app/security.py
+++ b/src/app/security.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import APIKeyHeader
 
+from .documents import ApiKeyDocument
 from .lib.api_keys import authenticate_api_key
 
 API_KEY_HEADER_NAME = "X-API-Key"
@@ -10,10 +11,7 @@ API_KEY_HEADER_NAME = "X-API-Key"
 api_key_header = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
 
 
-async def verify_api_key(
-    request: Request,
-    api_key: Annotated[str | None, Depends(api_key_header)],
-) -> str:
+async def _authenticate(request: Request, api_key: str | None) -> ApiKeyDocument:
     db = request.app.state.firestore
     doc = await authenticate_api_key(db, api_key)
     if doc is None:
@@ -21,7 +19,29 @@ async def verify_api_key(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing API key",
         )
+    return doc
+
+
+async def verify_api_key(
+    request: Request,
+    api_key: Annotated[str | None, Depends(api_key_header)],
+) -> str:
+    doc = await _authenticate(request, api_key)
+    return doc.key_id
+
+
+async def verify_admin_api_key(
+    request: Request,
+    api_key: Annotated[str | None, Depends(api_key_header)],
+) -> str:
+    doc = await _authenticate(request, api_key)
+    if not doc.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin API key required",
+        )
     return doc.key_id
 
 
 RequireApiKey = Annotated[str, Depends(verify_api_key)]
+RequireAdminApiKey = Annotated[str, Depends(verify_admin_api_key)]

--- a/src/app/security_test.py
+++ b/src/app/security_test.py
@@ -1,9 +1,12 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
+from .documents import ApiKeyDocument
 from .main import app
-from .security import verify_api_key
+from .security import verify_admin_api_key, verify_api_key
 
 
 @pytest.fixture
@@ -56,3 +59,42 @@ class TestHealthEndpointNoAuth:
     def test_health_returns_ok_status(self, client_invalid):
         response = client_invalid.get("/health")
         assert response.json()["status"] == "ok"
+
+
+def _make_request() -> MagicMock:
+    request = MagicMock()
+    request.app.state.firestore = MagicMock()
+    return request
+
+
+def _admin_doc(is_admin: bool) -> ApiKeyDocument:
+    return ApiKeyDocument(
+        key_id="a1b2c3d4",
+        key_hash="deadbeef",
+        email="test@example.com",
+        is_admin=is_admin,
+    )
+
+
+class TestVerifyAdminApiKey:
+    @pytest.mark.asyncio
+    async def test_raises_401_when_key_invalid(self):
+        with patch("app.security.authenticate_api_key", new=AsyncMock(return_value=None)):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_admin_api_key(_make_request(), "gea_bad")
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_raises_403_when_key_not_admin(self):
+        doc = _admin_doc(is_admin=False)
+        with patch("app.security.authenticate_api_key", new=AsyncMock(return_value=doc)):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_admin_api_key(_make_request(), "gea_valid")
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_returns_key_id_when_admin(self):
+        doc = _admin_doc(is_admin=True)
+        with patch("app.security.authenticate_api_key", new=AsyncMock(return_value=doc)):
+            result = await verify_admin_api_key(_make_request(), "gea_valid")
+        assert result == "a1b2c3d4"


### PR DESCRIPTION
Closes #367

Right now any valid API key can hit /admin/* endpoints, same as external-developer endpoints. This adds a per-key admin flag so only greenearth team keys can access admin routes.

# This PR

- Add `is_admin: bool` (default `False`) to `ApiKeyDocument` — existing keys without the field parse as non-admin
- Add `verify_admin_api_key` / `RequireAdminApiKey` to `security.py`, returning 403 for authenticated-but-non-admin keys (401 still applies for missing/invalid keys)
- Switch `/admin/redirects` (POST/PUT/DELETE) to `RequireAdminApiKey`
- Add `--admin` flag to `scripts/apikeys.py generate`; `list` now shows the admin column
- Update README docs for the admin flag and CLI usage

# Testing

- `pipenv run pyright` and `pipenv run pytest -v` — 1159 passed
- Verified inside the real devenv stack (`devctl test api` — all passed)
- Exercised the real API + Firestore emulator end-to-end via `scripts/apikeys.py` and `curl`:
  - non-admin key on `POST /admin/redirects` → 403
  - admin key on `POST /admin/redirects` → 201
  - no key on `POST /admin/redirects` → 401
  - non-admin key on a regular endpoint (`GET /`) → 200 (unaffected)