### PR TITLE
Add purpose control and make weights configurable per feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ from the public API.  This is available regardless of whether `debug_feeds` is
 enabled for the account.
 
 ```bash
-# List recent feed loads for your account (within the 15-min cache window)
+# List up to 100 recent feed loads for your account (within the last 24 hours)
 curl http://localhost:8000/api/feeds \
   -H "Authorization: Bearer <firebase-custom-token>"
 

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -12,16 +12,51 @@ Convention:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from .lib.candidates.base import CandidateResult
 from .models import CandidateGenerateRequest, CandidatePost, RankPredictResult
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
+
+
+class SourceWeightsDocument(BaseModel):
+    """Atomic relative weights for the configurable GreenEarth sources."""
+
+    model_config = {"extra": "forbid"}
+
+    following: float = Field(ge=0.0, le=1.0)
+    # Defaults to zero so three-source documents written before Network Likes
+    # remain readable without a bulk Firestore migration.
+    network_likes: float = Field(default=0.0, ge=0.0, le=1.0)
+    authors_topics: float = Field(ge=0.0, le=1.0)
+    popular: float = Field(ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def weights_sum_to_one(self) -> SourceWeightsDocument:
+        total = self.following + self.network_likes + self.authors_topics + self.popular
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError("source weights must sum to 1.0")
+        return self
+
+
+class FeedPreferencesDocument(BaseModel):
+    """Sparse preference values for one configured feed."""
+
+    model_config = {"extra": "forbid"}
+
+    source_weights: SourceWeightsDocument | None = None
+    # Read-only migration fallback. New preference responses and patches expose
+    # source_weights instead, but existing Firestore documents may still carry
+    # a social-radius preset.
+    social_radius: int | None = Field(default=None, ge=0, le=4)
+    freshness: int | None = Field(default=None, ge=0, le=5)
+    politics: float | None = Field(default=None, ge=0.5, le=1.5)
+    purpose: float | None = Field(default=None, ge=0.2, le=0.8)
 
 
 class UserDocument(BaseModel):
@@ -67,8 +102,7 @@ class UserDocument(BaseModel):
         default=1.0,
         ge=0.5,
         le=1.5,
-        description="Politics multiplier: 0.5-1.5.  "
-        "Applied to political content scores.",
+        description="Politics multiplier: 0.5-1.5.  Applied to political content scores.",
     )
     purpose: float = Field(
         default=0.5,
@@ -76,6 +110,10 @@ class UserDocument(BaseModel):
         le=0.8,
         description="Purpose preference: 0.2=engaging, 0.5=balanced, 0.8=constructive.  "
         "Used to weight engaging vs constructive content.",
+    )
+    feed_preferences: dict[str, FeedPreferencesDocument] = Field(
+        default_factory=dict,
+        description="Per-feed control values keyed by canonical feed name.",
     )
     created_by_load_test: bool = Field(
         default=False,
@@ -94,9 +132,10 @@ class FeedCacheDocument(BaseModel):
 
     items: list[str] = Field(default_factory=list, description="Cached AT URI list")
     expires_at: datetime = Field(..., description="UTC expiration timestamp for this cache entry")
-    items_meta: list["PipelineItemMeta"] = Field(default_factory=list)
-    generator_diagnostics: list["GeneratorDiagnostic"] = Field(default_factory=list)
+    items_meta: list[PipelineItemMeta] = Field(default_factory=list)
+    generator_diagnostics: list[GeneratorDiagnostic] = Field(default_factory=list)
     applied_social_radius: int | None = None
+    user_did: str | None = None
     feed_name: str | None = None
     generated_at: datetime | None = None
     api_release_sha: str | None = None
@@ -296,7 +335,9 @@ class FeedDebugDocument(BaseModel):
     feed_name: str = Field(..., description="Feed rkey that was loaded")
     regenerated: bool = Field(
         default=False,
-        description="True when this capture came from the cursor-regeneration path rather than a fresh load",
+        description=(
+            "True when this capture came from the cursor-regeneration path rather than a fresh load"
+        ),
     )
 
     # Inputs
@@ -334,7 +375,9 @@ class FeedDebugDocument(BaseModel):
     )
     diversification: list[FeedDebugDiversificationEntry] = Field(
         default_factory=list,
-        description="Per-item diversification breakdown in final order (empty when diversify was off)",
+        description=(
+            "Per-item diversification breakdown in final order (empty when diversify was off)"
+        ),
     )
     n_retrieved: int = Field(
         default=0,
@@ -422,7 +465,9 @@ class FeedSnapshotDocument(BaseModel):
     debug tool and is only written for debug-flagged users.
     """
 
-    request_id: str = Field(..., description="Feed-cache key / feedContext id (also the document ID)")
+    request_id: str = Field(
+        ..., description="Feed-cache key / feedContext id (also the document ID)"
+    )
     items: list[str] = Field(default_factory=list, description="AT URIs in final served order")
     feed_name: str
     generated_at: datetime
@@ -444,7 +489,9 @@ class RedirectDocument(BaseModel):
 
     slug: str = Field(..., description="Short identifier (also the document ID)")
     url: str = Field(..., description="Destination https:// URL")
-    description: str | None = Field(default=None, description="Human-readable label for this redirect")
+    description: str | None = Field(
+        default=None, description="Human-readable label for this redirect"
+    )
     created_at: datetime = Field(
         default_factory=_utcnow, description="When this mapping was created"
     )

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -91,6 +91,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="e2-s",
         internal_display_name="e2 S",
         avatar="assets/icons/unranked-your-feed.png",
+        preference_source="your-feed",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES.get(DEFAULT_SOCIAL_RADIUS),
             infill="popularity",
@@ -106,6 +107,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="67-r",
         internal_display_name="67 R",
         avatar="assets/icons/random.png",
+        controls=("freshness",),
         diversify=False,
         exclude_seen_posts=False,
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetia5l7y2j",
@@ -124,6 +126,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="a0-yf",
         internal_display_name="a0 YF",
         avatar="assets/icons/green-earth.png",
+        controls=("source_weights", "freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetfgpr3t2s",
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
@@ -158,6 +161,7 @@ FEEDS: dict[str, FeedConfig] = {
         internal_rkey="fd-bof",
         internal_display_name="fd BOF",
         avatar="assets/icons/best-of-friends.png",
+        controls=("freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetho32pa2g",
         # Slate-cutoff starting points — tune from the feed.slate.kept_share and
         # feed.slate.cutoff_count metrics once live (see issue #248). min_rank_score
@@ -188,6 +192,7 @@ FEEDS: dict[str, FeedConfig] = {
         "limits enabled, for observing and tuning thresholds (see issue #248).",
         internal_rkey="qr-cp",
         internal_display_name="qr CP",
+        preference_source="your-feed",
         # Same generator mix as your-feed, so cutoff behavior here previews what
         # real users would see.
         gen_request_template=CandidateGenerateRequest.model_construct(
@@ -228,7 +233,6 @@ FEEDS: dict[str, FeedConfig] = {
         min_rank_score=0.425,
         min_mmr_score=-0.05,
     ),
-
     ### (Private) Pure Candidate Generator Feeds, mostly for testing and debugging ###
     "followed-users": FeedConfig(
         display_name="Followed Users",
@@ -344,3 +348,17 @@ FEEDS: dict[str, FeedConfig] = {
         ),
     ),
 }
+
+
+def canonical_feed_name(feed_identifier: str) -> str | None:
+    """Resolve a configured feed name from its canonical or published rkey."""
+    if feed_identifier in FEEDS:
+        return feed_identifier
+    return next(
+        (
+            feed_name
+            for feed_name, config in FEEDS.items()
+            if config.internal_rkey == feed_identifier
+        ),
+        None,
+    )

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -5,6 +5,7 @@ from app.feeds import (
     FEEDS,
     SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
     SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+    canonical_feed_name,
 )
 
 CANDIDATE_ONLY_FEEDS = {
@@ -14,6 +15,15 @@ CANDIDATE_ONLY_FEEDS = {
     "two-tower": "two_tower",
     "two-tower-empty-history": "two_tower_empty_history",
 }
+
+
+def test_canonical_feed_name_resolves_configured_and_published_rkeys():
+    assert canonical_feed_name("your-feed") == "your-feed"
+    assert canonical_feed_name("a0-yf") == "your-feed"
+    assert canonical_feed_name("fd-bof") == "best-of-friends"
+    assert canonical_feed_name("67-r") == "random"
+    assert canonical_feed_name("missing") is None
+
 
 # AT Protocol app.bsky.feed.generator caps displayName at 24 graphemes. Published
 # names are composed from this metadata: prod publishes public feeds under the raw
@@ -33,9 +43,7 @@ class TestFeedsRegistry:
             SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
         ):
             for generators in presets.values():
-                weights = {
-                    generator.name: generator.weight for generator in generators
-                }
+                weights = {generator.name: generator.weight for generator in generators}
                 assert weights.get("two_tower", 0.0) == pytest.approx(
                     weights.get("popularity", 0.0)
                 )
@@ -46,10 +54,9 @@ class TestFeedsRegistry:
             SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
             SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
         ):
-            assert [
-                (generator.name, generator.weight)
-                for generator in presets[0]
-            ] == [("followed_users", 1.0)]
+            assert [(generator.name, generator.weight) for generator in presets[0]] == [
+                ("followed_users", 1.0)
+            ]
 
     def test_static_feed_defaults_include_network_likes(self):
         assert (
@@ -60,12 +67,10 @@ class TestFeedsRegistry:
     def test_network_likes_enabled_presets_add_network_likes_outside_friends(self):
         for radius in range(1, 5):
             with_network_likes = {
-                generator.name
-                for generator in SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[radius]
+                generator.name for generator in SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[radius]
             }
             without_network_likes = {
-                generator.name
-                for generator in SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[radius]
+                generator.name for generator in SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[radius]
             }
             assert "network_likes" in with_network_likes
             assert "network_likes" not in without_network_likes
@@ -73,9 +78,7 @@ class TestFeedsRegistry:
     def test_no_collision_between_internal_rkeys_and_primary_rkeys(self):
         primary_rkeys = set(FEEDS.keys())
         internal_rkeys = {
-            cfg.internal_rkey
-            for cfg in FEEDS.values()
-            if cfg.internal_rkey is not None
+            cfg.internal_rkey for cfg in FEEDS.values() if cfg.internal_rkey is not None
         }
         overlap = primary_rkeys & internal_rkeys
         assert not overlap, f"internal_rkey collides with a primary rkey: {overlap}"
@@ -94,9 +97,10 @@ class TestFeedsRegistry:
         for feed_name in ("your-feed", "best-of-friends"):
             cfg = FEEDS[feed_name]
             assert cfg.rank_request_template is not None
-            assert [
-                spec.name for spec in cfg.rank_request_template.models
-            ] == ["heavy_ranker", "perspective"]
+            assert [spec.name for spec in cfg.rank_request_template.models] == [
+                "heavy_ranker",
+                "perspective",
+            ]
 
     def test_ranked_feeds_have_slate_cutoffs(self):
         for feed_name in ("your-feed", "best-of-friends"):
@@ -108,17 +112,11 @@ class TestFeedsRegistry:
     def test_cold_start_feed_uses_empty_history_models(self):
         cfg = FEEDS["cold-start"]
         assert cfg.public is False
-        assert [
-            (spec.name, spec.weight)
-            for spec in cfg.gen_request_template.generators
-        ] == [
+        assert [(spec.name, spec.weight) for spec in cfg.gen_request_template.generators] == [
             ("popularity", 1.0),
         ]
         assert cfg.rank_request_template is not None
-        assert [
-            (spec.name, spec.weight)
-            for spec in cfg.rank_request_template.models
-        ] == [
+        assert [(spec.name, spec.weight) for spec in cfg.rank_request_template.models] == [
             ("heavy_ranker_empty_history", 1.0),
             ("perspective", 1.0),
         ]
@@ -142,9 +140,10 @@ class TestFeedsRegistry:
         cfg = FEEDS["cutoff-preview"]
         assert cfg.public is False
         assert cfg.rank_request_template is not None
-        assert [
-            spec.name for spec in cfg.rank_request_template.models
-        ] == ["heavy_ranker", "perspective"]
+        assert [spec.name for spec in cfg.rank_request_template.models] == [
+            "heavy_ranker",
+            "perspective",
+        ]
         assert cfg.diversify is True
         assert (
             cfg.gen_request_template.generators
@@ -167,9 +166,7 @@ class TestFeedNameLengths:
     @pytest.mark.parametrize("feed_name,cfg", list(FEEDS.items()))
     def test_internal_display_name_fits_with_prefix_and_sha(self, feed_name, cfg):
         # Worst case: dev/stage publishes internal feeds as "GE <name> <sha>".
-        composed = (
-            len(DEV_STAGE_PREFIX) + len(cfg.internal_display_name) + GIT_SHA_SUFFIX_LEN
-        )
+        composed = len(DEV_STAGE_PREFIX) + len(cfg.internal_display_name) + GIT_SHA_SUFFIX_LEN
         assert composed <= MAX_DISPLAY_NAME_GRAPHEMES, (
             f"{feed_name}: internal_display_name {cfg.internal_display_name!r} is too long — "
             f"'GE {cfg.internal_display_name} <sha>' would be {composed} chars "

--- a/src/app/lib/feed_preferences.py
+++ b/src/app/lib/feed_preferences.py
@@ -1,0 +1,124 @@
+"""Resolve configured, feed-scoped user controls."""
+
+from __future__ import annotations
+
+from typing import Literal, overload
+
+from ..documents import (
+    FeedPreferencesDocument,
+    SourceWeightsDocument,
+    UserDocument,
+)
+from ..feeds import FEEDS, SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES
+from ..models import FeedControlName
+
+DEFAULT_SOURCE_WEIGHTS = SourceWeightsDocument(
+    following=0.3,
+    network_likes=0.2,
+    authors_topics=0.25,
+    popular=0.25,
+)
+
+CONTROL_DEFAULTS: dict[FeedControlName, int | float | SourceWeightsDocument] = {
+    "source_weights": DEFAULT_SOURCE_WEIGHTS,
+    "social_radius": 3,
+    "freshness": 5,
+    "politics": 1.0,
+    "purpose": 0.5,
+}
+
+
+def source_weights_for_social_radius(social_radius: int) -> SourceWeightsDocument:
+    """Translate a legacy Social Radius preset into the atomic source shape."""
+    generators = SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES.get(
+        social_radius,
+        SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[3],
+    )
+    by_name = {generator.name: generator.weight for generator in generators}
+    return SourceWeightsDocument(
+        following=by_name.get("followed_users", 0.0),
+        network_likes=by_name.get("network_likes", 0.0),
+        authors_topics=by_name.get("two_tower", 0.0),
+        popular=by_name.get("popularity", 0.0),
+    )
+
+
+def preference_source(feed_name: str) -> str:
+    """Return the canonical storage key for a feed's preferences."""
+    feed = FEEDS[feed_name]
+    return feed.preference_source or feed_name
+
+
+def configured_controls(feed_name: str) -> tuple[FeedControlName, ...]:
+    """Return controls configured for a feed, following any preference alias."""
+    return FEEDS[preference_source(feed_name)].controls
+
+
+def resolve_feed_preferences(
+    user: UserDocument | None,
+    feed_name: str,
+) -> FeedPreferencesDocument:
+    """Resolve stored values, legacy fallbacks, and defaults for one feed."""
+    source = preference_source(feed_name)
+    stored = user.feed_preferences.get(source) if user is not None else None
+    values: dict[str, int | float | SourceWeightsDocument] = {}
+
+    for control in configured_controls(feed_name):
+        if control == "source_weights":
+            if stored is not None and stored.source_weights is not None:
+                values[control] = stored.source_weights
+            elif stored is not None and stored.social_radius is not None:
+                values[control] = source_weights_for_social_radius(stored.social_radius)
+            elif user is not None:
+                values[control] = source_weights_for_social_radius(user.social_radius)
+            else:
+                values[control] = DEFAULT_SOURCE_WEIGHTS
+            continue
+        stored_value = getattr(stored, control, None) if stored is not None else None
+        if stored_value is not None:
+            values[control] = stored_value
+        elif user is not None:
+            # Legacy flat preferences initialize every applicable feed until
+            # that feed's resolved values are materialized by its first patch.
+            values[control] = getattr(user, control)
+        else:
+            values[control] = CONTROL_DEFAULTS[control]
+
+    return FeedPreferencesDocument.model_validate(values)
+
+
+@overload
+def control_value(
+    user: UserDocument | None,
+    feed_name: str,
+    control: Literal["source_weights"],
+) -> SourceWeightsDocument: ...
+
+
+@overload
+def control_value(
+    user: UserDocument | None,
+    feed_name: str,
+    control: Literal["social_radius", "freshness"],
+) -> int: ...
+
+
+@overload
+def control_value(
+    user: UserDocument | None,
+    feed_name: str,
+    control: Literal["politics", "purpose"],
+) -> float: ...
+
+
+def control_value(
+    user: UserDocument | None,
+    feed_name: str,
+    control: FeedControlName,
+) -> int | float | SourceWeightsDocument:
+    """Resolve one value, returning its default when the feed does not expose it."""
+    if control not in configured_controls(feed_name):
+        return CONTROL_DEFAULTS[control]
+    value = getattr(resolve_feed_preferences(user, feed_name), control)
+    assert value is not None
+    return value

--- a/src/app/lib/feed_preferences_test.py
+++ b/src/app/lib/feed_preferences_test.py
@@ -1,0 +1,64 @@
+from ..documents import FeedPreferencesDocument, SourceWeightsDocument, UserDocument
+from .feed_preferences import DEFAULT_SOURCE_WEIGHTS, resolve_feed_preferences
+
+
+def test_resolver_prefers_atomic_source_weights_over_legacy_values():
+    # Three-source documents remain valid and resolve Network Likes to zero.
+    weights = SourceWeightsDocument(
+        following=0.5,
+        authors_topics=0.2,
+        popular=0.3,
+    )
+    user = UserDocument(
+        user_did="did:plc:test",
+        social_radius=0,
+        feed_preferences={
+            "your-feed": FeedPreferencesDocument(
+                source_weights=weights,
+                social_radius=4,
+            )
+        },
+    )
+
+    resolved = resolve_feed_preferences(user, "your-feed")
+
+    assert resolved.source_weights == weights
+    assert resolved.social_radius is None
+
+
+def test_resolver_lazily_translates_feed_scoped_social_radius():
+    user = UserDocument(
+        user_did="did:plc:test",
+        social_radius=0,
+        feed_preferences={
+            "your-feed": FeedPreferencesDocument(social_radius=4),
+        },
+    )
+
+    resolved = resolve_feed_preferences(user, "your-feed")
+
+    assert resolved.source_weights == SourceWeightsDocument(
+        following=0.1,
+        network_likes=0.1,
+        authors_topics=0.4,
+        popular=0.4,
+    )
+
+
+def test_resolver_translates_flat_legacy_social_radius():
+    user = UserDocument(user_did="did:plc:test", social_radius=1)
+
+    resolved = resolve_feed_preferences(user, "your-feed")
+
+    assert resolved.source_weights == SourceWeightsDocument(
+        following=0.7,
+        network_likes=0.1,
+        authors_topics=0.1,
+        popular=0.1,
+    )
+
+
+def test_resolver_uses_source_weight_defaults_without_a_user():
+    resolved = resolve_feed_preferences(None, "your-feed")
+
+    assert resolved.source_weights == DEFAULT_SOURCE_WEIGHTS

--- a/src/app/lib/firestore.py
+++ b/src/app/lib/firestore.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from google.cloud.firestore import (  # type: ignore[import-untyped]
     ArrayUnion,
@@ -22,11 +22,13 @@ from google.cloud.firestore import (  # type: ignore[import-untyped]
 from ..documents import (
     FeedActivityDocument,
     FeedDebugDocument,
+    FeedPreferencesDocument,
     FeedSnapshotDocument,
     InteractionDocument,
     RedirectDocument,
     UserDocument,
 )
+from .feed_preferences import preference_source, resolve_feed_preferences
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +40,8 @@ DISCARDED_POSTS_COLLECTION = "discarded_posts"
 FEED_DEBUG_COLLECTION = "feed_debug"
 FEED_SNAPSHOTS_COLLECTION = "feed_snapshots"
 MAX_FEED_SNAPSHOT_ITEMS = 500
+MAX_FEED_SNAPSHOT_DOCUMENTS = 100
+FIRESTORE_WRITE_BATCH_LIMIT = 500
 
 # Suffix appended to a daily-bucket document ID (``YYYY-MM-DD``) for load-test
 # traffic. Test buckets live in the same subcollection as real ones so the
@@ -148,7 +152,7 @@ async def upsert_user(
     ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
     doc = await ref.get()
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     if doc.exists:
         data = doc.to_dict()
@@ -219,7 +223,7 @@ async def set_user_debug_flag(db: AsyncClient, user_did: str, enabled: bool) -> 
     doc = await ref.get()
     if not doc.exists:
         raise ValueError(f"No user document for {user_did}")
-    await ref.update({"debug_feeds": enabled, "updated_at": datetime.now(timezone.utc)})
+    await ref.update({"debug_feeds": enabled, "updated_at": datetime.now(UTC)})
 
 
 async def set_user_social_radius(db: AsyncClient, user_did: str, social_radius: int) -> None:
@@ -268,6 +272,42 @@ async def set_user_preferences(
     )
 
 
+async def patch_user_feed_preferences(
+    db: AsyncClient,
+    user_did: str,
+    feed_name: str,
+    patch: FeedPreferencesDocument,
+) -> FeedPreferencesDocument:
+    """Atomically patch and materialize one feed without replacing siblings."""
+    ref = db.collection(USERS_COLLECTION).document(user_doc_id(user_did))
+    transaction = db.transaction()
+
+    @async_transactional
+    async def _patch(transaction) -> FeedPreferencesDocument:
+        snapshot = await ref.get(transaction=transaction)
+        data = snapshot.to_dict() if snapshot.exists else None
+        user = UserDocument.model_validate(data) if data is not None else None
+        resolved = resolve_feed_preferences(user, feed_name)
+        values = resolved.model_dump(exclude_none=True)
+        values.update(patch.model_dump(exclude_none=True))
+        updated = FeedPreferencesDocument.model_validate(values)
+        transaction.set(
+            ref,
+            {
+                "user_did": user_did,
+                "feed_preferences": {
+                    preference_source(feed_name): updated.model_dump(exclude_none=True),
+                },
+                "created_by_load_test": False,
+                "updated_at": datetime.now(UTC),
+            },
+            merge=True,
+        )
+        return updated
+
+    return await _patch(transaction)
+
+
 # ---------------------------------------------------------------------------
 # Feed activity
 # ---------------------------------------------------------------------------
@@ -309,13 +349,14 @@ async def upsert_feed_activity(
     )
     doc = await ref.get()
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     if doc.exists:
         data = doc.to_dict()
         if data is None:
             raise ValueError(
-                f"Firestore feed_activity document exists but to_dict() returned None for {user_did}/{feed_name}"
+                "Firestore feed_activity document exists but to_dict() returned "
+                f"None for {user_did}/{feed_name}"
             )
         await ref.update({"last_seen_at": now})
         data["last_seen_at"] = now
@@ -375,7 +416,7 @@ async def _record_daily_bucket_uris(
     if not post_uris:
         return
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     bucket_id = now.strftime("%Y-%m-%d")
     if load_test:
         bucket_id += LOAD_TEST_BUCKET_SUFFIX
@@ -405,7 +446,7 @@ async def _get_recent_bucket_uris(
     ``ArrayUnion`` preserves append order, so the result is roughly the most
     recent URIs.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     query = (
         db.collection(USERS_COLLECTION)
         .document(user_doc_id(user_did))
@@ -555,12 +596,8 @@ def _merge_feed_snapshots(
     meta_by_uri = {meta.at_uri: meta for meta in earlier.items_meta}
     meta_by_uri.update({meta.at_uri: meta for meta in later.items_meta})
     items_meta = [meta_by_uri[uri] for uri in ordered_items if uri in meta_by_uri]
-    existing_diag = {
-        (diag.name, diag.mode): diag for diag in existing.generator_diagnostics
-    }
-    incoming_diag = {
-        (diag.name, diag.mode): diag for diag in incoming.generator_diagnostics
-    }
+    existing_diag = {(diag.name, diag.mode): diag for diag in existing.generator_diagnostics}
+    incoming_diag = {(diag.name, diag.mode): diag for diag in incoming.generator_diagnostics}
     incoming_new = set(incoming.items) - set(existing.items)
     diagnostics = []
     for key in dict.fromkeys([*existing_diag, *incoming_diag]):
@@ -610,7 +647,12 @@ def _merge_feed_snapshots(
 
 
 async def merge_feed_snapshot(
-    db: AsyncClient, user_did: str, request_id: str, doc: FeedSnapshotDocument
+    db: AsyncClient,
+    user_did: str,
+    request_id: str,
+    doc: FeedSnapshotDocument,
+    *,
+    enforce_document_cap: bool = True,
 ) -> bool:
     """Atomically create or extend a feed-session snapshot.
 
@@ -642,22 +684,65 @@ async def merge_feed_snapshot(
     transaction = db.transaction()
 
     @async_transactional
-    async def _merge(transaction) -> bool:
+    async def _merge(transaction) -> tuple[bool, bool]:
         snapshot = await ref.get(transaction=transaction)
         if not snapshot.exists:
             transaction.set(ref, doc.model_dump())
-            return initial_truncated
+            return initial_truncated, True
 
         data = snapshot.to_dict()
         if data is None:
             transaction.set(ref, doc.model_dump())
-            return initial_truncated
+            return initial_truncated, False
 
         merged, truncated = _merge_feed_snapshots(FeedSnapshotDocument.model_validate(data), doc)
         transaction.set(ref, merged.model_dump())
-        return truncated
+        return truncated, False
 
-    return await _merge(transaction)
+    truncated, created = await _merge(transaction)
+    if created and enforce_document_cap:
+        await prune_feed_snapshots(db, user_did)
+    return truncated
+
+
+async def prune_feed_snapshots(
+    db: AsyncClient,
+    user_did: str,
+    *,
+    max_documents: int = MAX_FEED_SNAPSHOT_DOCUMENTS,
+) -> int:
+    """Delete snapshots older than the newest *max_documents* for a user.
+
+    The cap is enforced after a new snapshot is committed. Pruning is
+    intentionally fail-soft: a later snapshot creation retries the same query,
+    while feed serving remains unaffected by a cleanup failure.
+    """
+    try:
+        collection = (
+            db.collection(USERS_COLLECTION)
+            .document(user_doc_id(user_did))
+            .collection(FEED_SNAPSHOTS_COLLECTION)
+        )
+        query = collection.order_by("generated_at", direction=Query.DESCENDING).offset(
+            max_documents
+        )
+        overflow = [snapshot async for snapshot in query.stream()]
+
+        # The query returns newest-first. Reverse it so the oldest overflow
+        # documents are enqueued for deletion first, including across batches.
+        overflow.reverse()
+        for start in range(0, len(overflow), FIRESTORE_WRITE_BATCH_LIMIT):
+            batch = db.batch()
+            for snapshot in overflow[start : start + FIRESTORE_WRITE_BATCH_LIMIT]:
+                batch.delete(snapshot.reference)
+            await batch.commit()
+        return len(overflow)
+    except Exception:
+        logger.exception(
+            "Failed to prune feed snapshots for user '%s'",
+            user_did,
+        )
+        return 0
 
 
 async def get_feed_snapshot(
@@ -812,7 +897,7 @@ async def create_redirect(
 async def update_redirect(
     db: AsyncClient, slug: str, url: str, description: str | None = None
 ) -> RedirectDocument | None:
-    """Update the URL (and optionally description) for an existing slug. Returns ``None`` if not found."""
+    """Update an existing slug, returning ``None`` when it is not found."""
     ref = db.collection(REDIRECTS_COLLECTION).document(slug)
     existing = await ref.get()
     if not existing.exists:

--- a/src/app/lib/firestore_test.py
+++ b/src/app/lib/firestore_test.py
@@ -2,24 +2,30 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from google.cloud.firestore import ArrayUnion
 
-from ..documents import FeedDebugDocument, FeedSnapshotDocument, InteractionDocument, PipelineItemMeta, UserDocument
-from ..models import CandidateGenerateRequest, GeneratorSpec
+from ..documents import (
+    FeedDebugDocument,
+    FeedPreferencesDocument,
+    FeedSnapshotDocument,
+    InteractionDocument,
+    PipelineItemMeta,
+)
 from ..lib.firestore import (
     DISCARDED_POSTS_COLLECTION,
-    FEED_DEBUG_COLLECTION,
     FEED_SNAPSHOTS_COLLECTION,
-    LOAD_TEST_BUCKET_SUFFIX,
-    MAX_FEED_SNAPSHOT_ITEMS,
+    FIRESTORE_WRITE_BATCH_LIMIT,
     INTERACTIONS_COLLECTION,
+    LOAD_TEST_BUCKET_SUFFIX,
+    MAX_FEED_SNAPSHOT_DOCUMENTS,
+    MAX_FEED_SNAPSHOT_ITEMS,
     SEEN_POSTS_COLLECTION,
     USERS_COLLECTION,
+    _merge_feed_snapshots,
     delete_feed_snapshot,
     get_feed_activity,
     get_feed_debug,
@@ -29,9 +35,10 @@ from ..lib.firestore import (
     get_recent_seen_uris,
     get_user,
     get_user_by_username,
-    _merge_feed_snapshots,
     init_firestore_client,
     merge_feed_snapshot,
+    patch_user_feed_preferences,
+    prune_feed_snapshots,
     record_discarded_posts,
     record_interaction,
     record_seen_posts,
@@ -41,7 +48,7 @@ from ..lib.firestore import (
     user_doc_id,
     write_feed_debug,
 )
-
+from ..models import CandidateGenerateRequest, GeneratorSpec
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,7 +62,8 @@ FEED_NAME = "unranked-your-feed"
 def _mock_feed_activity_client():
     db = MagicMock()
     doc_ref = AsyncMock()
-    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    feed_activity = db.collection.return_value.document.return_value.collection
+    feed_activity.return_value.document.return_value = doc_ref
     return db, doc_ref
 
 
@@ -63,7 +71,8 @@ def _mock_seen_posts_write_client():
     """Mock the users/{did}/seen_posts/{bucket} document-write chain."""
     db = MagicMock()
     doc_ref = AsyncMock()
-    db.collection.return_value.document.return_value.collection.return_value.document.return_value = doc_ref
+    seen_posts = db.collection.return_value.document.return_value.collection
+    seen_posts.return_value.document.return_value = doc_ref
     return db, doc_ref
 
 
@@ -80,7 +89,8 @@ def _mock_seen_posts_query_client(buckets):
     db = MagicMock()
     query = MagicMock()
     query.stream.return_value = _async_iter(buckets)
-    db.collection.return_value.document.return_value.collection.return_value.where.return_value = query
+    seen_posts = db.collection.return_value.document.return_value.collection
+    seen_posts.return_value.where.return_value = query
     return db, query
 
 
@@ -215,14 +225,17 @@ class TestGetUser:
     @pytest.mark.asyncio
     async def test_returns_user_when_exists(self):
         db, _, doc_ref = _mock_firestore_client()
-        now = datetime.now(timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": now,
-            "updated_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": now,
+                "updated_at": now,
+                "last_seen_at": now,
+            },
+        )
 
         user = await get_user(db, USER_DID)
 
@@ -272,14 +285,17 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_updates_existing_user(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME)
 
@@ -312,14 +328,17 @@ class TestUpsertUser:
     async def test_unresolved_handle_does_not_erase_a_known_one(self):
         # A directory blip shouldn't wipe a handle we already resolved.
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, None)
 
@@ -332,14 +351,17 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_updates_username_when_changed(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": "old-handle.bsky.app",
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": "old-handle.bsky.app",
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME)
 
@@ -367,14 +389,17 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_load_test_existing_user_is_left_untouched(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME, is_load_test=True)
 
@@ -386,15 +411,18 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_real_request_clears_load_test_flag(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-            "created_by_load_test": True,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+                "created_by_load_test": True,
+            },
+        )
 
         user = await upsert_user(db, USER_DID, USERNAME)
 
@@ -407,20 +435,54 @@ class TestUpsertUser:
     @pytest.mark.asyncio
     async def test_real_request_on_unflagged_user_leaves_flag_alone(self):
         db, _, doc_ref = _mock_firestore_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": original_time,
-            "updated_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": original_time,
+                "updated_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         await upsert_user(db, USER_DID, USERNAME)
 
         update_fields = doc_ref.update.call_args[0][0]
         assert "created_by_load_test" not in update_fields
         assert "created_at" not in update_fields
+
+
+@pytest.mark.asyncio
+async def test_patch_user_feed_preferences_materializes_in_transaction():
+    db, _, doc_ref = _mock_firestore_client()
+    transaction = MagicMock()
+    db.transaction.return_value = transaction
+    doc_ref.get.return_value = _mock_doc_snapshot(
+        True,
+        {
+            "user_did": USER_DID,
+            "freshness": 4,
+            "purpose": 0.65,
+            "feed_preferences": {"random": {"freshness": 1}},
+        },
+    )
+
+    with patch("app.lib.firestore.async_transactional", side_effect=lambda fn: fn):
+        updated = await patch_user_feed_preferences(
+            db,
+            USER_DID,
+            "best-of-friends",
+            FeedPreferencesDocument(freshness=2),
+        )
+
+    assert updated.model_dump(exclude_none=True) == {"freshness": 2, "purpose": 0.65}
+    doc_ref.get.assert_awaited_once_with(transaction=transaction)
+    written = transaction.set.call_args.args[1]
+    assert written["feed_preferences"] == {"best-of-friends": {"freshness": 2, "purpose": 0.65}}
+    assert written["created_by_load_test"] is False
+    assert transaction.set.call_args.kwargs == {"merge": True}
 
 
 # ---------------------------------------------------------------------------
@@ -432,12 +494,15 @@ class TestGetFeedActivity:
     @pytest.mark.asyncio
     async def test_returns_doc_when_exists(self):
         db, doc_ref = _mock_feed_activity_client()
-        now = datetime.now(timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": now,
+                "last_seen_at": now,
+            },
+        )
 
         activity = await get_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -481,12 +546,15 @@ class TestUpsertFeedActivity:
     @pytest.mark.asyncio
     async def test_updates_only_last_seen_at_on_revisit(self):
         db, doc_ref = _mock_feed_activity_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -500,12 +568,15 @@ class TestUpsertFeedActivity:
     @pytest.mark.asyncio
     async def test_does_not_overwrite_first_seen_at(self):
         db, doc_ref = _mock_feed_activity_client()
-        original_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        doc_ref.get.return_value = _mock_doc_snapshot(True, {
-            "feed_name": FEED_NAME,
-            "first_seen_at": original_time,
-            "last_seen_at": original_time,
-        })
+        original_time = datetime(2026, 1, 1, tzinfo=UTC)
+        doc_ref.get.return_value = _mock_doc_snapshot(
+            True,
+            {
+                "feed_name": FEED_NAME,
+                "first_seen_at": original_time,
+                "last_seen_at": original_time,
+            },
+        )
 
         activity = await upsert_feed_activity(db, USER_DID, FEED_NAME)
 
@@ -564,7 +635,7 @@ class TestRecordSeenPosts:
             SEEN_POSTS_COLLECTION
         )
         # Bucket id is the current UTC date.
-        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        bucket_id = datetime.now(UTC).strftime("%Y-%m-%d")
         db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
             bucket_id
         )
@@ -575,7 +646,7 @@ class TestRecordSeenPosts:
         assert kwargs == {"merge": True}
         assert isinstance(payload["post_uris"], ArrayUnion)
         assert payload["post_uris"].values == ["at://post/1", "at://post/2"]
-        assert payload["expires_at"] > datetime.now(timezone.utc)
+        assert payload["expires_at"] > datetime.now(UTC)
 
     @pytest.mark.asyncio
     async def test_noop_on_empty(self):
@@ -592,7 +663,7 @@ class TestRecordSeenPosts:
         await record_seen_posts(db, USER_DID, ["at://post/1"], load_test=True)
 
         # Bucket id gets the load-test suffix; a separate doc from real seen posts.
-        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d") + LOAD_TEST_BUCKET_SUFFIX
+        bucket_id = datetime.now(UTC).strftime("%Y-%m-%d") + LOAD_TEST_BUCKET_SUFFIX
         db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
             bucket_id
         )
@@ -619,7 +690,8 @@ class TestGetRecentSeenUris:
         # Newest bucket first, duplicate "at://b" collapsed.
         assert uris == ["at://b", "at://c", "at://a"]
         # Query filters on a future expiry.
-        where_args = db.collection.return_value.document.return_value.collection.return_value.where.call_args[0]
+        seen_posts = db.collection.return_value.document.return_value.collection
+        where_args = seen_posts.return_value.where.call_args[0]
         assert where_args[0] == "expires_at"
         assert where_args[1] == ">"
 
@@ -668,7 +740,7 @@ class TestDiscardedPosts:
         db.collection.return_value.document.return_value.collection.assert_called_with(
             DISCARDED_POSTS_COLLECTION
         )
-        bucket_id = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        bucket_id = datetime.now(UTC).strftime("%Y-%m-%d")
         db.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
             bucket_id
         )
@@ -679,7 +751,7 @@ class TestDiscardedPosts:
         assert kwargs == {"merge": True}
         assert isinstance(payload["post_uris"], ArrayUnion)
         assert payload["post_uris"].values == ["at://post/1", "at://post/2"]
-        assert payload["expires_at"] > datetime.now(timezone.utc)
+        assert payload["expires_at"] > datetime.now(UTC)
 
     @pytest.mark.asyncio
     async def test_noop_on_empty(self):
@@ -723,7 +795,7 @@ REQUEST_ID = "req-abc123"
 
 
 def _feed_debug_doc() -> FeedDebugDocument:
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return FeedDebugDocument(
         request_id=REQUEST_ID,
         user_did=USER_DID,
@@ -746,14 +818,17 @@ def _feed_debug_doc() -> FeedDebugDocument:
 class TestGetUserByUsername:
     @pytest.mark.asyncio
     async def test_returns_first_match(self):
-        now = datetime.now(timezone.utc)
-        snap = _mock_doc_snapshot(True, {
-            "user_did": USER_DID,
-            "username": USERNAME,
-            "created_at": now,
-            "updated_at": now,
-            "last_seen_at": now,
-        })
+        now = datetime.now(UTC)
+        snap = _mock_doc_snapshot(
+            True,
+            {
+                "user_did": USER_DID,
+                "username": USERNAME,
+                "created_at": now,
+                "updated_at": now,
+                "last_seen_at": now,
+            },
+        )
         db = MagicMock()
         query = MagicMock()
         query.stream.return_value = _async_iter([snap])
@@ -856,7 +931,7 @@ class TestGetFeedDebug:
 class TestGetNewerFeedSnapshotUris:
     @pytest.mark.asyncio
     async def test_returns_uris_from_newer_snapshots(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         snap1 = _mock_doc_snapshot(True, {"items": ["at://a", "at://b"]})
         snap2 = _mock_doc_snapshot(True, {"items": ["at://c"]})
@@ -874,7 +949,7 @@ class TestGetNewerFeedSnapshotUris:
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_newer_snapshots(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         query = MagicMock()
         query.stream.return_value = _async_iter([])
@@ -890,7 +965,7 @@ class TestGetNewerFeedSnapshotUris:
 
     @pytest.mark.asyncio
     async def test_allows_empty_items_lists(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         db = MagicMock()
         snap = _mock_doc_snapshot(True, {"items": []})
         query = MagicMock()
@@ -908,10 +983,12 @@ class TestGetNewerFeedSnapshotUris:
 
 class TestMergeFeedSnapshots:
     def test_appends_regeneration_and_extends_expiration(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot("session-1", now, ["at://a", "at://b"])
         regenerated = _feed_snapshot(
-            "session-1", now + timedelta(minutes=2), ["at://c"],
+            "session-1",
+            now + timedelta(minutes=2),
+            ["at://c"],
             expires_at=now + timedelta(minutes=17),
         )
 
@@ -923,7 +1000,7 @@ class TestMergeFeedSnapshots:
         assert truncated is False
 
     def test_deduplicates_and_uses_newer_metadata(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot("session-1", now, ["at://a", "at://b"])
         regenerated = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://b", "at://c"])
         regenerated.items_meta[0] = PipelineItemMeta(at_uri="at://b", rank=99)
@@ -934,7 +1011,7 @@ class TestMergeFeedSnapshots:
         assert next(m for m in merged.items_meta if m.at_uri == "at://b").rank == 99
 
     def test_orders_out_of_order_background_writes(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         later = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://c"])
         earlier = _feed_snapshot("session-1", now, ["at://a", "at://b"])
 
@@ -944,7 +1021,7 @@ class TestMergeFeedSnapshots:
         assert merged.generated_at == now
 
     def test_preserves_originating_api_release(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot(
             "session-1",
             now,
@@ -963,9 +1040,10 @@ class TestMergeFeedSnapshots:
         assert merged.api_release_sha == "origin-sha"
 
     def test_caps_session_at_item_limit(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         initial = _feed_snapshot(
-            "session-1", now,
+            "session-1",
+            now,
             [f"at://post/{i}" for i in range(MAX_FEED_SNAPSHOT_ITEMS)],
         )
         later = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://overflow"])
@@ -978,27 +1056,141 @@ class TestMergeFeedSnapshots:
 
     @pytest.mark.asyncio
     async def test_creates_snapshot_in_transaction(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         doc = _feed_snapshot("session-1", now, ["at://a"])
         db, doc_ref = _mock_feed_activity_client()
         transaction = MagicMock()
         db.transaction.return_value = transaction
         doc_ref.get.return_value = _mock_doc_snapshot(False)
 
-        with patch("app.lib.firestore.async_transactional", side_effect=lambda fn: fn):
+        with (
+            patch("app.lib.firestore.async_transactional", side_effect=lambda fn: fn),
+            patch("app.lib.firestore.prune_feed_snapshots", new_callable=AsyncMock) as prune,
+        ):
             truncated = await merge_feed_snapshot(db, USER_DID, "session-1", doc)
 
         assert truncated is False
         doc_ref.get.assert_awaited_once_with(transaction=transaction)
         transaction.set.assert_called_once_with(doc_ref, doc.model_dump())
+        prune.assert_awaited_once_with(db, USER_DID)
+
+    @pytest.mark.asyncio
+    async def test_extending_snapshot_does_not_prune_documents(self):
+        now = datetime.now(UTC)
+        existing = _feed_snapshot("session-1", now, ["at://a"])
+        incoming = _feed_snapshot("session-1", now + timedelta(minutes=1), ["at://b"])
+        db, doc_ref = _mock_feed_activity_client()
+        transaction = MagicMock()
+        db.transaction.return_value = transaction
+        doc_ref.get.return_value = _mock_doc_snapshot(True, existing.model_dump())
+
+        with (
+            patch("app.lib.firestore.async_transactional", side_effect=lambda fn: fn),
+            patch("app.lib.firestore.prune_feed_snapshots", new_callable=AsyncMock) as prune,
+        ):
+            truncated = await merge_feed_snapshot(db, USER_DID, "session-1", incoming)
+
+        assert truncated is False
+        prune.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_creation_can_skip_document_cap(self):
+        doc = _feed_snapshot("session-1", datetime.now(UTC), ["at://a"])
+        db, doc_ref = _mock_feed_activity_client()
+        db.transaction.return_value = MagicMock()
+        doc_ref.get.return_value = _mock_doc_snapshot(False)
+
+        with (
+            patch("app.lib.firestore.async_transactional", side_effect=lambda fn: fn),
+            patch("app.lib.firestore.prune_feed_snapshots", new_callable=AsyncMock) as prune,
+        ):
+            await merge_feed_snapshot(
+                db,
+                USER_DID,
+                "session-1",
+                doc,
+                enforce_document_cap=False,
+            )
+
+        prune.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_empty_batch_skips_transaction(self):
-        doc = _feed_snapshot("session-1", datetime.now(timezone.utc), [])
+        doc = _feed_snapshot("session-1", datetime.now(UTC), [])
         db = MagicMock()
 
         assert await merge_feed_snapshot(db, USER_DID, "session-1", doc) is False
         db.transaction.assert_not_called()
+
+
+class TestPruneFeedSnapshots:
+    @staticmethod
+    def _client_with_overflow(snapshots):
+        db = MagicMock()
+        collection = MagicMock()
+        query = MagicMock()
+        query.stream.return_value = _async_iter(snapshots)
+        collection.order_by.return_value.offset.return_value = query
+        (db.collection.return_value.document.return_value.collection.return_value) = collection
+        return db, collection
+
+    @pytest.mark.asyncio
+    async def test_keeps_newest_documents_when_no_overflow_exists(self):
+        db, collection = self._client_with_overflow([])
+
+        deleted = await prune_feed_snapshots(db, USER_DID)
+
+        assert deleted == 0
+        collection.order_by.return_value.offset.assert_called_once_with(MAX_FEED_SNAPSHOT_DOCUMENTS)
+        db.batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deletes_overflow_oldest_first(self):
+        oldest = MagicMock()
+        middle = MagicMock()
+        newest_overflow = MagicMock()
+        db, _ = self._client_with_overflow([newest_overflow, middle, oldest])
+        batch = MagicMock()
+        batch.commit = AsyncMock()
+        db.batch.return_value = batch
+
+        deleted = await prune_feed_snapshots(db, USER_DID)
+
+        assert deleted == 3
+        assert [call.args[0] for call in batch.delete.call_args_list] == [
+            oldest.reference,
+            middle.reference,
+            newest_overflow.reference,
+        ]
+        batch.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deletes_large_overflow_in_firestore_sized_batches(self):
+        overflow = [MagicMock() for _ in range(FIRESTORE_WRITE_BATCH_LIMIT + 7)]
+        db, _ = self._client_with_overflow(overflow)
+        batches = [MagicMock(), MagicMock()]
+        for batch in batches:
+            batch.commit = AsyncMock()
+        db.batch.side_effect = batches
+
+        deleted = await prune_feed_snapshots(db, USER_DID)
+
+        assert deleted == FIRESTORE_WRITE_BATCH_LIMIT + 7
+        assert batches[0].delete.call_count == FIRESTORE_WRITE_BATCH_LIMIT
+        assert batches[1].delete.call_count == 7
+        batches[0].commit.assert_awaited_once()
+        batches[1].commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_is_non_fatal(self, caplog):
+        db = MagicMock()
+        collection = db.collection.return_value.document.return_value.collection.return_value
+        collection.order_by.side_effect = RuntimeError("query failed")
+
+        deleted = await prune_feed_snapshots(db, USER_DID)
+
+        assert deleted == 0
+        assert "Failed to prune feed snapshots" in caplog.text
 
 
 class TestDeleteFeedSnapshot:

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,7 +1,15 @@
 import base64
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+FeedControlName = Literal[
+    "source_weights",
+    "social_radius",
+    "freshness",
+    "politics",
+    "purpose",
+]
 
 
 class FeedCursor(BaseModel):
@@ -18,9 +26,7 @@ class FeedCursor(BaseModel):
 
     def encode(self) -> str:
         """Serialise to a URL-safe, opaque string."""
-        return base64.urlsafe_b64encode(
-            self.model_dump_json().encode()
-        ).decode()
+        return base64.urlsafe_b64encode(self.model_dump_json().encode()).decode()
 
     @classmethod
     def decode(cls, raw: str) -> "FeedCursor":
@@ -38,8 +44,7 @@ class FeedCursor(BaseModel):
 class CandidatePost(BaseModel):
     """A post returned by search or candidate generation."""
 
-    at_uri: str | None = Field(
-        default=None, description="The AT URI of the post (e.g. at://...)")
+    at_uri: str | None = Field(default=None, description="The AT URI of the post (e.g. at://...)")
     content: str | None = Field(default=None, description="The post text content")
     minilm_l12_embedding: str | None = Field(
         default=None, description="Base64-encoded float32 MiniLM L12 embedding (384-d)"
@@ -50,9 +55,7 @@ class CandidatePost(BaseModel):
     generator_name: str | None = Field(
         default=None, description="Name of the candidate generator that produced this post"
     )
-    author_did: str | None = Field(
-        default=None, description="AT Protocol DID of the post author"
-    )
+    author_did: str | None = Field(default=None, description="AT Protocol DID of the post author")
     author_username: str | None = Field(
         default=None,
         description="AT Protocol handle of the post author (resolved from author_did; "
@@ -61,9 +64,7 @@ class CandidatePost(BaseModel):
     contains_images: bool | None = Field(
         default=None, description="Whether the post embeds one or more images"
     )
-    contains_video: bool | None = Field(
-        default=None, description="Whether the post embeds video"
-    )
+    contains_video: bool | None = Field(default=None, description="Whether the post embeds video")
     image_count: int | None = Field(
         default=None, description="Number of images embedded in the post"
     )
@@ -209,6 +210,14 @@ class FeedConfig(BaseModel):
     public: bool = Field(False)
     internal_rkey: str
     internal_display_name: str
+    controls: tuple[FeedControlName, ...] = Field(
+        default_factory=tuple,
+        description="User-configurable controls exposed for this feed, in display order.",
+    )
+    preference_source: str | None = Field(
+        default=None,
+        description="Feed whose stored preferences this pipeline inherits, when different.",
+    )
     gen_request_template: CandidateGenerateRequest
     rank_request_template: RankPredictRequest | None = Field(
         None,
@@ -256,6 +265,7 @@ class FeedConfig(BaseModel):
     )
     avatar: str | None = Field(
         None,
-        description="Path to avatar image relative to repo root (e.g. 'assets/icons/your-feed.png'). "
+        description="Path to avatar image relative to repo root "
+        "(e.g. 'assets/icons/your-feed.png'). "
         "Used by publish_feed.py at publish time; not read at runtime.",
     )

--- a/src/app/models_feed_transparency.py
+++ b/src/app/models_feed_transparency.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # GET /api/feeds
@@ -17,7 +17,7 @@ class FeedSummary(BaseModel):
     feed_name: str
     api_release_sha: str | None = None
     applied_social_radius: int | None = None
-    generator_diagnostics: list["GeneratorDiagnosticView"] = Field(default_factory=list)
+    generator_diagnostics: list[GeneratorDiagnosticView] = Field(default_factory=list)
 
 
 class FeedListResponse(BaseModel):
@@ -107,14 +107,34 @@ class FeedDetailResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# GET / PUT /api/feeds/preferences
+# GET /api/feeds/preferences and PATCH /api/feeds/preferences/{feed_name}
 # ---------------------------------------------------------------------------
 
 
-class Preferences(BaseModel):
+class SourceWeights(BaseModel):
     model_config = {"extra": "forbid"}
 
-    social_radius: int = Field(default=3, ge=0, le=4)
-    freshness: int = Field(default=5, ge=0, le=5)
-    politics: float = Field(default=1.0, ge=0.5, le=1.5)
-    purpose: float = Field(default=0.5, ge=0.2, le=0.8)
+    following: float = Field(ge=0.0, le=1.0)
+    network_likes: float = Field(default=0.0, ge=0.0, le=1.0)
+    authors_topics: float = Field(ge=0.0, le=1.0)
+    popular: float = Field(ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def weights_sum_to_one(self) -> SourceWeights:
+        total = self.following + self.network_likes + self.authors_topics + self.popular
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError("source weights must sum to 1.0")
+        return self
+
+
+class FeedPreferences(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    source_weights: SourceWeights | None = None
+    freshness: int | None = Field(default=None, ge=0, le=5)
+    politics: float | None = Field(default=None, ge=0.5, le=1.5)
+    purpose: float | None = Field(default=None, ge=0.2, le=0.8)
+
+
+class PreferencesResponse(BaseModel):
+    feeds: dict[str, FeedPreferences]

--- a/src/app/routers/feed_transparency.py
+++ b/src/app/routers/feed_transparency.py
@@ -13,13 +13,15 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, HTTPException, Request, status
 from google.cloud.firestore import AsyncClient
 
-from ..documents import FeedSnapshotDocument, PipelineItemMeta
+from ..documents import FeedPreferencesDocument, FeedSnapshotDocument, PipelineItemMeta
+from ..feeds import FEEDS, canonical_feed_name
+from ..lib.feed_preferences import resolve_feed_preferences
 from ..lib.firebase_auth import FirebaseUser
 from ..lib.firestore import (
     get_feed_snapshot,
     get_recent_feed_snapshots,
     get_user,
-    set_user_preferences,
+    patch_user_feed_preferences,
 )
 from ..lib.post_hydration import hydrate_posts
 from ..models_feed_transparency import (
@@ -29,20 +31,21 @@ from ..models_feed_transparency import (
     FeedDetailResponse,
     FeedItemView,
     FeedListResponse,
+    FeedPreferences,
     FeedSummary,
-    GeneratorView,
     GeneratorDiagnosticView,
+    GeneratorView,
     MediaView,
     ModelScoreView,
-    Preferences,
+    PreferencesResponse,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["feed-transparency"], prefix="/api/feeds")
 
-CACHE_WINDOW_MINUTES = 15
-DEFAULT_LIST_LIMIT = 20
+CACHE_WINDOW_HOURS = 24
+DEFAULT_LIST_LIMIT = 100
 PUBLIC_MODERATION_LABELS = frozenset(
     {
         "porn",
@@ -163,23 +166,23 @@ async def list_feeds(
 ) -> FeedListResponse:
     """Return recent feed snapshots within the cache window."""
     db: AsyncClient = request.app.state.firestore
-    cutoff = datetime.now(UTC) - timedelta(minutes=CACHE_WINDOW_MINUTES)
+    cutoff = datetime.now(UTC) - timedelta(hours=CACHE_WINDOW_HOURS)
 
-    # Every feed the user loaded, not one hardcoded name: each summary carries
-    # its own feed_name, so which of them to surface is the client's call.
-    # Dropping the filter also drops the (feed_name, generated_at) composite
-    # index this query used to need.
-    docs = await get_recent_feed_snapshots(
-        db, user_doc_id, cutoff=cutoff, limit=DEFAULT_LIST_LIMIT
-    )
+    # Query all recent loads without a feed-name index, then expose only the
+    # configured public pages below. In-memory canonicalization also keeps
+    # legacy snapshots written with a stage/internal published rkey visible.
+    docs = await get_recent_feed_snapshots(db, user_doc_id, cutoff=cutoff, limit=DEFAULT_LIST_LIMIT)
 
     summaries: list[FeedSummary] = []
     seen_snapshots: set[tuple[str, tuple[str, ...]]] = set()
     for doc in docs:
+        resolved_feed_name = canonical_feed_name(doc.feed_name)
+        if resolved_feed_name is None or not FEEDS[resolved_feed_name].public:
+            continue
         # Treat the complete ordered post sequence as the snapshot identity.
         # Documents are newest-first, so skipping a repeated key retains the
         # newest load while preserving snapshots with different posts or order.
-        snapshot_key = (doc.feed_name, tuple(doc.items))
+        snapshot_key = (resolved_feed_name, tuple(doc.items))
         if snapshot_key in seen_snapshots:
             continue
         seen_snapshots.add(snapshot_key)
@@ -188,7 +191,7 @@ async def list_feeds(
             FeedSummary(
                 request_id=doc.request_id,
                 generated_at=doc.generated_at,
-                feed_name=doc.feed_name,
+                feed_name=resolved_feed_name,
                 api_release_sha=doc.api_release_sha,
                 applied_social_radius=doc.applied_social_radius,
                 generator_diagnostics=[
@@ -202,45 +205,77 @@ async def list_feeds(
 
 
 # ---------------------------------------------------------------------------
-# GET / PUT /api/feeds/preferences  (must precede /{request_id})
+# GET/PATCH /api/feeds/preferences  (must precede /{request_id})
 # ---------------------------------------------------------------------------
 
 
-@router.get("/preferences", response_model=Preferences)
+@router.get(
+    "/preferences",
+    response_model=PreferencesResponse,
+    response_model_exclude_none=True,
+)
 async def get_preferences(
     request: Request,
     user_doc_id: FirebaseUser,
-) -> Preferences:
-    """Return the current preferences for the authenticated user."""
+) -> PreferencesResponse:
+    """Return configured controls and values for every public feed."""
     db: AsyncClient = request.app.state.firestore
     user_doc = await get_user(db, f"did:plc:{user_doc_id}")
-    if user_doc is None:
-        return Preferences()
-    return Preferences(
-        social_radius=user_doc.social_radius,
-        freshness=user_doc.freshness,
-        politics=user_doc.politics,
-        purpose=user_doc.purpose,
+    return PreferencesResponse(
+        feeds={
+            feed_name: FeedPreferences.model_validate(
+                resolve_feed_preferences(user_doc, feed_name).model_dump(exclude_none=True)
+            )
+            for feed_name, feed in FEEDS.items()
+            if feed.public and feed.controls
+        }
     )
 
 
-@router.put("/preferences", response_model=Preferences)
-async def put_preferences(
+@router.patch(
+    "/preferences/{feed_name}",
+    response_model=FeedPreferences,
+    response_model_exclude_none=True,
+)
+async def patch_preferences(
     request: Request,
-    body: Preferences,
+    feed_name: str,
+    body: FeedPreferences,
     user_doc_id: FirebaseUser,
-) -> Preferences:
-    """Update the preferences for the authenticated user."""
+) -> FeedPreferences:
+    """Update only the supplied controls for one configured public feed."""
+    feed = FEEDS.get(feed_name)
+    if feed is None or not feed.public or not feed.controls:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown feed")
+
+    supplied = body.model_fields_set
+    if not supplied:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one control is required",
+        )
+    if any(getattr(body, control) is None for control in supplied):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Control values cannot be null",
+        )
+    unsupported = supplied.difference(feed.controls)
+    if unsupported:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported controls for {feed_name}: {', '.join(sorted(unsupported))}",
+        )
+
     db: AsyncClient = request.app.state.firestore
-    await set_user_preferences(
+    user_did = f"did:plc:{user_doc_id}"
+    patch = FeedPreferencesDocument.model_validate(body.model_dump(exclude_none=True))
+    updated = await patch_user_feed_preferences(
         db,
-        f"did:plc:{user_doc_id}",
-        social_radius=body.social_radius,
-        freshness=body.freshness,
-        politics=body.politics,
-        purpose=body.purpose,
+        user_did,
+        feed_name,
+        patch,
     )
-    return body
+    return FeedPreferences.model_validate(updated.model_dump(exclude_none=True))
 
 
 @router.get("/{request_id}", response_model=FeedDetailResponse)

--- a/src/app/routers/feed_transparency_test.py
+++ b/src/app/routers/feed_transparency_test.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from ..main import app
 from ..documents import (
     DiversificationMeta,
     FeedSnapshotDocument,
@@ -17,6 +16,7 @@ from ..documents import (
     ModelScoreMeta,
     PipelineItemMeta,
 )
+from ..main import app
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -51,7 +51,7 @@ def _snapshot_doc(
     diversify: bool = True,
     **overrides,
 ) -> FeedSnapshotDocument:
-    now = generated_at or datetime(2026, 7, 12, 15, 30, tzinfo=timezone.utc)
+    now = generated_at or datetime(2026, 7, 12, 15, 30, tzinfo=UTC)
     meta = items_meta or [
         PipelineItemMeta(
             at_uri="at://did:plc:author/app.bsky.feed.post/post1",
@@ -93,15 +93,19 @@ def test_list_feeds_returns_summaries(mock_query, client):
         _snapshot_doc(
             request_id="req-1",
             api_release_sha="api-sha-1",
-            generated_at=datetime.now(timezone.utc),
+            generated_at=datetime.now(UTC),
             items=["at://a"],
-            items_meta=[PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)],
+            items_meta=[
+                PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)
+            ],
         ),
         _snapshot_doc(
             request_id="req-2",
-            generated_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+            generated_at=datetime.now(UTC) - timedelta(minutes=5),
             items=["at://b"],
-            items_meta=[PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)],
+            items_meta=[
+                PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)
+            ],
         ),
     ]
 
@@ -115,16 +119,27 @@ def test_list_feeds_returns_summaries(mock_query, client):
 
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
-def test_list_feeds_covers_every_feed_not_one_hardcoded_name(mock_query, client):
-    """Snapshots are returned whatever feed produced them.
+def test_list_feeds_queries_last_24_hours_with_100_document_limit(mock_query, client):
+    mock_query.return_value = []
+    earliest_cutoff = datetime.now(UTC) - timedelta(hours=24)
 
-    Each summary carries its own feed_name, so choosing which to surface is the
-    client's call. Filtering server-side would also reintroduce the
-    (feed_name, generated_at) composite index this query no longer needs.
-    """
-    now = datetime.now(timezone.utc)
+    response = client.get("/api/feeds")
+
+    latest_cutoff = datetime.now(UTC) - timedelta(hours=24)
+    assert response.status_code == 200
+    assert mock_query.await_args is not None
+    assert earliest_cutoff <= mock_query.await_args.kwargs["cutoff"] <= latest_cutoff
+    assert mock_query.await_args.kwargs["limit"] == 100
+
+
+@patch("app.routers.feed_transparency.get_recent_feed_snapshots")
+def test_list_feeds_returns_public_feeds_without_a_query_filter(mock_query, client):
+    """The broad query is filtered to the public observability pages in memory."""
+    now = datetime.now(UTC)
     mock_query.return_value = [
-        _snapshot_doc(request_id="req-1", generated_at=now, items=["at://a"], feed_name="your-feed"),
+        _snapshot_doc(
+            request_id="req-1", generated_at=now, items=["at://a"], feed_name="your-feed"
+        ),
         _snapshot_doc(
             request_id="req-2",
             generated_at=now - timedelta(minutes=1),
@@ -136,9 +151,38 @@ def test_list_feeds_covers_every_feed_not_one_hardcoded_name(mock_query, client)
     response = client.get("/api/feeds")
 
     assert response.status_code == 200
-    assert [f["feed_name"] for f in response.json()["feeds"]] == ["your-feed", "popularity"]
+    assert [f["feed_name"] for f in response.json()["feeds"]] == ["your-feed"]
     # No feed_name filter reaches the query.
     assert "feed_name" not in mock_query.call_args.kwargs
+
+
+@patch("app.routers.feed_transparency.get_recent_feed_snapshots")
+def test_list_feeds_maps_published_rkeys_to_public_feed_pages(mock_query, client):
+    now = datetime.now(UTC)
+    mock_query.return_value = [
+        _snapshot_doc(request_id="req-1", generated_at=now, items=["at://a"], feed_name="a0-yf"),
+        _snapshot_doc(
+            request_id="req-2",
+            generated_at=now - timedelta(minutes=1),
+            items=["at://b"],
+            feed_name="fd-bof",
+        ),
+        _snapshot_doc(
+            request_id="req-3",
+            generated_at=now - timedelta(minutes=2),
+            items=["at://c"],
+            feed_name="67-r",
+        ),
+    ]
+
+    response = client.get("/api/feeds")
+
+    assert response.status_code == 200
+    assert [f["feed_name"] for f in response.json()["feeds"]] == [
+        "your-feed",
+        "best-of-friends",
+        "random",
+    ]
 
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
@@ -164,7 +208,7 @@ def test_list_feeds_returns_401_without_auth():
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_collapses_identical_snapshots_and_keeps_newest(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newer = _snapshot_doc(
         request_id="req-1",
         generated_at=now,
@@ -192,7 +236,7 @@ def test_list_feeds_collapses_identical_snapshots_and_keeps_newest(mock_query, c
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_same_posts_in_different_order(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     mock_query.return_value = [
         _snapshot_doc(
             request_id="req-1",
@@ -216,7 +260,7 @@ def test_list_feeds_preserves_same_posts_in_different_order(mock_query, client):
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_identical_posts_from_different_feeds(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     mock_query.return_value = [
         _snapshot_doc(
             request_id="req-1",
@@ -242,21 +286,30 @@ def test_list_feeds_preserves_identical_posts_from_different_feeds(mock_query, c
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_newest_first_order(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newest = _snapshot_doc(
-        request_id="req-3", generated_at=now,
+        request_id="req-3",
+        generated_at=now,
         items=["at://c"],
-        items_meta=[PipelineItemMeta(at_uri="at://c", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://c", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     middle = _snapshot_doc(
-        request_id="req-2", generated_at=now - timedelta(minutes=3),
+        request_id="req-2",
+        generated_at=now - timedelta(minutes=3),
         items=["at://b"],
-        items_meta=[PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://b", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     oldest = _snapshot_doc(
-        request_id="req-1", generated_at=now - timedelta(minutes=6),
+        request_id="req-1",
+        generated_at=now - timedelta(minutes=6),
         items=["at://a"],
-        items_meta=[PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     mock_query.return_value = [newest, middle, oldest]
 
@@ -270,9 +323,10 @@ def test_list_feeds_newest_first_order(mock_query, client):
 
 @patch("app.routers.feed_transparency.get_recent_feed_snapshots")
 def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, client):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     newest = _snapshot_doc(
-        request_id="req-3", generated_at=now,
+        request_id="req-3",
+        generated_at=now,
         items=["at://a", "at://b", "at://c"],
         items_meta=[
             PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1),
@@ -281,7 +335,8 @@ def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, clie
         ],
     )
     middle = _snapshot_doc(
-        request_id="req-2", generated_at=now - timedelta(minutes=3),
+        request_id="req-2",
+        generated_at=now - timedelta(minutes=3),
         items=["at://a", "at://b"],
         items_meta=[
             PipelineItemMeta(at_uri="at://a", rank=1, rank_score=1.0, after_rank_position=1),
@@ -289,9 +344,12 @@ def test_list_feeds_preserves_fully_overlapping_middle_snapshot(mock_query, clie
         ],
     )
     oldest = _snapshot_doc(
-        request_id="req-1", generated_at=now - timedelta(minutes=6),
+        request_id="req-1",
+        generated_at=now - timedelta(minutes=6),
         items=["at://d"],
-        items_meta=[PipelineItemMeta(at_uri="at://d", rank=1, rank_score=1.0, after_rank_position=1)],
+        items_meta=[
+            PipelineItemMeta(at_uri="at://d", rank=1, rank_score=1.0, after_rank_position=1)
+        ],
     )
     mock_query.return_value = [newest, middle, oldest]
 
@@ -322,7 +380,7 @@ def test_get_feed_detail_returns_merged_data(mock_get_snapshot, mock_hydrate, cl
                 "avatar_url": "https://cdn.bsky.app/avatar.jpg",
             },
             "content": "Hello world",
-            "created_at": datetime(2026, 7, 12, 10, 0, tzinfo=timezone.utc),
+            "created_at": datetime(2026, 7, 12, 10, 0, tzinfo=UTC),
             "media": {
                 "image_urls": [],
                 "video_url": None,
@@ -515,7 +573,7 @@ def test_get_feed_detail_multiple_items(mock_get_snapshot, mock_hydrate, client)
 
 
 # ---------------------------------------------------------------------------
-# GET / PUT /api/feeds/preferences
+# GET /api/feeds/preferences and PATCH /api/feeds/preferences/{feed_name}
 # ---------------------------------------------------------------------------
 
 
@@ -530,11 +588,22 @@ def test_get_preferences_returns_default_for_new_user(mock_get_user, client):
 
     response = client.get("/api/feeds/preferences")
     assert response.status_code == 200
-    data = response.json()
-    assert data["social_radius"] == 3  # default
-    assert data["freshness"] == 5  # seven-day default
-    assert data["politics"] == 1.0  # default
-    assert data["purpose"] == 0.5  # default
+    assert response.json() == {
+        "feeds": {
+            "random": {"freshness": 5},
+            "your-feed": {
+                "source_weights": {
+                    "following": 0.3,
+                    "network_likes": 0.2,
+                    "authors_topics": 0.25,
+                    "popular": 0.25,
+                },
+                "freshness": 5,
+                "purpose": 0.5,
+            },
+            "best-of-friends": {"freshness": 5, "purpose": 0.5},
+        }
+    }
 
 
 @patch("app.routers.feed_transparency.get_user")
@@ -552,77 +621,127 @@ def test_get_preferences_returns_stored_value(mock_get_user, client):
 
     response = client.get("/api/feeds/preferences")
     assert response.status_code == 200
-    data = response.json()
-    assert data["social_radius"] == 0
-    assert data["freshness"] == 3
-    assert data["politics"] == 1.25
-    assert data["purpose"] == 0.65
-
-
-@patch("app.routers.feed_transparency.set_user_preferences")
-def test_put_preferences_updates_value(mock_set_prefs, client):
-    response = client.put(
-        "/api/feeds/preferences",
-        json={
-            "social_radius": 3,
-            "freshness": 4,
-            "politics": 1.5,
-            "purpose": 0.8,
+    assert response.json()["feeds"] == {
+        "random": {"freshness": 3},
+        "your-feed": {
+            "source_weights": {
+                "following": 1.0,
+                "network_likes": 0.0,
+                "authors_topics": 0.0,
+                "popular": 0.0,
+            },
+            "freshness": 3,
+            "purpose": 0.65,
         },
+        "best-of-friends": {"freshness": 3, "purpose": 0.65},
+    }
+
+
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_updates_only_selected_feed(mock_patch_prefs, client):
+    from ..documents import FeedPreferencesDocument
+
+    mock_patch_prefs.return_value = FeedPreferencesDocument(
+        freshness=4,
+        purpose=0.65,
+    )
+    response = client.patch(
+        "/api/feeds/preferences/best-of-friends",
+        json={"freshness": 4},
     )
     assert response.status_code == 200
-    data = response.json()
-    assert data["social_radius"] == 3
-    assert data["freshness"] == 4
-    assert data["politics"] == 1.5
-    assert data["purpose"] == 0.8
-    mock_set_prefs.assert_awaited_once()
+    assert response.json() == {"freshness": 4, "purpose": 0.65}
+    args = mock_patch_prefs.await_args.args
+    assert args[1:3] == ("did:plc:test-user", "best-of-friends")
+    assert args[3].model_dump(exclude_none=True) == {"freshness": 4}
 
 
-@patch("app.routers.feed_transparency.set_user_preferences")
-def test_put_preferences_rejects_out_of_range(mock_set_prefs, client):
-    response = client.put(
-        "/api/feeds/preferences",
-        json={
-            "social_radius": 10,
-            "freshness": 2,
-            "politics": 1.0,
-            "purpose": 0.5,
-        },
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_rejects_out_of_range(mock_patch_prefs, client):
+    response = client.patch(
+        "/api/feeds/preferences/random",
+        json={"freshness": 10},
     )
     assert response.status_code == 422
+    mock_patch_prefs.assert_not_awaited()
 
 
-@patch("app.routers.feed_transparency.set_user_preferences")
-def test_put_preferences_rejects_camel_case_body(mock_set_prefs, client):
-    response = client.put(
-        "/api/feeds/preferences",
-        json={
-            "socialRadius": 3,
-            "freshness": 2,
-            "politics": 1.0,
-            "purpose": 0.5,
+@pytest.mark.parametrize(
+    "weight_values",
+    [
+        {
+            "following": 0.3,
+            "network_likes": 0.2,
+            "authors_topics": 0.25,
+            "popular": 0.25,
         },
+        {"following": 1.0, "network_likes": 0.0, "authors_topics": 0.0, "popular": 0.0},
+        {"following": 0.0, "network_likes": 0.0, "authors_topics": 1.0, "popular": 0.0},
+        {"following": 0.0, "network_likes": 0.0, "authors_topics": 0.0, "popular": 1.0},
+    ],
+)
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_accepts_atomic_source_weights(mock_patch_prefs, weight_values, client):
+    from ..documents import FeedPreferencesDocument, SourceWeightsDocument
+
+    weights = SourceWeightsDocument(**weight_values)
+    mock_patch_prefs.return_value = FeedPreferencesDocument(source_weights=weights)
+
+    response = client.patch(
+        "/api/feeds/preferences/your-feed",
+        json={"source_weights": weights.model_dump()},
     )
 
-    assert response.status_code == 422
-    mock_set_prefs.assert_not_awaited()
-
-
-@patch("app.routers.feed_transparency.set_user_preferences")
-def test_put_preferences_creates_user_doc_if_missing(mock_set_prefs, client):
-    response = client.put(
-        "/api/feeds/preferences",
-        json={
-            "social_radius": 1,
-            "freshness": 2,
-            "politics": 1.0,
-            "purpose": 0.5,
-        },
-    )
     assert response.status_code == 200
-    assert response.json()["social_radius"] == 1
-    mock_set_prefs.assert_awaited_once()
+    assert response.json() == {"source_weights": weights.model_dump()}
+    assert mock_patch_prefs.await_args.args[3].source_weights == weights
+
+
+@pytest.mark.parametrize(
+    "weights",
+    [
+        {"following": 0.5, "authors_topics": 0.2},
+        {"following": 0.5, "authors_topics": 0.2, "popular": 0.2},
+        {"following": -0.1, "authors_topics": 0.4, "popular": 0.7},
+        {"following": 0.0, "authors_topics": 1.1, "popular": -0.1},
+    ],
+)
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_rejects_invalid_source_weights(mock_patch_prefs, weights, client):
+    response = client.patch(
+        "/api/feeds/preferences/your-feed",
+        json={"source_weights": weights},
+    )
+    assert response.status_code == 422
+    mock_patch_prefs.assert_not_awaited()
+
+
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_rejects_unsupported_control(mock_patch_prefs, client):
+    response = client.patch(
+        "/api/feeds/preferences/random",
+        json={"purpose": 0.8},
+    )
+    assert response.status_code == 422
+    mock_patch_prefs.assert_not_awaited()
+
+
+@pytest.mark.parametrize("body", [{}, {"freshness": None}, {"socialRadius": 3}])
+@patch("app.routers.feed_transparency.patch_user_feed_preferences")
+def test_patch_preferences_rejects_invalid_body(mock_patch_prefs, body, client):
+    response = client.patch(
+        "/api/feeds/preferences/your-feed",
+        json=body,
+    )
+    assert response.status_code == 422
+    mock_patch_prefs.assert_not_awaited()
+
+
+def test_patch_preferences_rejects_unknown_or_internal_feed(client):
+    assert client.patch("/api/feeds/preferences/nope", json={"freshness": 2}).status_code == 404
+    assert (
+        client.patch("/api/feeds/preferences/cold-start", json={"freshness": 2}).status_code == 404
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -679,12 +798,18 @@ def test_get_feed_detail_preserves_items_seen_in_newer_snapshots(
     doc = _snapshot_doc(
         items_meta=[
             PipelineItemMeta(
-                at_uri=uri1, rank=1, rank_score=0.92, after_rank_position=1,
+                at_uri=uri1,
+                rank=1,
+                rank_score=0.92,
+                after_rank_position=1,
                 generators=[GeneratorMeta(name="two_tower", score=0.85)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.92)],
             ),
             PipelineItemMeta(
-                at_uri=uri2, rank=2, rank_score=0.88, after_rank_position=2,
+                at_uri=uri2,
+                rank=2,
+                rank_score=0.88,
+                after_rank_position=2,
                 generators=[GeneratorMeta(name="popularity", score=0.80)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.88)],
             ),
@@ -758,12 +883,8 @@ def test_get_feed_detail_filters_public_post_and_author_labels(
         **_hydrated(labeled_author, "author.bsky.social"),
     }
     hydrated[safe]["moderation"] = {"post_labels": [], "author_labels": []}
-    hydrated[labeled_post]["moderation"] = {
-        "post_labels": ["graphic-media"], "author_labels": []
-    }
-    hydrated[labeled_author]["moderation"] = {
-        "post_labels": [], "author_labels": ["porn"]
-    }
+    hydrated[labeled_post]["moderation"] = {"post_labels": ["graphic-media"], "author_labels": []}
+    hydrated[labeled_author]["moderation"] = {"post_labels": [], "author_labels": ["porn"]}
     mock_hydrate.return_value = hydrated
 
     response = client.get("/api/feeds/req-abc")
@@ -787,12 +908,18 @@ def test_get_feed_detail_returns_all_when_no_newer_snapshots(
     doc = _snapshot_doc(
         items_meta=[
             PipelineItemMeta(
-                at_uri=uri1, rank=1, rank_score=0.92, after_rank_position=1,
+                at_uri=uri1,
+                rank=1,
+                rank_score=0.92,
+                after_rank_position=1,
                 generators=[GeneratorMeta(name="two_tower", score=0.85)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.92)],
             ),
             PipelineItemMeta(
-                at_uri=uri2, rank=2, rank_score=0.88, after_rank_position=2,
+                at_uri=uri2,
+                rank=2,
+                rank_score=0.88,
+                after_rank_position=2,
                 generators=[GeneratorMeta(name="popularity", score=0.80)],
                 model_scores=[ModelScoreMeta(name="heavy_ranker", weight=1.0, score=0.88)],
             ),
@@ -816,9 +943,7 @@ def test_get_feed_detail_returns_all_when_no_newer_snapshots(
 
 @patch("app.routers.feed_transparency.hydrate_posts")
 @patch("app.routers.feed_transparency.get_feed_snapshot")
-def test_get_feed_detail_diverse_pipeline_metadata(
-    mock_get_snapshot, mock_hydrate, client
-):
+def test_get_feed_detail_diverse_pipeline_metadata(mock_get_snapshot, mock_hydrate, client):
     uri = "at://did:plc:author/app.bsky.feed.post/post1"
     doc = _snapshot_doc(
         items_meta=[

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -23,7 +23,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from concurrent.futures import Future
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import wraps
 from threading import Lock
 from typing import NamedTuple
@@ -37,12 +37,14 @@ from ..documents import (
     FeedSnapshotDocument,
     InteractionDocument,
     PipelineItemMeta,
+    SourceWeightsDocument,
 )
 from ..feeds import (
     DEFAULT_SOCIAL_RADIUS,
     FEEDS,
     SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
-    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+    SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,  # noqa: F401 - compatibility export
+    canonical_feed_name,
 )
 from ..lib.atproto_auth import verify_auth_header
 from ..lib.candidates import run_generate
@@ -53,6 +55,7 @@ from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import DEFAULT_TTL_SECONDS, FeedCache
 from ..lib.feed_context import FeedContextPayload, decode_feed_context, encode_feed_context
 from ..lib.feed_debug import FeedDebugRecorder, current_recorder, feed_debug_scope
+from ..lib.feed_preferences import configured_controls, control_value
 from ..lib.firestore import (
     FEED_DEBUG_RETENTION_DAYS,
     delete_feed_snapshot,
@@ -89,7 +92,13 @@ from ..lib.release import api_release_sha
 from ..lib.request_cache import request_cache_scope
 from ..lib.request_context import set_traffic
 from ..lib.telemetry import timed
-from ..models import CandidateGenerateRequest, CandidatePost, FeedConfig, FeedCursor
+from ..models import (
+    CandidateGenerateRequest,
+    CandidatePost,
+    FeedConfig,
+    FeedCursor,
+    GeneratorSpec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +109,7 @@ router = APIRouter(tags=["xrpc"])
 # Configuration
 # ---------------------------------------------------------------------------
 
-FEED_SNAPSHOT_RETENTION_SECONDS = 900  # 15 minutes
+FEED_SNAPSHOT_RETENTION_SECONDS = 24 * 60 * 60  # 24 hours
 INITIAL_REQUEST_REUSE_SECONDS = 5
 
 try:
@@ -430,11 +439,13 @@ async def _hydrate_embeddings(es, candidates: list[CandidatePost]) -> list[Candi
         logger.exception("Embedding hydration failed; continuing without")
         ctx = current_pipeline_context()
         if ctx is not None:
-            ctx.record(DegradationEvent(
-                stage=DegradationStage.EMBED_HYDRATION,
-                component="fetch_post_embeddings",
-                cause=exc,
-            ))
+            ctx.record(
+                DegradationEvent(
+                    stage=DegradationStage.EMBED_HYDRATION,
+                    component="fetch_post_embeddings",
+                    cause=exc,
+                )
+            )
         return candidates
 
     encoded: dict[str, str] = {}
@@ -476,9 +487,7 @@ def _record_cutoff(feed_name: str, reason: str, uris: list[str]) -> None:
         return
     collector = get_metric_collector()
     if collector:
-        collector.record(
-            "feed.slate.cutoff_count", len(uris), feed_name=feed_name, reason=reason
-        )
+        collector.record("feed.slate.cutoff_count", len(uris), feed_name=feed_name, reason=reason)
     rec = current_recorder()
     if rec is not None:
         rec.record_cutoff(reason, uris)
@@ -582,12 +591,15 @@ async def _run_ranking_pipeline(
                 logger.exception("Ranking stage failed; falling back to unranked ordering")
                 if ctx is not None:
                     component = getattr(exc, "name", type(exc).__name__)
-                    ctx.record(DegradationEvent(
-                        stage=DegradationStage.RANK,
-                        component=component,
-                        cause=exc,
-                    ))
-                    # ctx.record re-raises exc when fail_fast=True, so reaching here means fail_fast=False
+                    ctx.record(
+                        DegradationEvent(
+                            stage=DegradationStage.RANK,
+                            component=component,
+                            cause=exc,
+                        )
+                    )
+                    # ctx.record re-raises when fail_fast=True, so this is the
+                    # fail-open path.
                     ordered = sorted(candidates, key=lambda c: c.score or 0.0, reverse=True)
                 else:
                     raise
@@ -602,11 +614,7 @@ async def _run_ranking_pipeline(
             # ordered is sorted desc by the combined score, so everything from
             # the first sub-floor candidate on is below the floor.
             cut_idx = next(
-                (
-                    i
-                    for i, c in enumerate(ordered)
-                    if (c.score or 0.0) < feed_cfg.min_rank_score
-                ),
+                (i for i, c in enumerate(ordered) if (c.score or 0.0) < feed_cfg.min_rank_score),
                 len(ordered),
             )
             low_score_uris = [c.at_uri for c in ordered[cut_idx:] if c.at_uri]
@@ -637,9 +645,7 @@ async def _run_ranking_pipeline(
         if feed_cfg.max_render_share is not None:
             max_keep = max(1, math.floor(feed_cfg.max_render_share * n_retrieved))
             if len(final) > max_keep:
-                _record_cutoff(
-                    feed_name, "share", [c.at_uri for c in final[max_keep:] if c.at_uri]
-                )
+                _record_cutoff(feed_name, "share", [c.at_uri for c in final[max_keep:] if c.at_uri])
                 final = final[:max_keep]
 
         final_uris = [c.at_uri for c in final if c.at_uri]
@@ -654,9 +660,7 @@ async def _run_ranking_pipeline(
         if not final_uris and pre_cut_uris:
             # The quality gates rejected everything we retrieved.
             if collector:
-                collector.record(
-                    "feed.slate.empty_after_cutoff_count", 1, feed_name=feed_name
-                )
+                collector.record("feed.slate.empty_after_cutoff_count", 1, feed_name=feed_name)
             if EMPTY_SLATE_FAIL_OPEN:
                 logger.warning(
                     "Slate cutoffs emptied feed '%s' (%d candidates retrieved); failing open",
@@ -675,7 +679,62 @@ async def _run_ranking_pipeline(
             if collector is not None:
                 collector.record("feed.render.degraded_count", 1, feed_name=ctx.feed_name)
 
-        return PipelineResult(final_uris, low_score_uris)
+    return PipelineResult(final_uris, low_score_uris)
+
+
+def _with_purpose_weights(feed_cfg: FeedConfig, purpose: float) -> FeedConfig:
+    """Return a request-local feed config with the user's purpose weights.
+
+    Purpose is the constructive share of the combined rank score. Engaging
+    rankers receive the complementary share. Feed templates are module-level
+    shared objects, so both model copies are required to keep user preferences
+    isolated between requests.
+    """
+    rank_template = feed_cfg.rank_request_template
+    if rank_template is None:
+        return feed_cfg
+
+    engaging_names = {"heavy_ranker", "heavy_ranker_empty_history"}
+    updated = False
+    models = []
+    for model in rank_template.models:
+        if model.name in engaging_names:
+            models.append(model.model_copy(update={"weight": 1.0 - purpose}))
+            updated = True
+        elif model.name == "perspective":
+            models.append(model.model_copy(update={"weight": purpose}))
+            updated = True
+        else:
+            models.append(model)
+
+    if not updated:
+        return feed_cfg
+    return feed_cfg.model_copy(
+        update={"rank_request_template": rank_template.model_copy(update={"models": models})}
+    )
+
+
+def _source_generators(
+    weights: SourceWeightsDocument,
+    *,
+    include_network_likes: bool,
+    fallback_radius: int,
+) -> list[GeneratorSpec]:
+    """Build a request-local candidate mix from an atomic source preference."""
+    configured = [
+        ("followed_users", weights.following),
+        ("two_tower", weights.authors_topics),
+        ("popularity", weights.popular),
+    ]
+    if include_network_likes:
+        configured.append(("network_likes", weights.network_likes))
+    else:
+        total = sum(weight for _, weight in configured)
+        if total <= 0:
+            return SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[fallback_radius]
+        configured = [(name, weight / total) for name, weight in configured]
+
+    return [GeneratorSpec(name=name, weight=weight) for name, weight in configured if weight > 0]
 
 
 async def _run_pipeline_capturing(
@@ -709,7 +768,7 @@ async def _run_pipeline_capturing(
     for now; PostHog per-user flag (issue 279) will pass it in when implemented.
     """
     recorder = FeedDebugRecorder(feed_name=feed_name, regenerated=regenerated)
-    generated_at = datetime.now(timezone.utc)
+    generated_at = datetime.now(UTC)
     ctx = PipelineContext(feed_name=feed_name)
 
     with feed_debug_scope(recorder), pipeline_context_scope(ctx):
@@ -790,10 +849,7 @@ def _snapshot_page(
 ) -> FeedSnapshotDocument:
     """Restrict pipeline metadata to posts actually returned in one page."""
     meta_by_uri = {meta.at_uri: meta for meta in snapshot.items_meta}
-    items_meta = [
-        meta_by_uri.get(uri, PipelineItemMeta(at_uri=uri))
-        for uri in uris
-    ]
+    items_meta = [meta_by_uri.get(uri, PipelineItemMeta(at_uri=uri)) for uri in uris]
     diagnostics = [
         diagnostic.model_copy(
             update={
@@ -869,9 +925,7 @@ def _record_similarity_metric(
     carry a score, since it wasn't organically selected by MMR.
     """
     scores = [
-        scores_by_uri[uri]
-        for uri in page_uris
-        if uri in scores_by_uri and uri != exclude_uri
+        scores_by_uri[uri] for uri in page_uris if uri in scores_by_uri and uri != exclude_uri
     ]
     if not scores:
         return
@@ -1007,7 +1061,7 @@ async def _record_session(
         )
         username = None
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     try:
         await upsert_user(db, user_did, username, is_load_test=is_load_test)
@@ -1050,7 +1104,7 @@ async def _resolve_handles(request: Request, dids: set[str]) -> dict[str, str]:
             return None
 
     handles = await asyncio.gather(*(_one(did) for did in did_list))
-    return {did: handle for did, handle in zip(did_list, handles) if handle}
+    return {did: handle for did, handle in zip(did_list, handles, strict=True) if handle}
 
 
 async def _write_feed_snapshot_background(
@@ -1076,7 +1130,13 @@ async def _write_feed_snapshot_background(
     if not snapshot.items:
         return
     try:
-        truncated = await merge_feed_snapshot(db, user_did, request_id, snapshot)
+        truncated = await merge_feed_snapshot(
+            db,
+            user_did,
+            request_id,
+            snapshot,
+            enforce_document_cap=not load_test,
+        )
         if truncated:
             logger.warning(
                 "Feed snapshot reached item limit for user '%s', request '%s'",
@@ -1086,9 +1146,7 @@ async def _write_feed_snapshot_background(
             )
             collector = get_metric_collector()
             if collector is not None:
-                collector.record(
-                    "feed.snapshot.truncated_count", 1, feed_name=snapshot.feed_name
-                )
+                collector.record("feed.snapshot.truncated_count", 1, feed_name=snapshot.feed_name)
         if load_test:
             await delete_feed_snapshot(db, user_did, request_id)
     except Exception:
@@ -1130,7 +1188,7 @@ async def _write_feed_debug(
         logger.exception("Failed to write feed debug record for user '%s'", user_did)
 
 
-async def _record_interactions(db, interactions: list["Interaction"]) -> None:
+async def _record_interactions(db, interactions: list[Interaction]) -> None:
     """Verify each interaction's feedContext and persist the valid ones.
 
     The signed feedContext is the trust anchor: interactions with a missing or
@@ -1173,7 +1231,7 @@ async def _record_interactions(db, interactions: list["Interaction"]) -> None:
             event=event,
             feed_name=payload.feed,
             request_id=payload.rid,
-            feed_generated_at=datetime.fromtimestamp(payload.iat, tz=timezone.utc),
+            feed_generated_at=datetime.fromtimestamp(payload.iat, tz=UTC),
             load_test=payload.lt,
         )
         try:
@@ -1220,12 +1278,7 @@ def _feed_name_for_metrics(feed: object) -> str:
         return "unknown"
     if collection != "app.bsky.feed.generator":
         return "unknown"
-    if rkey in FEEDS:
-        return rkey
-    for name, config in FEEDS.items():
-        if config.internal_rkey == rkey:
-            return name
-    return "unknown"
+    return canonical_feed_name(rkey) or "unknown"
 
 
 def _record_feed_render_metrics(
@@ -1333,13 +1386,7 @@ async def get_feed_skeleton(
         collection = ""
 
     if collection == "app.bsky.feed.generator":
-        if rkey in FEEDS:
-            feed_name = rkey
-        else:
-            for key, cfg in FEEDS.items():
-                if cfg.internal_rkey == rkey:
-                    feed_name = key
-                    break
+        feed_name = canonical_feed_name(rkey)
 
     if feed_name is None:
         raise HTTPException(
@@ -1405,9 +1452,7 @@ async def get_feed_skeleton(
         logger.error("Firestore client not initialized")
         raise HTTPException(status_code=500, detail="Firestore unavailable")
 
-    _spawn_background(
-        _record_session(request, user_did, feed_name, db, is_load_test=is_load_test)
-    )
+    _spawn_background(_record_session(request, user_did, feed_name, db, is_load_test=is_load_test))
 
     uses_network_likes_flag = feed_name in (
         "your-feed",
@@ -1442,31 +1487,53 @@ async def get_feed_skeleton(
     except Exception:
         logger.exception("Failed to read debug flag for user '%s'", user_did)
 
-    # Social Radius only reallocates the fixed candidate batch among sources;
-    # it never increases the total candidate count or per-request batch cap.
-    # Apply its preference override to personalized-feed generator weights.
+    # Purpose controls the relative influence of the engaging and constructive
+    # rankers only for feeds that declare it. Apply it to a request-local copy;
+    # module-level FEEDS templates must remain immutable.
+    controls = configured_controls(feed_name)
+    if "purpose" in controls:
+        purpose = float(control_value(user_doc, feed_name, "purpose"))
+        feed_cfg = _with_purpose_weights(feed_cfg, purpose)
+
+    # Source weights only reallocate the fixed candidate batch among sources.
+    # GreenEarth's unranked and cutoff-preview variants share the public
+    # GreenEarth preference via preference_source; cold-start intentionally
+    # keeps its static popularity-only mix.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if uses_network_likes_flag:
-        if user_doc is not None:
-            applied_social_radius = user_doc.social_radius
-        else:
-            applied_social_radius = DEFAULT_SOCIAL_RADIUS
-        network_likes_in_your_feed = (
-            True
-            if posthog_client is None
-            else feature_flags.get(NETWORK_LIKES_FLAG, False)
+    if uses_network_likes_flag and "source_weights" in controls:
+        source_weights = control_value(user_doc, feed_name, "source_weights")
+        assert isinstance(source_weights, SourceWeightsDocument)
+        preference_key = FEEDS[feed_name].preference_source or feed_name
+        stored = user_doc.feed_preferences.get(preference_key) if user_doc is not None else None
+        has_custom_weights = stored is not None and stored.source_weights is not None
+        legacy_radius = (
+            stored.social_radius
+            if stored is not None and stored.social_radius is not None
+            else user_doc.social_radius
+            if user_doc is not None
+            else DEFAULT_SOCIAL_RADIUS
         )
-        if network_likes_in_your_feed:
-            social_radius_presets = SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES
+        if not has_custom_weights:
+            applied_social_radius = legacy_radius
+
+        include_network_likes = (
+            True if posthog_client is None else feature_flags.get(NETWORK_LIKES_FLAG, False)
+        )
+        if include_network_likes or has_custom_weights:
+            generators = _source_generators(
+                source_weights,
+                include_network_likes=include_network_likes,
+                fallback_radius=legacy_radius,
+            )
         else:
-            social_radius_presets = SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES
-        preset = social_radius_presets.get(applied_social_radius)
-        if preset is not None:
-            generators_override = {"generators": preset}
+            generators = SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES[legacy_radius]
+        generators_override = {"generators": generators}
 
     freshness_index = (
-        user_doc.freshness if user_doc is not None else DEFAULT_FRESHNESS_INDEX
+        int(control_value(user_doc, feed_name, "freshness"))
+        if "freshness" in controls
+        else DEFAULT_FRESHNESS_INDEX
     )
     max_age_hours = max_age_hours_for_freshness(freshness_index)
 
@@ -1484,12 +1551,22 @@ async def get_feed_skeleton(
         if cursor is not None:
             try:
                 parsed = FeedCursor.decode(cursor)
-            except ValueError:
-                raise HTTPException(status_code=400, detail="Invalid cursor")
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="Invalid cursor") from exc
 
             async with timed(logger, "feedcache_retrieve", cache_id=parsed.id):
                 cache_doc = await feed_cache.retrieve_document(parsed.id)
             if cache_doc is not None:
+                if cache_doc.user_did != user_did or cache_doc.feed_name != feed_name:
+                    logger.warning(
+                        "Rejected cursor outside its originating user/feed context",
+                        extra={
+                            "request_id": parsed.id,
+                            "feed_name": feed_name,
+                            "cached_feed_name": cache_doc.feed_name,
+                        },
+                    )
+                    raise HTTPException(status_code=400, detail="Invalid cursor")
                 cached_uris = cache_doc.items
                 if parsed.offset < len(cached_uris):
                     # Serve from the existing cached batch.
@@ -1513,7 +1590,7 @@ async def get_feed_skeleton(
                         request_id=parsed.id,
                         items=cached_uris,
                         feed_name=cache_doc.feed_name or feed_name,
-                        generated_at=cache_doc.generated_at or datetime.now(timezone.utc),
+                        generated_at=cache_doc.generated_at or datetime.now(UTC),
                         api_release_sha=cache_doc.api_release_sha,
                         expires_at=cache_doc.expires_at,
                         generator_diagnostics=cache_doc.generator_diagnostics,
@@ -1690,13 +1767,9 @@ async def get_feed_skeleton(
             # later pages would skip posts.
             next_cursor = None
             if cache_uris:
-                cache_meta_by_uri = {
-                    meta.at_uri: meta for meta in generated_snapshot.items_meta
-                }
+                cache_meta_by_uri = {meta.at_uri: meta for meta in generated_snapshot.items_meta}
                 cache_items_meta = [
-                    cache_meta_by_uri[uri]
-                    for uri in cache_uris
-                    if uri in cache_meta_by_uri
+                    cache_meta_by_uri[uri] for uri in cache_uris if uri in cache_meta_by_uri
                 ]
                 async with timed(logger, "feedcache_store", cache_id=request_id):
                     await feed_cache.store_document(
@@ -1706,11 +1779,11 @@ async def get_feed_skeleton(
                             items_meta=cache_items_meta,
                             generator_diagnostics=generated_snapshot.generator_diagnostics,
                             applied_social_radius=applied_social_radius,
+                            user_did=user_did,
                             feed_name=feed_name,
                             generated_at=generated_snapshot.generated_at,
                             api_release_sha=generated_snapshot.api_release_sha,
-                            expires_at=datetime.now(timezone.utc)
-                            + timedelta(seconds=DEFAULT_TTL_SECONDS),
+                            expires_at=datetime.now(UTC) + timedelta(seconds=DEFAULT_TTL_SECONDS),
                             load_test=is_load_test,
                         ),
                     )

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1,7 +1,7 @@
 """Tests for the XRPC feed generator endpoints."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,9 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from ..documents import (
-    DiversificationMeta,
     FeedCacheDocument,
-    FeedSnapshotDocument,
     PipelineItemMeta,
 )
 from ..feeds import FEEDS
@@ -36,6 +34,7 @@ def _isolate_initial_request_reuse():
     yield
     _clear_initial_request_cache()
 
+
 SERVICE_DID = "did:web:test.example.com"
 PUBLISHER_DID = "did:plc:publisherabc123"
 FEED_RKEY = "unranked-your-feed"
@@ -44,13 +43,9 @@ RANDOM_FEED_RKEY = "random"
 RANDOM_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANDOM_FEED_RKEY}"
 RANKED_FEED_RKEY = "your-feed"
 RANKED_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{RANKED_FEED_RKEY}"
-CUTOFF_PREVIEW_FEED_URI = (
-    f"at://{SERVICE_DID}/app.bsky.feed.generator/cutoff-preview"
-)
+CUTOFF_PREVIEW_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/cutoff-preview"
 COLD_START_FEED_RKEY = "cold-start"
-COLD_START_FEED_URI = (
-    f"at://{SERVICE_DID}/app.bsky.feed.generator/{COLD_START_FEED_RKEY}"
-)
+COLD_START_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{COLD_START_FEED_RKEY}"
 BEST_OF_FRIENDS_FEED_RKEY = "best-of-friends"
 BEST_OF_FRIENDS_FEED_URI = f"at://{SERVICE_DID}/app.bsky.feed.generator/{BEST_OF_FRIENDS_FEED_RKEY}"
 # The AppView sends the publisher DID in the feed URI, not the service DID.
@@ -66,10 +61,18 @@ CANDIDATE_ONLY_FEEDS = (
 TEST_EMBEDDING = encode_float32_b64([1.0, 0.0, 0.0])
 
 
-def _make_candidates(prefix: str, n: int, generator_name: str = "test", with_embedding: bool = False) -> list[CandidatePost]:
+def _make_candidates(
+    prefix: str, n: int, generator_name: str = "test", with_embedding: bool = False
+) -> list[CandidatePost]:
     embedding = TEST_EMBEDDING if with_embedding else None
     return [
-        CandidatePost(at_uri=f"at://{prefix}/{i}", content=f"post {i}", minilm_l12_embedding=embedding, score=None, generator_name=generator_name)
+        CandidatePost(
+            at_uri=f"at://{prefix}/{i}",
+            content=f"post {i}",
+            minilm_l12_embedding=embedding,
+            score=None,
+            generator_name=generator_name,
+        )
         for i in range(n)
     ]
 
@@ -95,9 +98,7 @@ def _patch_unranked_your_feed_generators(
     followed_users_gen.generate.return_value = CandidateResult(
         generator_name="followed_users",
         candidates=(
-            two_tower_candidates
-            if followed_users_candidates is None
-            else followed_users_candidates
+            two_tower_candidates if followed_users_candidates is None else followed_users_candidates
         ),
     )
     network_likes_gen = AsyncMock()
@@ -241,6 +242,7 @@ client = TestClient(app)
 # /.well-known/did.json
 # ---------------------------------------------------------------------------
 
+
 class TestWellKnownDid:
     def test_returns_200(self):
         resp = client.get("/.well-known/did.json")
@@ -276,6 +278,7 @@ class TestWellKnownDid:
 # ---------------------------------------------------------------------------
 # /xrpc/app.bsky.feed.describeFeedGenerator
 # ---------------------------------------------------------------------------
+
 
 class TestDescribeFeedGenerator:
     def test_returns_200(self):
@@ -321,20 +324,27 @@ class TestDescribeFeedGenerator:
 # /xrpc/app.bsky.feed.getFeedSkeleton
 # ---------------------------------------------------------------------------
 
+
 class TestGetFeedSkeleton:
     """Tests for the getFeedSkeleton endpoint."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
         """Default to an authenticated caller for non-auth-focused tests."""
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Keep Firestore I/O out of generic feed skeleton tests."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -357,7 +367,9 @@ class TestGetFeedSkeleton:
 
     def test_returns_feed_items(self):
         with self._patch_generators(_make_candidates("p", 3)):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert len(data["feed"]) == 3
         assert data["feed"][0]["post"] == "at://p/0"
 
@@ -365,19 +377,23 @@ class TestGetFeedSkeleton:
         """A fresh feed load excludes the user's recently-seen posts."""
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(
-            generator_name="two_tower", candidates=_make_candidates("p", 2),
+            generator_name="two_tower",
+            candidates=_make_candidates("p", 2),
         )
         followed_gen = AsyncMock()
         followed_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
         network_likes_gen = AsyncMock()
         network_likes_gen.generate.return_value = CandidateResult(
-            generator_name="network_likes", candidates=[],
+            generator_name="network_likes",
+            candidates=[],
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -396,9 +412,7 @@ class TestGetFeedSkeleton:
                 return_value=["at://seen/1", "at://seen/2"],
             ),
         ):
-            resp = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
-            )
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
 
         assert resp.status_code == 200
         assert primary_gen.generate.call_args.kwargs.get("exclude_uris") == [
@@ -412,19 +426,23 @@ class TestGetFeedSkeleton:
 
         primary_gen = AsyncMock()
         primary_gen.generate.return_value = CandidateResult(
-            generator_name="two_tower", candidates=_make_candidates("p", 2),
+            generator_name="two_tower",
+            candidates=_make_candidates("p", 2),
         )
         followed_gen = AsyncMock()
         followed_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
         network_likes_gen = AsyncMock()
         network_likes_gen.generate.return_value = CandidateResult(
-            generator_name="network_likes", candidates=[],
+            generator_name="network_likes",
+            candidates=[],
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -437,13 +455,9 @@ class TestGetFeedSkeleton:
 
         with (
             patch("app.lib.candidates.generate.get_generator", side_effect=fake_get),
-            patch(
-                "app.routers.xrpc.get_recent_seen_uris", new_callable=AsyncMock
-            ) as seen_fetch,
+            patch("app.routers.xrpc.get_recent_seen_uris", new_callable=AsyncMock) as seen_fetch,
         ):
-            resp = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
-            )
+            resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
 
         assert resp.status_code == 200
         seen_fetch.assert_not_called()
@@ -511,9 +525,7 @@ class TestGetFeedSkeleton:
                 params={"feed": FEED_URI, "limit": 3},
             ).json()
             key = ("did:plc:testuser", FEED_RKEY, 3, False)
-            xrpc_mod._initial_requests[key].created_at -= (
-                xrpc_mod.INITIAL_REQUEST_REUSE_SECONDS + 1
-            )
+            xrpc_mod._initial_requests[key].created_at -= xrpc_mod.INITIAL_REQUEST_REUSE_SECONDS + 1
             second = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI, "limit": 3},
@@ -609,12 +621,32 @@ class TestGetFeedSkeleton:
 
     def test_deduplicates_by_at_uri(self):
         duped = [
-            CandidatePost(at_uri="at://dup/1", content="a", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://dup/1", content="a", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://dup/2", content="b", minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://dup/1",
+                content="a",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://dup/1",
+                content="a",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://dup/2",
+                content="b",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(duped):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         uris = [item["post"] for item in data["feed"]]
         assert uris == ["at://dup/1", "at://dup/2"]
 
@@ -717,7 +749,9 @@ class TestGetFeedSkeleton:
 
     def test_empty_feed_returns_empty_list(self):
         with self._patch_generators([]):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert data["feed"] == []
 
     # --- MMR diversification ---
@@ -725,13 +759,43 @@ class TestGetFeedSkeleton:
     def test_same_author_candidates_are_spread_in_feed(self):
         """MMR should interleave candidates from the same author with others."""
         candidates = [
-            CandidatePost(at_uri="at://alice/1", score=1.0, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://alice/2", score=0.9, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://alice/3", score=0.8, author_did="did:plc:alice", content=None, minilm_l12_embedding=None, generator_name="g"),
-            CandidatePost(at_uri="at://bob/1", score=0.5, author_did="did:plc:bob", content=None, minilm_l12_embedding=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://alice/1",
+                score=1.0,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://alice/2",
+                score=0.9,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://alice/3",
+                score=0.8,
+                author_did="did:plc:alice",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://bob/1",
+                score=0.5,
+                author_did="did:plc:bob",
+                content=None,
+                minilm_l12_embedding=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(candidates):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         uris = [item["post"] for item in data["feed"]]
         assert uris[0] == "at://alice/1"
         assert uris.index("at://bob/1") < uris.index("at://alice/2")
@@ -740,11 +804,25 @@ class TestGetFeedSkeleton:
 
     def test_posts_without_at_uri_are_skipped(self):
         candidates = [
-            CandidatePost(at_uri=None, content="no uri", minilm_l12_embedding=None, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://good/1", content="has uri", minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri=None,
+                content="no uri",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://good/1",
+                content="has uri",
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
         with self._patch_generators(candidates):
-            data = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}).json()
+            data = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI}
+            ).json()
         assert len(data["feed"]) == 1
         assert data["feed"][0]["post"] == "at://good/1"
 
@@ -753,18 +831,25 @@ class TestGetFeedSkeleton:
 # Candidate-generator-only feeds
 # ---------------------------------------------------------------------------
 
+
 class TestCandidateGeneratorOnlyFeeds:
     """Tests for private feeds that expose one candidate generator directly."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.mark.parametrize("feed_name,expected_generator", CANDIDATE_ONLY_FEEDS)
@@ -812,18 +897,25 @@ class TestCandidateGeneratorOnlyFeeds:
 # Cursor / pagination
 # ---------------------------------------------------------------------------
 
+
 class TestFeedSkeletonCursor:
     """Tests for cursor-based feed pagination."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def _patch_generators(self, primary_candidates, infill_candidates=None):
@@ -946,6 +1038,42 @@ class TestFeedSkeletonCursor:
         assert resp.status_code == 400
         assert "Invalid cursor" in resp.json()["detail"]
 
+    def test_cursor_cannot_be_reused_for_another_feed(self):
+        expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        app.state.feed_cache._docs["feed-bound-cache"] = FeedCacheDocument(
+            items=["at://private/1"],
+            expires_at=expires_at,
+            user_did="did:plc:testuser",
+            feed_name="your-feed",
+        )
+        cursor = FeedCursor(id="feed-bound-cache", offset=0).encode()
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": RANDOM_FEED_URI, "cursor": cursor},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid cursor"
+
+    def test_cursor_cannot_be_reused_for_another_user(self):
+        expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        app.state.feed_cache._docs["user-bound-cache"] = FeedCacheDocument(
+            items=["at://private/1"],
+            expires_at=expires_at,
+            user_did="did:plc:someone-else",
+            feed_name="unranked-your-feed",
+        )
+        cursor = FeedCursor(id="user-bound-cache", offset=0).encode()
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI, "cursor": cursor},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid cursor"
+
     def test_expired_cursor_generates_fresh_results(self):
         """When the cache entry is gone, a fresh batch is generated."""
         candidates = _make_candidates("p", 8)
@@ -985,7 +1113,7 @@ class TestFeedSkeletonCursor:
             app.state.feed_cache = saved
 
     def test_end_of_cache_regenerates_with_exclusions(self):
-        """When cursor offset >= cached length, new posts are generated excluding previously shown."""
+        """Regenerate with exclusions when the cursor is past the cached posts."""
         candidates = _make_candidates("p", 6)
         with self._patch_generators(candidates):
             first = client.get(
@@ -1114,15 +1242,18 @@ class TestFeedSkeletonCursor:
         )
         infill_gen = AsyncMock()
         infill_gen.generate.return_value = CandidateResult(
-            generator_name="popularity", candidates=[],
+            generator_name="popularity",
+            candidates=[],
         )
         followed_users_gen = AsyncMock()
         followed_users_gen.generate.return_value = CandidateResult(
-            generator_name="followed_users", candidates=[],
+            generator_name="followed_users",
+            candidates=[],
         )
         network_likes_gen = AsyncMock()
         network_likes_gen.generate.return_value = CandidateResult(
-            generator_name="network_likes", candidates=[],
+            generator_name="network_likes",
+            candidates=[],
         )
 
         def fake_get(name):
@@ -1143,12 +1274,21 @@ class TestFeedSkeletonCursor:
         # containing the 5 initial URIs.
         call_kwargs = primary_gen.generate.call_args
         assert call_kwargs.kwargs.get("exclude_uris") == [
-            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
+            "at://p/0",
+            "at://p/1",
+            "at://p/2",
+            "at://p/3",
+            "at://p/4",
         ]
         followed_call_kwargs = followed_users_gen.generate.call_args
         assert followed_call_kwargs.kwargs.get("exclude_uris") == [
-            "at://p/0", "at://p/1", "at://p/2", "at://p/3", "at://p/4",
+            "at://p/0",
+            "at://p/1",
+            "at://p/2",
+            "at://p/3",
+            "at://p/4",
         ]
+
 
 class TestGetFeedSkeletonAuth:
     """Tests that getFeedSkeleton correctly passes through the authenticated DID."""
@@ -1159,8 +1299,10 @@ class TestGetFeedSkeletonAuth:
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
         """Avoid real Firestore interactions unless a test explicitly patches it."""
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def test_authenticated_user_did_passed_to_generator(self):
@@ -1187,7 +1329,7 @@ class TestGetFeedSkeletonAuth:
 
     def test_unauthenticated_request_uses_empty_did(self):
         """Without auth header, endpoint should reject the request."""
-        with self._patch_generators(_make_candidates("p", 2)) as mock_get:
+        with self._patch_generators(_make_candidates("p", 2)):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI},
@@ -1259,7 +1401,9 @@ class TestGetFeedSkeletonAuth:
                 new_callable=AsyncMock,
                 return_value=mock_payload,
             ),
-            patch.object(app.state.id_resolver.did, "resolve", new_callable=AsyncMock, return_value=None),
+            patch.object(
+                app.state.id_resolver.did, "resolve", new_callable=AsyncMock, return_value=None
+            ),
         ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -1395,22 +1539,27 @@ class TestGetFeedSkeletonAuth:
 # _get_service_did / _get_hostname helpers
 # ---------------------------------------------------------------------------
 
+
 class TestConfigHelpers:
     def test_get_service_did_from_env(self):
         from ..routers.xrpc import _get_service_did
+
         assert _get_service_did() == SERVICE_DID
 
     def test_get_service_did_default(self, monkeypatch):
         from ..routers.xrpc import _get_service_did
+
         monkeypatch.delenv("GE_FEED_GENERATOR_DID", raising=False)
         assert _get_service_did() == "did:web:localhost"
 
     def test_get_hostname_from_did_web(self):
         from ..routers.xrpc import _get_hostname
+
         assert _get_hostname() == "test.example.com"
 
     def test_get_hostname_non_web_did(self, monkeypatch):
         from ..routers.xrpc import _get_hostname
+
         monkeypatch.setenv("GE_FEED_GENERATOR_DID", "did:plc:abc123")
         assert _get_hostname() == "localhost"
 
@@ -1419,18 +1568,25 @@ class TestConfigHelpers:
 # Ranked feed
 # ---------------------------------------------------------------------------
 
+
 class TestRankedFeed:
     """Tests for feeds with a rank_request_template wired in."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1483,8 +1639,10 @@ class TestRankedFeed:
         ]
         rank_result = RankPredictResult(rankings=reversed_rankings)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1496,13 +1654,23 @@ class TestRankedFeed:
     def test_hydrates_lightweight_candidates_before_ranking(self):
         """Embedding-free generated candidates are hydrated before ranking."""
         candidates = _make_candidates("p", 1)
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.fetch_post_embeddings", new_callable=AsyncMock, return_value=[("at://p/0", [1.0, 0.0, 0.0])]) as mock_fetch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.fetch_post_embeddings",
+                new_callable=AsyncMock,
+                return_value=[("at://p/0", [1.0, 0.0, 0.0])],
+            ) as mock_fetch,
+            patch(
+                "app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result
+            ) as mock_run,
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1519,17 +1687,39 @@ class TestRankedFeed:
     def test_drops_candidates_missing_embeddings_before_ranking(self):
         """Candidates still missing embeddings after hydration are not sent to ranking."""
         candidates = [
-            CandidatePost(at_uri="at://p/0", content=None, minilm_l12_embedding=TEST_EMBEDDING, score=None, generator_name="g"),
-            CandidatePost(at_uri="at://p/1", content=None, minilm_l12_embedding=None, score=None, generator_name="g"),
+            CandidatePost(
+                at_uri="at://p/0",
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                score=None,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/1",
+                content=None,
+                minilm_l12_embedding=None,
+                score=None,
+                generator_name="g",
+            ),
         ]
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
-            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=0.5),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/0", rank=1, rank_score=1.0),
+                RankedCandidate(at_uri="at://p/1", rank=2, rank_score=0.5),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc._hydrate_embeddings", new_callable=AsyncMock, return_value=candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result) as mock_run:
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc._hydrate_embeddings",
+                new_callable=AsyncMock,
+                return_value=candidates,
+            ),
+            patch(
+                "app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result
+            ) as mock_run,
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1549,19 +1739,41 @@ class TestRankedFeed:
         """
         # Generator scores: p/0 highest, p/1 middle, p/2 lowest.
         candidates = [
-            CandidatePost(at_uri="at://p/0", score=3.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
-            CandidatePost(at_uri="at://p/1", score=2.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
-            CandidatePost(at_uri="at://p/2", score=1.0, content=None, minilm_l12_embedding=TEST_EMBEDDING, generator_name="g"),
+            CandidatePost(
+                at_uri="at://p/0",
+                score=3.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/1",
+                score=2.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
+            CandidatePost(
+                at_uri="at://p/2",
+                score=1.0,
+                content=None,
+                minilm_l12_embedding=TEST_EMBEDDING,
+                generator_name="g",
+            ),
         ]
         # Ranker reverses the order: p/2 best, p/1 middle, p/0 worst.
-        rank_result = RankPredictResult(rankings=[
-            RankedCandidate(at_uri="at://p/2", rank=1, rank_score=3.0),
-            RankedCandidate(at_uri="at://p/1", rank=2, rank_score=2.0),
-            RankedCandidate(at_uri="at://p/0", rank=3, rank_score=1.0),
-        ])
+        rank_result = RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri="at://p/2", rank=1, rank_score=3.0),
+                RankedCandidate(at_uri="at://p/1", rank=2, rank_score=2.0),
+                RankedCandidate(at_uri="at://p/0", rank=3, rank_score=1.0),
+            ]
+        )
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1575,8 +1787,14 @@ class TestRankedFeed:
         """When ranking raises, the feed soft-fails and returns candidates in unranked order."""
         candidates = _make_candidates("p", 3, with_embedding=True)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inference down"),
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1614,9 +1832,10 @@ class TestEmbeddingHydrationTimeout:
 
         candidates = [CandidatePost(at_uri="at://post/1", score=0.5)]
 
-        with patch(
-            "app.routers.xrpc.fetch_post_embeddings", side_effect=_hangs
-        ), pipeline_context_scope(PipelineContext(feed_name="f")) as ctx:
+        with (
+            patch("app.routers.xrpc.fetch_post_embeddings", side_effect=_hangs),
+            pipeline_context_scope(PipelineContext(feed_name="f")) as ctx,
+        ):
             result = await xrpc_module._hydrate_embeddings(object(), candidates)
 
         assert result == candidates
@@ -1630,18 +1849,25 @@ class TestEmbeddingHydrationTimeout:
 # Slate cutoffs (max_render_share / min_rank_score / min_mmr_score)
 # ---------------------------------------------------------------------------
 
+
 class TestSlateCutoffs:
     """The quality gates cut the slate and drive session restarts + discards."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1691,17 +1917,21 @@ class TestSlateCutoffs:
     def _rank_result(scores: list[float]) -> RankPredictResult:
         """Rank p/0..p/n-1 with the given scores, in descending-score order."""
         order = sorted(range(len(scores)), key=lambda i: -scores[i])
-        return RankPredictResult(rankings=[
-            RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=scores[i])
-            for r, i in enumerate(order)
-        ])
+        return RankPredictResult(
+            rankings=[
+                RankedCandidate(at_uri=f"at://p/{i}", rank=r + 1, rank_score=scores[i])
+                for r, i in enumerate(order)
+            ]
+        )
 
     def _get_feed(self, candidates, rank_result, discarded_mock=None):
         gen_patch, _ = self._patch_generators(candidates)
         discarded_mock = discarded_mock if discarded_mock is not None else AsyncMock()
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch("app.routers.xrpc.record_discarded_posts", discarded_mock):
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch("app.routers.xrpc.record_discarded_posts", discarded_mock),
+        ):
             return client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1733,13 +1963,15 @@ class TestSlateCutoffs:
         discarded = AsyncMock()
 
         gen_patch, _ = self._patch_generators(candidates)
-        with gen_patch, \
-             patch(
-                 "app.routers.xrpc.run_predict",
-                 new_callable=AsyncMock,
-                 return_value=self._rank_result([0.8, 0.6, 0.5, 0.4]),
-             ), \
-             patch("app.routers.xrpc.record_discarded_posts", discarded):
+        with (
+            gen_patch,
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                return_value=self._rank_result([0.8, 0.6, 0.5, 0.4]),
+            ),
+            patch("app.routers.xrpc.record_discarded_posts", discarded),
+        ):
             client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANKED_FEED_URI},
@@ -1826,19 +2058,21 @@ class TestSlateCutoffs:
         gen_patch, primary_gen = self._patch_generators(candidates)
 
         rank_result = self._rank_result([0.7, 0.6])
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch("app.routers.xrpc.record_discarded_posts", new_callable=AsyncMock), \
-             patch(
-                 "app.routers.xrpc.get_recent_seen_uris",
-                 new_callable=AsyncMock,
-                 return_value=["at://seen/1"],
-             ), \
-             patch(
-                 "app.routers.xrpc.get_recent_discarded_uris",
-                 new_callable=AsyncMock,
-                 return_value=["at://disc/1"],
-             ):
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch("app.routers.xrpc.record_discarded_posts", new_callable=AsyncMock),
+            patch(
+                "app.routers.xrpc.get_recent_seen_uris",
+                new_callable=AsyncMock,
+                return_value=["at://seen/1"],
+            ),
+            patch(
+                "app.routers.xrpc.get_recent_discarded_uris",
+                new_callable=AsyncMock,
+                return_value=["at://disc/1"],
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": RANKED_FEED_URI}
             )
@@ -1854,11 +2088,13 @@ class TestSlateCutoffs:
         gen_patch, _ = self._patch_generators(_make_candidates("p", 2, with_embedding=True))
 
         rank_result = self._rank_result([0.5, 0.4])
-        with gen_patch, \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result), \
-             patch(
-                 "app.routers.xrpc.get_recent_discarded_uris", new_callable=AsyncMock
-             ) as discarded_fetch:
+        with (
+            gen_patch,
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+            patch(
+                "app.routers.xrpc.get_recent_discarded_uris", new_callable=AsyncMock
+            ) as discarded_fetch,
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": RANKED_FEED_URI}
             )
@@ -1907,18 +2143,25 @@ class TestSlateCutoffs:
 # Best-of-friends feed
 # ---------------------------------------------------------------------------
 
+
 class TestBestOfFriendsFeed:
     """Tests for the best-of-friends feed (followed_users candidates + two-tower ranking)."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -1953,8 +2196,10 @@ class TestBestOfFriendsFeed:
         ]
         rank_result = RankPredictResult(rankings=reversed_rankings)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, return_value=rank_result),
+        ):
             data = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -1964,11 +2209,17 @@ class TestBestOfFriendsFeed:
         assert posts == ["at://p/2", "at://p/1", "at://p/0"]
 
     def test_ranking_failure_soft_fails_to_unranked(self):
-        """When the two-tower ranker raises, the feed soft-fails and returns candidates in unranked order."""
+        """A two-tower failure returns candidates in unranked order."""
         candidates = _make_candidates("p", 3, with_embedding=True)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", new_callable=AsyncMock, side_effect=RuntimeError("inference down")):
+        with (
+            self._patch_generators(candidates),
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inference down"),
+            ),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -1988,8 +2239,10 @@ class TestBestOfFriendsFeed:
         async def _slow_run_predict(*args, **kwargs):
             await asyncio.sleep(1)
 
-        with self._patch_generators(candidates), \
-             patch("app.routers.xrpc.run_predict", side_effect=_slow_run_predict):
+        with (
+            self._patch_generators(candidates),
+            patch("app.routers.xrpc.run_predict", side_effect=_slow_run_predict),
+        ):
             resp = TestClient(app, raise_server_exceptions=False).get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": BEST_OF_FRIENDS_FEED_URI},
@@ -2034,9 +2287,7 @@ class TestShortEvent:
 
 class TestSendInteractions:
     def test_returns_empty_object(self):
-        resp = client.post(
-            "/xrpc/app.bsky.feed.sendInteractions", json={"interactions": []}
-        )
+        resp = client.post("/xrpc/app.bsky.feed.sendInteractions", json={"interactions": []})
         assert resp.status_code == 200
         assert resp.json() == {}
 
@@ -2178,7 +2429,9 @@ class TestSendInteractions:
         monkeypatch.setattr(FEEDS["your-feed"], "exclude_seen_posts", False)
         seen = "app.bsky.feed.defs#interactionSeen"
         ix = Interaction(
-            item="at://post/1", event=seen, feed_context=_make_token(feed="your-feed"),
+            item="at://post/1",
+            event=seen,
+            feed_context=_make_token(feed="your-feed"),
         )
         db = MagicMock()
         with (
@@ -2251,13 +2504,18 @@ class TestSendInteractions:
 # Feed debug capture
 # ---------------------------------------------------------------------------
 
+
 class TestFeedDebugCapture:
     """getFeedSkeleton always writes a lightweight snapshot; full debug is gated on debug_feeds."""
 
     @pytest.fixture(autouse=True)
     def _mock_auth_and_session(self):
         with (
-            patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"),
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value="did:plc:testuser",
+            ),
             patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
         ):
@@ -2269,7 +2527,9 @@ class TestFeedDebugCapture:
     def _user_doc(self, debug_feeds):
         from ..documents import UserDocument
 
-        return UserDocument(user_did="did:plc:testuser", username=TEST_USERNAME, debug_feeds=debug_feeds)
+        return UserDocument(
+            user_did="did:plc:testuser", username=TEST_USERNAME, debug_feeds=debug_feeds
+        )
 
     @staticmethod
     async def _drain(coros):
@@ -2293,7 +2553,9 @@ class TestFeedDebugCapture:
         snapshot = MagicMock(items=["at://a"], feed_name="your-feed")
         collector = MagicMock()
         with (
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=True),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=True
+            ),
             patch("app.routers.xrpc.get_metric_collector", return_value=collector),
         ):
             await _write_feed_snapshot_background(MagicMock(), "did:plc:testuser", "r1", snapshot)
@@ -2307,8 +2569,14 @@ class TestFeedDebugCapture:
         """Snapshot always written regardless of debug flag."""
         with (
             self._patch_generators(_make_candidates("p", 3)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(False)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(False),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2321,8 +2589,14 @@ class TestFeedDebugCapture:
         candidates = _make_candidates("p", 8)
         with (
             self._patch_generators(candidates),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(False)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(False),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
         ):
             response = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -2335,15 +2609,24 @@ class TestFeedDebugCapture:
         assert snapshot.items == returned
         assert snapshot.items == ["at://p/0", "at://p/1", "at://p/2"]
         assert [meta.at_uri for meta in snapshot.items_meta] == snapshot.items
+        assert snapshot.expires_at - snapshot.generated_at == timedelta(hours=24)
 
     def test_full_debug_record_when_enabled(self):
         """Full debug record written in background when debug_feeds is on."""
         spawned: list = []
         with (
             self._patch_generators(_make_candidates("p", 3)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=self._user_doc(True)),
-            patch("app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                return_value=self._user_doc(True),
+            ),
+            patch(
+                "app.routers.xrpc._spawn_background", side_effect=lambda coro: spawned.append(coro)
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2362,8 +2645,14 @@ class TestFeedDebugCapture:
         """Snapshot still written even when user lookup fails."""
         with (
             self._patch_generators(_make_candidates("p", 2)),
-            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, side_effect=RuntimeError("boom")),
-            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False) as mock_snapshot,
+            patch(
+                "app.routers.xrpc.get_user",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock, return_value=False
+            ) as mock_snapshot,
             patch("app.routers.xrpc.write_feed_debug", new_callable=AsyncMock) as mock_debug,
         ):
             resp = client.get("/xrpc/app.bsky.feed.getFeedSkeleton", params={"feed": FEED_URI})
@@ -2376,6 +2665,7 @@ class TestFeedDebugCapture:
 # ---------------------------------------------------------------------------
 # Probe bypass (Cloud Scheduler)
 # ---------------------------------------------------------------------------
+
 
 class TestGetFeedSkeletonProbe:
     """Cloud Scheduler hits the endpoint without AT Protocol auth.
@@ -2393,13 +2683,17 @@ class TestGetFeedSkeletonProbe:
     @pytest.fixture(autouse=True)
     def _no_at_proto_auth(self):
         """Simulate requests with no AT Protocol Bearer token."""
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None):
+        with patch(
+            "app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_firestore(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     def test_correct_probe_secret_returns_200(self):
@@ -2482,7 +2776,9 @@ class TestLoadTestSession:
 
     @pytest.fixture(autouse=True)
     def _no_at_proto_auth(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None):
+        with patch(
+            "app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value=None
+        ):
             yield
 
     @pytest.fixture(autouse=True)
@@ -2564,6 +2860,8 @@ class TestLoadTestSession:
             )
         assert resp.status_code == 200
         snapshot_write.assert_awaited()
+        assert snapshot_write.await_args is not None
+        assert snapshot_write.await_args.kwargs["enforce_document_cap"] is False
         snapshot_del.assert_awaited()
 
     def test_real_request_snapshot_not_deleted(self):
@@ -2584,6 +2882,8 @@ class TestLoadTestSession:
             )
         assert resp.status_code == 200
         snapshot_write.assert_awaited()
+        assert snapshot_write.await_args is not None
+        assert snapshot_write.await_args.kwargs["enforce_document_cap"] is True
         snapshot_del.assert_not_awaited()
 
     def test_dedup_key_isolates_real_from_load_test(self):
@@ -2722,7 +3022,11 @@ class TestDiversityScoreMetric:
     @pytest.fixture(autouse=True)
     def _mock_auth_and_session(self):
         with (
-            patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"),
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value="did:plc:testuser",
+            ),
             patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
         ):
@@ -2811,9 +3115,7 @@ class TestDiversityScoreMetric:
         )
         with patch("app.lib.candidates.generate.get_generator", return_value=random_gen):
             client = TestClient(app)
-            resp = client.get(
-                f"/xrpc/app.bsky.feed.getFeedSkeleton?feed={RANDOM_FEED_URI}&limit=5"
-            )
+            resp = client.get(f"/xrpc/app.bsky.feed.getFeedSkeleton?feed={RANDOM_FEED_URI}&limit=5")
 
         set_metric_collector(None)
         assert resp.status_code == 200
@@ -2825,9 +3127,10 @@ class TestDiversityScoreMetric:
         score, so it must not be averaged into the mean-similarity metric,
         even when it happens to also be one of the organically-generated
         candidates (and so does carry a real similarity score)."""
+        from app.routers import xrpc as xrpc_mod
+
         from ..lib.diversify import mmr_rerank as real_mmr_rerank
         from ..lib.feed_debug import FeedDebugRecorder, feed_debug_scope
-        from app.routers import xrpc as xrpc_mod
 
         collector = FakeMetricCollector()
         set_metric_collector(cast(MetricCollector, collector))
@@ -2858,9 +3161,7 @@ class TestDiversityScoreMetric:
             patch.object(xrpc_mod, "FEEDS", patched_feeds),
         ):
             client = TestClient(app)
-            resp = client.get(
-                f"/xrpc/app.bsky.feed.getFeedSkeleton?feed={RANDOM_FEED_URI}&limit=5"
-            )
+            resp = client.get(f"/xrpc/app.bsky.feed.getFeedSkeleton?feed={RANDOM_FEED_URI}&limit=5")
 
         set_metric_collector(None)
         assert resp.status_code == 200
@@ -2893,6 +3194,7 @@ class TestDiversityScoreMetric:
         assert similarity_by_uri[pinned_uri] == 0.0
         assert value > 0.0
 
+
 # ---------------------------------------------------------------------------
 # Pinned post
 # ---------------------------------------------------------------------------
@@ -2905,7 +3207,11 @@ class TestPinnedPost:
         cfg = FEEDS["random"].model_copy(update={"pinned_post_uri": self.PINNED_URI})
         return {"random": cfg, **{k: v for k, v in FEEDS.items() if k != "random"}}
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2923,8 +3229,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -2933,7 +3241,11 @@ class TestPinnedPost:
         assert resp.status_code == 200
         assert resp.json()["feed"][0]["post"] == self.PINNED_URI
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2973,7 +3285,11 @@ class TestPinnedPost:
         ]
         assert all(meta.at_uri != self.PINNED_URI for meta in snapshot.items_meta)
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -2982,7 +3298,9 @@ class TestPinnedPost:
         from app.routers import xrpc as xrpc_mod
 
         candidates = [
-            CandidatePost(at_uri=self.PINNED_URI, content="pinned", score=None, generator_name="random_posts"),
+            CandidatePost(
+                at_uri=self.PINNED_URI, content="pinned", score=None, generator_name="random_posts"
+            ),
             *_make_candidates("did:plc:a", 4, "random_posts"),
         ]
         random_gen = AsyncMock()
@@ -2994,8 +3312,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -3006,7 +3326,11 @@ class TestPinnedPost:
         assert post_uris.count(self.PINNED_URI) == 1
         assert post_uris[0] == self.PINNED_URI
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -3025,8 +3349,10 @@ class TestPinnedPost:
             return random_gen if name == "random_posts" else None
 
         patched_feeds = self._make_random_feed_with_pin()
-        with patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator), \
-             patch.object(xrpc_mod, "FEEDS", patched_feeds):
+        with (
+            patch("app.lib.candidates.generate.get_generator", side_effect=fake_get_generator),
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+        ):
             first = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": RANDOM_FEED_URI, "limit": 10},
@@ -3044,7 +3370,11 @@ class TestPinnedPost:
 
         assert second["feed"][0]["post"] == "at://did:plc:a/9"
 
-    @patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser")
+    @patch(
+        "app.routers.xrpc.verify_auth_header",
+        new_callable=AsyncMock,
+        return_value="did:plc:testuser",
+    )
     @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
     @patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock)
     @patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock)
@@ -3058,7 +3388,9 @@ class TestPinnedPost:
         cache._store["testcacheid"] = cached_uris
         cache._docs["testcacheid"] = FeedCacheDocument(
             items=cached_uris,
-            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            expires_at=datetime.now(UTC) + timedelta(minutes=10),
+            user_did="did:plc:testuser",
+            feed_name=RANDOM_FEED_RKEY,
         )
         app.state.feed_cache = cache
 
@@ -3075,22 +3407,28 @@ class TestPinnedPost:
 
 
 # ---------------------------------------------------------------------------
-# Social-radius override
+# Source-weight override and Social Radius migration
 # ---------------------------------------------------------------------------
 
 
-class TestSocialRadiusOverride:
-    """Generator weights are overridden based on user_doc.social_radius."""
+class TestSourceWeightsOverride:
+    """Generator weights resolve from atomic settings or legacy presets."""
 
     @pytest.fixture(autouse=True)
     def _mock_auth(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)
     def _mock_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), \
-             patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
             yield
 
     @patch("app.routers.xrpc.get_user")
@@ -3139,6 +3477,45 @@ class TestSocialRadiusOverride:
         gen_request = mock_pipeline.call_args.args[1]
         assert gen_request.generators == SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES[4]
 
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_applies_custom_source_weights(self, mock_pipeline, mock_get_user):
+        from ..documents import (
+            FeedPreferencesDocument,
+            SourceWeightsDocument,
+            UserDocument,
+        )
+        from .xrpc import PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            feed_preferences={
+                "your-feed": FeedPreferencesDocument(
+                    source_weights=SourceWeightsDocument(
+                        following=0.4,
+                        network_likes=0.2,
+                        authors_topics=0.15,
+                        popular=0.25,
+                    )
+                )
+            },
+        )
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": RANKED_FEED_URI, "limit": 30},
+        )
+
+        assert response.status_code == 200
+        gen_request = mock_pipeline.call_args.args[1]
+        assert [(g.name, g.weight) for g in gen_request.generators] == [
+            ("followed_users", 0.4),
+            ("two_tower", 0.15),
+            ("popularity", 0.25),
+            ("network_likes", 0.2),
+        ]
+
     @patch("app.routers.xrpc.evaluate_feature_flags")
     @patch("app.routers.xrpc.get_user")
     @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
@@ -3165,10 +3542,7 @@ class TestSocialRadiusOverride:
 
         assert resp.status_code == 200
         gen_request = mock_pipeline.call_args.args[1]
-        assert [
-            (generator.name, generator.weight)
-            for generator in gen_request.generators
-        ] == [
+        assert [(generator.name, generator.weight) for generator in gen_request.generators] == [
             ("popularity", 1.0),
         ]
         mock_feature_flags.assert_not_called()
@@ -3366,6 +3740,192 @@ class TestSocialRadiusOverride:
             ["fail-fast-feed", "network-likes-in-your-feed"],
         )
 
+    @patch(
+        "app.routers.xrpc.evaluate_feature_flags",
+        return_value={"fail-fast-feed": False, "network-likes-in-your-feed": False},
+    )
+    @patch("app.routers.xrpc.get_posthog_client")
+    @patch("app.routers.xrpc.get_user")
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_disabled_network_likes_normalizes_custom_weights(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        _mock_get_posthog_client,
+        _mock_feature_flags,
+    ):
+        from ..documents import (
+            FeedPreferencesDocument,
+            SourceWeightsDocument,
+            UserDocument,
+        )
+        from .xrpc import PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            feed_preferences={
+                "your-feed": FeedPreferencesDocument(
+                    source_weights=SourceWeightsDocument(
+                        following=0.4,
+                        network_likes=0.2,
+                        authors_topics=0.1,
+                        popular=0.3,
+                    )
+                )
+            },
+        )
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": RANKED_FEED_URI, "limit": 30},
+        )
+
+        assert response.status_code == 200
+        generators = mock_pipeline.call_args.args[1].generators
+        assert [generator.name for generator in generators] == [
+            "followed_users",
+            "two_tower",
+            "popularity",
+        ]
+        assert [generator.weight for generator in generators] == pytest.approx([0.5, 0.125, 0.375])
+
+
+class TestPurposeOverride:
+    """Ranker weights are overridden based on user_doc.purpose."""
+
+    @pytest.mark.parametrize(
+        ("feed_name", "engaging_name"),
+        [
+            ("your-feed", "heavy_ranker"),
+            ("best-of-friends", "heavy_ranker"),
+            ("cutoff-preview", "heavy_ranker"),
+            ("cold-start", "heavy_ranker_empty_history"),
+        ],
+    )
+    @pytest.mark.parametrize("purpose", [0.2, 0.5, 0.8])
+    def test_applies_complementary_weights_to_ranked_feeds(self, feed_name, engaging_name, purpose):
+        from .xrpc import _with_purpose_weights
+
+        original = FEEDS[feed_name]
+        adjusted = _with_purpose_weights(original, purpose)
+        assert adjusted.rank_request_template is not None
+        weights = {model.name: model.weight for model in adjusted.rank_request_template.models}
+
+        assert weights[engaging_name] == pytest.approx(1.0 - purpose)
+        assert weights["perspective"] == pytest.approx(purpose)
+        assert original.rank_request_template is not None
+        assert [model.weight for model in original.rank_request_template.models] == [1.0, 1.0]
+
+    def test_unranked_feed_is_unchanged(self):
+        from .xrpc import _with_purpose_weights
+
+        original = FEEDS["random"]
+        assert _with_purpose_weights(original, 0.8) is original
+
+    @pytest.fixture(autouse=True)
+    def _mock_auth(self):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_upsert(self):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
+            yield
+
+    @patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None)
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_missing_user_uses_balanced_weights(self, mock_pipeline, _mock_get_user):
+        from .xrpc import PipelineResult
+
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": RANKED_FEED_URI, "limit": 30},
+        )
+
+        assert response.status_code == 200
+        feed_cfg = mock_pipeline.call_args.args[0]
+        assert feed_cfg.rank_request_template is not None
+        assert [model.weight for model in feed_cfg.rank_request_template.models] == [0.5, 0.5]
+
+
+class TestFeedScopedControls:
+    @pytest.fixture(autouse=True)
+    def _mock_auth_and_upserts(self):
+        with (
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value="did:plc:testuser",
+            ),
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        ("feed_uri", "expected_hours", "expected_weights"),
+        [
+            (RANKED_FEED_URI, 6, [0.2, 0.8]),
+            (BEST_OF_FRIENDS_FEED_URI, 24, [0.65, 0.35]),
+            (RANDOM_FEED_URI, 72, None),
+            (COLD_START_FEED_URI, 168, [1.0, 1.0]),
+            (FEED_URI, 6, None),
+        ],
+    )
+    @patch("app.routers.xrpc.get_user", new_callable=AsyncMock)
+    @patch("app.routers.xrpc._run_ranking_pipeline", new_callable=AsyncMock)
+    def test_pipeline_uses_only_the_selected_feed_preferences(
+        self,
+        mock_pipeline,
+        mock_get_user,
+        feed_uri,
+        expected_hours,
+        expected_weights,
+    ):
+        from ..documents import FeedPreferencesDocument, UserDocument
+        from .xrpc import PipelineResult
+
+        mock_get_user.return_value = UserDocument(
+            user_did="did:plc:testuser",
+            # Legacy values deliberately differ so configured nested values
+            # prove they win, while the unconfigured internal feed uses defaults.
+            freshness=1,
+            purpose=0.5,
+            feed_preferences={
+                "your-feed": FeedPreferencesDocument(social_radius=4, freshness=0, purpose=0.8),
+                "best-of-friends": FeedPreferencesDocument(freshness=2, purpose=0.35),
+                "random": FeedPreferencesDocument(freshness=4),
+            },
+        )
+        mock_pipeline.return_value = PipelineResult(["at://dummy/1"], [])
+
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": feed_uri, "limit": 30},
+        )
+
+        assert response.status_code == 200
+        feed_cfg = mock_pipeline.call_args.args[0]
+        gen_request = mock_pipeline.call_args.args[1]
+        assert gen_request.max_age_hours == expected_hours
+        if expected_weights is not None:
+            assert feed_cfg.rank_request_template is not None
+            assert [
+                model.weight for model in feed_cfg.rank_request_template.models
+            ] == pytest.approx(expected_weights)
+        elif feed_cfg.rank_request_template is not None:
+            assert [model.weight for model in feed_cfg.rank_request_template.models] == [1.0, 1.0]
+
 
 class TestGetFeedSkeletonMetrics:
     """Feed renders emit exactly one success or failure counter."""
@@ -3381,8 +3941,9 @@ class TestGetFeedSkeletonMetrics:
 
     @pytest.fixture(autouse=True)
     def _mock_firestore_upsert(self):
-        with patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock), patch(
-            "app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
         ):
             yield
 
@@ -3401,24 +3962,18 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 200
-        success_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.success_count"
-        ]
+        success_calls = [call for call in self.mc.calls if call[0] == "feed.render.success_count"]
         assert len(success_calls) == 1
         assert success_calls[0][2]["feed_name"] == FEED_RKEY
 
     def test_unknown_feed_records_failure_count_400(self):
         response = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
-            params={
-                "feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"
-            },
+            params={"feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"},
         )
 
         assert response.status_code == 400
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": "unknown",
@@ -3437,9 +3992,7 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 401
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": FEED_RKEY,
@@ -3469,9 +4022,7 @@ class TestGetFeedSkeletonMetrics:
             )
 
         assert response.status_code == 504
-        failure_calls = [
-            call for call in self.mc.calls if call[0] == "feed.render.failure_count"
-        ]
+        failure_calls = [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         assert len(failure_calls) == 1
         assert failure_calls[0][2] == {
             "feed_name": FEED_RKEY,
@@ -3481,14 +4032,10 @@ class TestGetFeedSkeletonMetrics:
     def test_failure_records_no_success_count(self):
         client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
-            params={
-                "feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"
-            },
+            params={"feed": f"at://{SERVICE_DID}/app.bsky.feed.generator/nonexistent"},
         )
 
-        assert [
-            call for call in self.mc.calls if call[0] == "feed.render.success_count"
-        ] == []
+        assert [call for call in self.mc.calls if call[0] == "feed.render.success_count"] == []
 
 
 class TestDevSession:
@@ -3511,18 +4058,14 @@ class TestDevSession:
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.delenv("GE_DEV_SESSION_SECRET", raising=False)
-        request = self._request(
-            {"X-Dev-Session": "anything", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "anything", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) is None
 
     def test_ignores_a_wrong_secret(self, monkeypatch):
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "correct")
-        request = self._request(
-            {"X-Dev-Session": "wrong", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "wrong", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) is None
 
     def test_ignores_a_request_with_no_headers(self, monkeypatch):
@@ -3535,9 +4078,7 @@ class TestDevSession:
         from ..routers.xrpc import dev_session_did
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "correct")
-        request = self._request(
-            {"X-Dev-Session": "correct", "X-Dev-Session-DID": "did:plc:abc"}
-        )
+        request = self._request({"X-Dev-Session": "correct", "X-Dev-Session-DID": "did:plc:abc"})
         assert dev_session_did(request) == "did:plc:abc"
 
     def test_rejects_a_did_that_is_not_did_plc(self, monkeypatch):
@@ -3560,9 +4101,7 @@ class TestDevSessionStartupGuard:
     """It must be impossible to serve deployed traffic with this enabled."""
 
     @pytest.mark.asyncio
-    async def test_refuses_to_start_when_enabled_in_a_deployed_environment(
-        self, monkeypatch
-    ):
+    async def test_refuses_to_start_when_enabled_in_a_deployed_environment(self, monkeypatch):
         from ..main import app, lifespan
 
         monkeypatch.setenv("GE_DEV_SESSION_SECRET", "anything")
@@ -3697,7 +4236,11 @@ class TestFailFastFeatureFlag:
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
-        with patch("app.routers.xrpc.verify_auth_header", new_callable=AsyncMock, return_value="did:plc:testuser"):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
             yield
 
     @pytest.fixture(autouse=True)

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -2502,9 +2502,7 @@ class TestSendInteractions:
         with (
             patch("app.routers.xrpc.record_interaction", new_callable=AsyncMock),
             patch("app.routers.xrpc.get_posthog_client", return_value=MagicMock()),
-            patch(
-                "app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=user
-            ) as get_u,
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=user) as get_u,
             patch("app.routers.xrpc.track_interaction") as track,
         ):
             await _record_interactions(db, interactions)


### PR DESCRIPTION
- Added feed-scoped preferences with four atomic candidate-source weights, including Network Likes.
- Added purpose weight controls (engaging vs constructive)
- Persist last 24 hours of posts
- Added preference migration, validation, generator allocation, and feature-flag behavior.
- Improved feed snapshot diagnostics, retention, observability, and feed mapping.
- Secured pagination cursors to their originating user and feed.
- Fixed concurrency issues