### PR TITLE
Cache followed users per user in Firestore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,8 @@ export GE_FOLLOWS_CACHE_LEASE_SEC="30"
 # Quiet period after a failed refresh, so a user whose follows cannot be
 # fetched does not spawn a refresh task on every request.
 export GE_FOLLOWS_CACHE_RETRY_COOLDOWN_SEC="60"
+
+# How often one process samples population health (how many cached users are
+# incomplete or stale) and reports it as gauges. Runs deferred, off the
+# request path.
+export GE_FOLLOWS_CACHE_SWEEP_SEC="300"

--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,22 @@ export GE_SERVICE_NAME="greenearth-api"
 
 # How often (in seconds) to flush metrics to Cloud Monitoring.
 export GE_METRICS_EXPORT_INTERVAL_SEC="60"
+
+########## Followed-Users Cache ##########
+
+# Per-user cache of Bluesky follow lists (issue #83). Jetstream ingest keeps
+# entries current; these knobs only govern the backstop refresh.
+
+# Age at which an entry is refreshed in the background (default 6 hours).
+export GE_FOLLOWS_CACHE_TTL_SEC="21600"
+
+# Budget for a background follow walk. Larger than the request-path clamp
+# because nothing is waiting on it.
+export GE_FOLLOWS_REFRESH_TIMEOUT_SEC="15"
+
+# How long one instance may hold the refresh lease before another may retry.
+export GE_FOLLOWS_CACHE_LEASE_SEC="30"
+
+# Quiet period after a failed refresh, so a user whose follows cannot be
+# fetched does not spawn a refresh task on every request.
+export GE_FOLLOWS_CACHE_RETRY_COOLDOWN_SEC="60"

--- a/src/app/documents.py
+++ b/src/app/documents.py
@@ -147,6 +147,61 @@ class FeedCacheDocument(BaseModel):
     )
 
 
+class FollowedUsersCacheDocument(BaseModel):
+    """Cached Bluesky follow list for one user.
+
+    The document ID is the user's ``user_doc_id``.  Replaces a live
+    ``app.bsky.graph.getFollows`` walk on every feed request (see issue #83).
+
+    Two writers touch this document.  The API owns ``follows`` and rewrites it
+    on refresh; the jetstream ingester only ever appends to ``pending_adds``
+    (via ``ArrayUnion``, so it never reads first) or stamps ``invalidated_at``.
+    That split is what keeps the two writers from clobbering each other.
+    """
+
+    follows: list[str] = Field(
+        default_factory=list,
+        description="Followed DIDs.  Stored uncompressed: ~1000 DIDs is ~40 KB against a "
+        "1 MiB document limit, and array fields index per element so the 7.5 KiB "
+        "index-entry limit is never in play.",
+    )
+    complete: bool = Field(
+        default=False,
+        description="True when the walk that produced 'follows' exhausted the cursor or hit "
+        "the follow cap.  False means it was truncated by an error or an expired "
+        "budget, and the entry is refreshed on the next read however young it is "
+        "— otherwise one Bluesky blip pins a user to a partial follow set for a "
+        "whole TTL.  Defaults False so a legacy or unreadable document is "
+        "refreshed rather than trusted.",
+    )
+    generated_at: datetime | None = Field(
+        default=None, description="When 'follows' was fetched from Bluesky"
+    )
+    pending_adds: list[str] = Field(
+        default_factory=list,
+        description="DIDs followed since the last refresh, appended by jetstream ingest.  "
+        "Merged into 'follows' on read and folded in on refresh.",
+    )
+    invalidated_at: datetime | None = Field(
+        default=None,
+        description="Stamped by jetstream ingest on an unfollow.  Jetstream deletes carry no "
+        "subject DID, so the entry is marked stale and reconciled by the next "
+        "refresh rather than edited in place.",
+    )
+    refresh_started_at: datetime | None = Field(
+        default=None, description="Refresh lease; held across instances, expires on its own"
+    )
+    refresh_failed_at: datetime | None = Field(
+        default=None,
+        description="Last failed refresh.  Imposes a short cooldown so a user whose follows "
+        "cannot be fetched does not spawn a refresh task on every request.",
+    )
+    expires_at: datetime | None = Field(
+        default=None, description="UTC expiration timestamp; drives native Firestore TTL"
+    )
+    api_release_sha: str | None = None
+
+
 class SeenPostsDocument(BaseModel):
     """Post URIs a user has seen on a given UTC day.
 

--- a/src/app/lib/bsky.py
+++ b/src/app/lib/bsky.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from dataclasses import dataclass, field
 
 import httpx
 
@@ -57,6 +58,26 @@ class FollowedUsersLookupError(Exception):
     """Raised when followed-user lookup fails."""
 
 
+@dataclass(frozen=True)
+class FollowsFetch:
+    """The outcome of one followed-users walk.
+
+    ``complete`` is ``True`` only when the walk ended on its own terms — the
+    cursor ran out, or ``limit`` was reached, which is a deliberate bound
+    rather than a failure. A page error or an expired budget yields whatever
+    was collected with ``complete=False``.
+
+    The distinction exists for the followed-users cache: a partial list is
+    still worth serving (it beats no candidates at all), but storing one as
+    authoritative would pin a user to a truncated follow set until the entry
+    expires. Callers that only want the DIDs can use
+    :func:`get_followed_user_dids`.
+    """
+
+    dids: list[str] = field(default_factory=list)
+    complete: bool = True
+
+
 def _is_retryable_follow_lookup_error(exc: httpx.HTTPError) -> bool:
     if isinstance(exc, httpx.TimeoutException):
         return True
@@ -88,17 +109,38 @@ async def _get_follows_page(
 
 
 async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
+    """Followed DIDs only, discarding the completeness signal."""
+    return (await fetch_followed_user_dids(user_did, limit)).dids
+
+
+async def fetch_followed_user_dids(
+    user_did: str,
+    limit: int,
+    timeout_seconds: float | None = None,
+) -> FollowsFetch:
+    """Walk ``app.bsky.graph.getFollows`` for *user_did*.
+
+    *timeout_seconds* bounds the whole walk; it defaults to the tight
+    request-path budget, and the background cache refresh passes a larger one
+    because it is not blocking a response.
+
+    Raises :class:`FollowedUsersLookupError` only when nothing at all could be
+    fetched. Any partial result comes back with ``complete=False``.
+    """
     base_url = "https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows"
     followed_dids: list[str] = []
     cursor: str | None = None
 
     if limit <= 0:
-        return followed_dids
+        return FollowsFetch(dids=followed_dids, complete=True)
+
+    if timeout_seconds is None:
+        timeout_seconds = FOLLOWS_LOOKUP_TIMEOUT_SECONDS
 
     client = get_http_client()
 
     try:
-        async with asyncio.timeout(FOLLOWS_LOOKUP_TIMEOUT_SECONDS):
+        async with asyncio.timeout(timeout_seconds):
             while len(followed_dids) < limit:
                 page_limit = min(FOLLOWS_PAGE_LIMIT, limit - len(followed_dids))
                 params = {"actor": user_did, "limit": page_limit}
@@ -136,7 +178,7 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                             user_did,
                             exc,
                         )
-                        return followed_dids[:limit]
+                        return FollowsFetch(dids=followed_dids[:limit], complete=False)
                     raise
 
                 followed_dids.extend(
@@ -157,9 +199,9 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
                 "exceeded %.1fs",
                 len(followed_dids),
                 user_did,
-                FOLLOWS_LOOKUP_TIMEOUT_SECONDS,
+                timeout_seconds,
             )
-            return followed_dids[:limit]
+            return FollowsFetch(dids=followed_dids[:limit], complete=False)
         raise FollowedUsersLookupError(
             f"Failed to fetch followed users for {user_did}"
         ) from exc
@@ -172,4 +214,6 @@ async def get_followed_user_dids(user_did: str, limit: int) -> list[str]:
             f"Failed to fetch followed users for {user_did}"
         ) from exc
 
-    return followed_dids[:limit]
+    # Fell out of the loop on an exhausted cursor or a reached limit: both are
+    # the walk finishing on its own terms.
+    return FollowsFetch(dids=followed_dids[:limit], complete=True)

--- a/src/app/lib/bsky_test.py
+++ b/src/app/lib/bsky_test.py
@@ -4,7 +4,12 @@ import httpx
 import pytest
 
 from . import bsky as bsky_module
-from .bsky import FollowedUsersLookupError, get_followed_user_dids
+from .bsky import (
+    FollowedUsersLookupError,
+    FollowsFetch,
+    fetch_followed_user_dids,
+    get_followed_user_dids,
+)
 
 
 class FakeResponse:
@@ -410,3 +415,133 @@ class TestGetFollowedUserDids:
 
         with pytest.raises(FollowedUsersLookupError, match="Unexpected follows response"):
             await get_followed_user_dids("did:plc:user1", limit=100)
+
+
+class TestFetchFollowedUserDidsCompleteness:
+    """``complete`` distinguishes an exhaustive walk from a truncated one.
+
+    The followed-users cache persists this: an entry built from an incomplete
+    fetch must never be treated as authoritative, or a single Bluesky blip
+    would pin a user to a truncated follow set for a whole TTL.
+    """
+
+    @pytest.mark.asyncio
+    async def test_complete_when_cursor_is_exhausted(self, fake_http_client):
+        fake_http_client.response = FakeResponse({
+            "follows": [{"did": "did:plc:follow1"}],
+        })
+
+        result = await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+        assert result == FollowsFetch(dids=["did:plc:follow1"], complete=True)
+
+    @pytest.mark.asyncio
+    async def test_complete_when_limit_cap_is_reached_with_cursor_remaining(
+        self,
+        fake_http_client,
+    ):
+        # Stopping at MAX_FOLLOWED_USERS is a deliberate bound, not a failure:
+        # the walk did everything it was asked to do.
+        page = [{"did": f"did:plc:follow{i}"} for i in range(100)]
+        fake_http_client.response = FakeResponse({"follows": page, "cursor": "more"})
+
+        result = await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+        assert result.complete is True
+        assert len(result.dids) == 100
+
+    @pytest.mark.asyncio
+    async def test_incomplete_when_a_later_page_fails(self, fake_http_client, monkeypatch):
+        async def fake_sleep(delay):
+            return None
+
+        monkeypatch.setattr(bsky_module.asyncio, "sleep", fake_sleep)
+        request = httpx.Request("GET", "https://example.test")
+        error_page = FakeResponse(
+            status_exc=httpx.HTTPStatusError(
+                "service unavailable",
+                request=request,
+                response=httpx.Response(503, request=request),
+            )
+        )
+        first_page = [{"did": f"did:plc:follow{i}"} for i in range(100)]
+        fake_http_client.responses = [
+            FakeResponse({"follows": first_page, "cursor": "next-page"}),
+            error_page,
+            error_page,
+        ]
+
+        result = await fetch_followed_user_dids("did:plc:user1", limit=200)
+
+        assert result.complete is False
+        assert len(result.dids) == 100
+
+    @pytest.mark.asyncio
+    async def test_incomplete_when_budget_expires(self, fake_http_client, monkeypatch):
+        class ExpiringTimeout:
+            def __init__(self, delay):
+                self.delay = delay
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                raise TimeoutError
+
+        monkeypatch.setattr(bsky_module.asyncio, "timeout", ExpiringTimeout)
+        fake_http_client.response = FakeResponse({"follows": [{"did": "did:plc:follow1"}]})
+
+        result = await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+        assert result == FollowsFetch(dids=["did:plc:follow1"], complete=False)
+
+    @pytest.mark.asyncio
+    async def test_empty_result_is_complete(self, fake_http_client):
+        # A user who follows nobody is a legitimate complete answer, not a
+        # cold entry to be refreshed on every request forever.
+        fake_http_client.response = FakeResponse({"follows": []})
+
+        result = await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+        assert result == FollowsFetch(dids=[], complete=True)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_nothing_could_be_fetched(self, fake_http_client):
+        fake_http_client.response = FakeResponse(json_exc=ValueError("bad json"))
+
+        with pytest.raises(FollowedUsersLookupError):
+            await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_budget_overrides_the_request_path_default(
+        self,
+        fake_http_client,
+        monkeypatch,
+    ):
+        # The background refresh is not on the request path, so it buys a
+        # bigger budget than the 1s clamp a feed request can afford.
+        budgets: list[float] = []
+
+        class RecordingTimeout:
+            def __init__(self, delay):
+                budgets.append(delay)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        monkeypatch.setattr(bsky_module.asyncio, "timeout", RecordingTimeout)
+        fake_http_client.response = FakeResponse({"follows": []})
+
+        await fetch_followed_user_dids("did:plc:user1", limit=100, timeout_seconds=15.0)
+        await fetch_followed_user_dids("did:plc:user1", limit=100)
+
+        assert budgets == [15.0, bsky_module.FOLLOWS_LOOKUP_TIMEOUT_SECONDS]
+
+    @pytest.mark.asyncio
+    async def test_get_followed_user_dids_still_returns_a_plain_list(self, fake_http_client):
+        fake_http_client.response = FakeResponse({"follows": [{"did": "did:plc:follow1"}]})
+
+        assert await get_followed_user_dids("did:plc:user1", limit=100) == ["did:plc:follow1"]

--- a/src/app/lib/candidates/followed_users.py
+++ b/src/app/lib/candidates/followed_users.py
@@ -7,15 +7,16 @@ that the requesting user follows.
 import logging
 
 from ...models import CandidatePost, MaxAgeHours
-from ..bsky import FollowedUsersLookupError, get_followed_user_dids
+from ..bsky import FollowedUsersLookupError
 from ..config import fail_fast
+from ..followed_users_cache import MAX_FOLLOWED_USERS, get_followed_dids_cached
 from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
 
 logger = logging.getLogger(__name__)
 
-MAX_FOLLOWED_USERS = 1_000
+__all__ = ["MAX_FOLLOWED_USERS", "FollowedUsersCandidateGenerator", "followed_users_search"]
 
 
 async def followed_users_search(
@@ -33,11 +34,8 @@ async def followed_users_search(
         filters.append({"term": {"contains_video": True}})
 
     try:
-        async with timed(logger, "bsky_get_follows", user_did=user_did):
-            followed_dids = await get_followed_user_dids(
-                user_did,
-                limit=MAX_FOLLOWED_USERS,
-            )
+        async with timed(logger, "follows_lookup", user_did=user_did):
+            followed_dids = await get_followed_dids_cached(user_did)
     except FollowedUsersLookupError as exc:
         logger.warning(
             "Skipping followed_users candidate generation for %s after follow "

--- a/src/app/lib/candidates/followed_users_test.py
+++ b/src/app/lib/candidates/followed_users_test.py
@@ -4,7 +4,6 @@ import pytest
 
 from ..candidates import followed_users as followed_users_module
 from ..candidates.followed_users import (
-    MAX_FOLLOWED_USERS,
     FollowedUsersCandidateGenerator,
     FollowedUsersLookupError,
     followed_users_search,
@@ -36,28 +35,27 @@ class FakeEs:
 
 
 def stub_followed_dids(monkeypatch, dids: list[str]):
-    async def fake_get_followed_user_dids(user_did: str, limit: int):
+    async def fake_get_followed_dids(user_did: str):
         return dids
 
     monkeypatch.setattr(
         followed_users_module,
-        "get_followed_user_dids",
-        fake_get_followed_user_dids,
+        "get_followed_dids_cached",
+        fake_get_followed_dids,
     )
 
 
 class TestFollowedUsersSearch:
     @pytest.mark.asyncio
     async def test_returns_candidates_scored(self, monkeypatch):
-        async def fake_get_followed_user_dids(user_did: str, limit: int):
+        async def fake_get_followed_dids(user_did: str):
             assert user_did == "did:plc:user1"
-            assert limit == MAX_FOLLOWED_USERS
             return ["did:plc:follow1", "did:plc:follow2"]
 
         monkeypatch.setattr(
             followed_users_module,
-            "get_followed_user_dids",
-            fake_get_followed_user_dids,
+            "get_followed_dids_cached",
+            fake_get_followed_dids,
         )
         es = FakeEs(responses={
             "posts_recent": {
@@ -201,13 +199,13 @@ class TestFollowedUsersSearch:
 
     @pytest.mark.asyncio
     async def test_lookup_errors_return_empty_and_skip_es(self, monkeypatch):
-        async def fake_get_followed_user_dids(user_did: str, limit: int):
+        async def fake_get_followed_dids(user_did: str):
             raise FollowedUsersLookupError("lookup exploded")
 
         monkeypatch.setattr(
             followed_users_module,
-            "get_followed_user_dids",
-            fake_get_followed_user_dids,
+            "get_followed_dids_cached",
+            fake_get_followed_dids,
         )
         es = FakeEs()
 

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -17,9 +17,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from ...models import CandidatePost, MaxAgeHours
-from ..bsky import FollowedUsersLookupError, get_followed_user_dids
+from ..bsky import FollowedUsersLookupError
 from ..config import fail_fast
 from ..elasticsearch import unwrap_es_response
+from ..followed_users_cache import MAX_FOLLOWED_USERS, get_followed_dids_cached
 from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
@@ -31,8 +32,9 @@ logger = logging.getLogger(__name__)
 # Parameters
 # ---------------------------------------------------------------------------
 
-# Maximum number of followed users to use in the query
-MAX_FOLLOWED_USERS = 1_000
+# Maximum number of followed users to use in the query is MAX_FOLLOWED_USERS,
+# imported from followed_users_cache so the fetch cap and the query cap cannot
+# drift apart.
 
 # Minimum number of recent likes to fetch in each page.
 LIKED_POSTS_PAGE_SIZE = 100
@@ -173,11 +175,8 @@ async def network_likes_search(
     """Fetch posts liked by users followed by user_did."""
 
     try:
-        async with timed(logger, "bsky_get_follows", user_did=user_did):
-            followed_dids: list[str] = await get_followed_user_dids(
-                user_did,
-                limit=MAX_FOLLOWED_USERS,
-            )
+        async with timed(logger, "follows_lookup", user_did=user_did):
+            followed_dids: list[str] = await get_followed_dids_cached(user_did)
     except FollowedUsersLookupError as exc:
         logger.warning(
             "Skipping network_likes candidate generation for %s after follow "

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -5,7 +5,6 @@ import pytest
 from .. import bsky as bsky_module
 from ..candidates import network_likes as network_likes_module
 from ..candidates.network_likes import (
-    MAX_FOLLOWED_USERS,
     NetworkLikesCandidateGenerator,
     fetch_posts_by_uris,
     fetch_recent_liked_post_uri_page,
@@ -120,15 +119,14 @@ class FakeEs:
 
 
 def stub_followed_dids(monkeypatch, dids: list[str]):
-    async def fake_get_followed_user_dids(user_did: str, limit: int):
+    async def fake_get_followed_dids(user_did: str):
         assert user_did == "did:plc:user1"
-        assert limit == MAX_FOLLOWED_USERS
         return dids
 
     monkeypatch.setattr(
         network_likes_module,
-        "get_followed_user_dids",
-        fake_get_followed_user_dids,
+        "get_followed_dids_cached",
+        fake_get_followed_dids,
     )
 
 
@@ -414,13 +412,13 @@ class TestNetworkLikesSearch:
 
     @pytest.mark.asyncio
     async def test_lookup_error_returns_empty_and_skips_es(self, monkeypatch):
-        async def fake_get_followed_user_dids(user_did: str, limit: int):
+        async def fake_get_followed_dids(user_did: str):
             raise bsky_module.FollowedUsersLookupError("lookup exploded")
 
         monkeypatch.setattr(
             network_likes_module,
-            "get_followed_user_dids",
-            fake_get_followed_user_dids,
+            "get_followed_dids_cached",
+            fake_get_followed_dids,
         )
         es = FakeEs()
 

--- a/src/app/lib/followed_users_cache.py
+++ b/src/app/lib/followed_users_cache.py
@@ -35,10 +35,15 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Awaitable, Callable
 
-from google.cloud.firestore import AsyncClient, async_transactional  # type: ignore[import-untyped]
+from google.cloud.firestore import (  # type: ignore[import-untyped]
+    AsyncClient,
+    FieldFilter,
+    async_transactional,
+)
 
 from .bsky import FollowedUsersLookupError, FollowsFetch, fetch_followed_user_dids
 from .metrics import get_metric_collector
@@ -67,6 +72,10 @@ MAX_PENDING_ADDS = 500
 # Age at which staleness is loud enough to alert on: refreshes have been
 # failing for long enough that jetstream cannot be the explanation either.
 STALE_ALERT_SECONDS = 86_400  # 24 hours
+
+# Single-flight key for the population sweep. A NUL byte cannot appear in a
+# Firestore document ID, so this can never collide with a user's key.
+_SWEEP_KEY = "\x00sweep"
 
 
 def _int_env(name: str, default: int) -> int:
@@ -104,6 +113,22 @@ def retry_cooldown_seconds() -> int:
     task on every single request.
     """
     return _int_env("GE_FOLLOWS_CACHE_RETRY_COOLDOWN_SEC", 60)
+
+
+def sweep_interval_seconds() -> int:
+    """How often one process samples population health (see ``_sweep``)."""
+    return _int_env("GE_FOLLOWS_CACHE_SWEEP_SEC", 300)
+
+
+# Rate-limits the population sweep per process. Module-level rather than
+# per-instance so it survives a cache being rebuilt in tests and scripts.
+_last_sweep_at: float | None = None
+
+
+def reset_sweep_clock() -> None:
+    """Forget when the last sweep ran (tests)."""
+    global _last_sweep_at
+    _last_sweep_at = None
 
 
 def user_doc_id(user_did: str) -> str:
@@ -162,6 +187,14 @@ class FollowedUsersCache:
         cached *and* the live walk fails — the same signal the generators
         already handle.
         """
+        try:
+            return await self._lookup(user_did)
+        finally:
+            # Deferred deliberately: the sweep is an aggregation over the whole
+            # collection and must never sit on the request path.
+            self._maybe_sweep()
+
+    async def _lookup(self, user_did: str) -> list[str]:
         key = user_doc_id(user_did)
 
         try:
@@ -179,13 +212,17 @@ class FollowedUsersCache:
             return fetch.dids
 
         follows = _merge(entry.follows, entry.pending_adds)
+        # Recorded for every served entry, fresh or not: a series containing
+        # only overdue entries says nothing about how fresh the healthy
+        # population is, and reads as alarming even when nothing is wrong.
+        self._note_age(entry, user_did)
+
         reason = self._staleness(entry)
         if reason is None:
             self._record("hit")
             return follows
 
         self._record(reason)
-        self._note_age(entry, user_did)
         self._spawn(key, self._refresh(key, user_did))
         return follows
 
@@ -355,7 +392,8 @@ class FollowedUsersCache:
                 await self._release(key, failed=True)
                 return
 
-            if not fetch.complete and not await self._may_overwrite(key):
+            previous = await self._read(key)
+            if not fetch.complete and previous is not None and previous.complete:
                 # A partial walk must never shrink a complete entry. Leave it
                 # stale so the next request tries again.
                 logger.info(
@@ -368,6 +406,7 @@ class FollowedUsersCache:
                 await self._release(key, failed=True)
                 return
 
+            self._note_drift(previous, fetch, user_did)
             await self._doc_ref(key).set(self._document(fetch))
             outcome = "success" if fetch.complete else "partial"
             logger.info(
@@ -384,10 +423,95 @@ class FollowedUsersCache:
             if mc := get_metric_collector():
                 mc.record("follows_cache.refresh_count", 1, outcome=outcome)
 
-    async def _may_overwrite(self, key: str) -> bool:
-        """True when the stored entry is absent or itself incomplete."""
-        entry = await self._read(key)
-        return entry is None or not entry.complete
+    def _note_drift(
+        self,
+        previous: "FollowedUsersCacheDocument | None",
+        fetch: FollowsFetch,
+        user_did: str,
+    ) -> None:
+        """Record how far the refreshed set moved from what we were serving.
+
+        This is the only correctness signal in the system. An entry that is
+        confidently ``complete`` but *wrong* — because jetstream deltas were
+        dropped and the TTL had not yet fired — is otherwise indistinguishable
+        from a correct one. In steady state churn per refresh sits near zero;
+        a rising delta at TTL boundaries means the live update path is not
+        doing its job.
+        """
+        if previous is None:
+            return  # Nothing was being served; there is no drift to speak of.
+        served = set(_merge(previous.follows, previous.pending_adds))
+        refreshed = set(fetch.dids)
+        added = len(refreshed - served)
+        removed = len(served - refreshed)
+        if mc := get_metric_collector():
+            mc.record("follows_cache.refresh_added", added)
+            mc.record("follows_cache.refresh_removed", removed)
+        if added or removed:
+            logger.info(
+                "Followed-users refresh for %s moved the set: +%d -%d",
+                user_did,
+                added,
+                removed,
+            )
+
+    def _maybe_sweep(self) -> None:
+        """Schedule a population sweep if one is due.
+
+        Rate-limited per process rather than coordinated across instances:
+        the aggregation is three counts over a small collection, and a handful
+        of instances reporting the same gauge is cheaper than a lease.
+        """
+        global _last_sweep_at
+        now = time.monotonic()
+        if _last_sweep_at is not None and now - _last_sweep_at < sweep_interval_seconds():
+            return
+        # Stamped before spawning so concurrent lookups don't stack sweeps.
+        _last_sweep_at = now
+        self._spawn(_SWEEP_KEY, self._sweep())
+
+    async def _sweep(self) -> None:
+        """Count the cached population by health and report it as gauges.
+
+        Lookup metrics are request-weighted, so one heavy user stuck
+        incomplete is indistinguishable from many users briefly incomplete.
+        These are the per-user counterparts, and they are what answers
+        "is follow state broadly correct, or degraded?".
+        """
+        try:
+            collection = self._db.collection(FOLLOWED_USERS_CACHE_COLLECTION)
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=ttl_seconds())
+            total = await self._count(collection.count())
+            incomplete = await self._count(
+                collection.where(filter=FieldFilter("complete", "==", False)).count()
+            )
+            stale = await self._count(
+                collection.where(filter=FieldFilter("generated_at", "<", cutoff)).count()
+            )
+        except Exception:
+            # Observability must never take the feature down with it.
+            logger.warning("Followed-users population sweep failed", exc_info=True)
+            return
+
+        if mc := get_metric_collector():
+            # endpoint/traffic are normally inherited from the request that
+            # spawned the task; pinned here so this gauge is one timeseries
+            # rather than one per endpoint that happened to trigger it.
+            labels = {"endpoint": "followed_users_sweep", "traffic": "internal"}
+            mc.record("follows_cache.users_rate", total, state="total", **labels)
+            mc.record("follows_cache.users_rate", incomplete, state="incomplete", **labels)
+            mc.record("follows_cache.users_rate", stale, state="stale", **labels)
+        logger.info(
+            "Followed-users population: total=%d incomplete=%d stale=%d",
+            total,
+            incomplete,
+            stale,
+        )
+
+    async def _count(self, aggregation) -> int:
+        """Unwrap a Firestore count() aggregation result."""
+        result = await aggregation.get()
+        return int(result[0][0].value)
 
     async def _release(self, key: str, *, failed: bool) -> None:
         """Drop the lease so the next request can retry immediately.

--- a/src/app/lib/followed_users_cache.py
+++ b/src/app/lib/followed_users_cache.py
@@ -1,0 +1,461 @@
+"""Per-user cache of Bluesky follow lists.
+
+Two candidate generators — ``followed_users`` and ``network_likes`` — need the
+set of accounts a user follows.  Before this cache each of them walked
+``app.bsky.graph.getFollows`` live on every feed request: up to ten sequential
+round-trips to ``public.api.bsky.app`` under a 1s budget, sitting in front of
+the Elasticsearch query, silently truncated when the budget expired, and
+yielding nothing at all when Bluesky hiccuped (see issue #83).
+
+Follows change rarely, so they are cached in Firestore — Firestore rather than
+Elasticsearch because Elasticsearch is the loaded resource the caching is meant
+to protect.  One document per user, holding a plain list of DIDs; a user's
+follow list is small enough that neither compression nor an in-process layer
+earns its keep, and per-user scoping means one person's unfollow invalidates
+only their own entry.
+
+Freshness comes from three places:
+
+1. **Jetstream** (``ingex``) appends newly-followed DIDs to ``pending_adds``
+   and stamps ``invalidated_at`` on an unfollow.  This is the primary
+   mechanism; the TTL below is the backstop for anything it misses.
+2. **A TTL refresh**, run in the background after a response has been served,
+   so no user request ever waits on Bluesky.
+3. **The completeness flag** — see :class:`~app.lib.bsky.FollowsFetch`.  A
+   truncated walk is still served, but is never trusted: it refreshes on every
+   read until one walk finishes, and it can never overwrite a complete entry.
+
+Every failure degrades to the pre-cache behaviour rather than breaking feed
+serving: a Firestore outage means a live Bluesky walk, and a Bluesky outage
+means the last known follow list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+from google.cloud.firestore import AsyncClient, async_transactional  # type: ignore[import-untyped]
+
+from .bsky import FollowedUsersLookupError, FollowsFetch, fetch_followed_user_dids
+from .metrics import get_metric_collector
+from .release import api_release_sha
+from .request_cache import get_request_cache
+
+if TYPE_CHECKING:
+    from ..documents import FollowedUsersCacheDocument
+
+logger = logging.getLogger(__name__)
+
+FOLLOWED_USERS_CACHE_COLLECTION = "followed_users_cache"
+
+# Cap on how many follows are fetched and stored. Consolidated from the two
+# copies that previously lived in the candidate generators.
+MAX_FOLLOWED_USERS = 1_000
+
+# How long an entry lives before native Firestore TTL reclaims it. Bounds the
+# collection to users who actually request feeds.
+RETENTION_DAYS = 30
+
+# Beyond this many un-folded jetstream deltas, refresh instead of merging on
+# every read. Keeps the array (and the read-time merge) bounded.
+MAX_PENDING_ADDS = 500
+
+# Age at which staleness is loud enough to alert on: refreshes have been
+# failing for long enough that jetstream cannot be the explanation either.
+STALE_ALERT_SECONDS = 86_400  # 24 hours
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except ValueError:
+        logger.warning("Invalid %s; using default %d", name, default)
+        return default
+
+
+def ttl_seconds() -> int:
+    """Age at which an entry is refreshed. A backstop under jetstream, so hours."""
+    return _int_env("GE_FOLLOWS_CACHE_TTL_SEC", 21_600)  # 6 hours
+
+
+def lease_seconds() -> int:
+    """Longest a refresh may hold the lease before another instance may retry."""
+    return _int_env("GE_FOLLOWS_CACHE_LEASE_SEC", 30)
+
+
+def refresh_timeout_seconds() -> float:
+    """Budget for a background walk.
+
+    Generous compared with the request-path clamp in ``bsky.py``: nothing is
+    waiting on it, and a walk that gives up early writes an incomplete entry
+    that has to be redone.
+    """
+    return float(_int_env("GE_FOLLOWS_REFRESH_TIMEOUT_SEC", 15))
+
+
+def retry_cooldown_seconds() -> int:
+    """Quiet period after a failed refresh.
+
+    Without it, a user whose follows cannot be fetched would spawn a refresh
+    task on every single request.
+    """
+    return _int_env("GE_FOLLOWS_CACHE_RETRY_COOLDOWN_SEC", 60)
+
+
+def user_doc_id(user_did: str) -> str:
+    """Firestore document ID for *user_did*.
+
+    Deferred rather than imported at module scope: ``lib.firestore`` imports
+    ``documents``, which pulls in the candidate generators, which import this
+    module.  Sharing the helper keeps this collection keyed exactly like
+    ``users``.
+    """
+    from .firestore import user_doc_id as _user_doc_id
+
+    return _user_doc_id(user_did)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Firestore may hand back naive datetimes; they are always UTC."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _age_seconds(value: datetime | None, now: datetime) -> float | None:
+    if value is None:
+        return None
+    return (now - _as_utc(value)).total_seconds()
+
+
+def _merge(follows: list[str], pending_adds: list[str]) -> list[str]:
+    """``follows`` then any jetstream additions, de-duplicated, order preserved."""
+    seen = set(follows)
+    merged = list(follows)
+    for did in pending_adds:
+        if did not in seen:
+            seen.add(did)
+            merged.append(did)
+    return merged
+
+
+class FollowedUsersCache:
+    """Firestore-backed store for per-user follow lists."""
+
+    def __init__(self, db: AsyncClient) -> None:
+        self._db = db
+        # In-flight refreshes, so one instance does not stack duplicate tasks
+        # for the same user while a refresh is already running.
+        self._refreshing: set[str] = set()
+        # Strong references keep background refreshes from being garbage
+        # collected mid-flight; the done callback drops them.
+        self._tasks: set[asyncio.Task] = set()
+
+    # -- public API --------------------------------------------------------
+
+    async def get_followed_dids(self, user_did: str) -> list[str]:
+        """Return the DIDs *user_did* follows, refreshing in the background if stale.
+
+        Raises :class:`FollowedUsersLookupError` only when there is nothing
+        cached *and* the live walk fails — the same signal the generators
+        already handle.
+        """
+        key = user_doc_id(user_did)
+
+        try:
+            entry = await self._read(key)
+        except Exception:
+            logger.exception("Failed to read followed-users cache for %s", user_did)
+            self._record("error")
+            return (await self._fetch(user_did)).dids
+
+        if entry is None:
+            # Cold: exactly the pre-cache path, under the request-path budget.
+            self._record("miss")
+            fetch = await self._fetch(user_did)
+            self._spawn(key, self._store_cold(key, user_did, fetch))
+            return fetch.dids
+
+        follows = _merge(entry.follows, entry.pending_adds)
+        reason = self._staleness(entry)
+        if reason is None:
+            self._record("hit")
+            return follows
+
+        self._record(reason)
+        self._note_age(entry, user_did)
+        self._spawn(key, self._refresh(key, user_did))
+        return follows
+
+    async def drain(self) -> None:
+        """Await in-flight background refreshes (shutdown and tests)."""
+        if self._tasks:
+            await asyncio.gather(*list(self._tasks), return_exceptions=True)
+
+    # -- internals ---------------------------------------------------------
+
+    def _doc_ref(self, key: str):
+        return self._db.collection(FOLLOWED_USERS_CACHE_COLLECTION).document(key)
+
+    async def _read(self, key: str) -> "FollowedUsersCacheDocument | None":
+        # Imported here (not at module top) to avoid an import cycle:
+        # documents -> candidates.base -> ... -> followed_users_cache -> documents.
+        from ..documents import FollowedUsersCacheDocument
+
+        snapshot = await self._doc_ref(key).get()
+        if not snapshot.exists:
+            return None
+        data = snapshot.to_dict()
+        if data is None:
+            return None
+        try:
+            entry = FollowedUsersCacheDocument.model_validate(data)
+        except Exception:
+            # An unreadable document is a miss, not an error: it will be
+            # overwritten by the next refresh.
+            logger.warning("Invalid followed-users cache document for key=%s", key)
+            return None
+        if entry.generated_at is None:
+            # No walk has ever populated this document — it holds only a lease
+            # or a failure stamp. Serving it would look exactly like "follows
+            # nobody" and silently drop the generator's allocation.
+            return None
+        return entry
+
+    def _staleness(self, entry: "FollowedUsersCacheDocument") -> str | None:
+        """Why *entry* needs refreshing, or ``None`` if it does not."""
+        if not entry.complete:
+            # However young: a truncated follow list must never be trusted.
+            return "incomplete"
+        if entry.invalidated_at is not None:
+            return "invalidated"
+        if len(entry.pending_adds) > MAX_PENDING_ADDS:
+            return "pending_overflow"
+        age = _age_seconds(entry.generated_at, datetime.now(timezone.utc))
+        if age is None or age > ttl_seconds():
+            return "stale"
+        return None
+
+    def _note_age(self, entry: "FollowedUsersCacheDocument", user_did: str) -> None:
+        age = _age_seconds(entry.generated_at, datetime.now(timezone.utc))
+        if age is None:
+            return
+        if mc := get_metric_collector():
+            mc.record("follows_cache.age_seconds", age)
+        if age >= STALE_ALERT_SECONDS:
+            logger.error(
+                "Followed-users cache for %s is %.0fs old (>= %ds); refreshes are not completing",
+                user_did,
+                age,
+                STALE_ALERT_SECONDS,
+            )
+
+    async def _fetch(self, user_did: str, timeout_seconds: float | None = None) -> FollowsFetch:
+        return await fetch_followed_user_dids(
+            user_did,
+            MAX_FOLLOWED_USERS,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def _document(self, fetch: FollowsFetch) -> dict:
+        from ..documents import FollowedUsersCacheDocument  # cycle; see _read
+
+        now = datetime.now(timezone.utc)
+        return FollowedUsersCacheDocument(
+            follows=fetch.dids,
+            complete=fetch.complete,
+            generated_at=now,
+            pending_adds=[],
+            invalidated_at=None,
+            refresh_started_at=None,
+            refresh_failed_at=None,
+            expires_at=now + timedelta(days=RETENTION_DAYS),
+            api_release_sha=api_release_sha(),
+        ).model_dump()
+
+    async def _store_cold(self, key: str, user_did: str, fetch: FollowsFetch) -> None:
+        """Persist a cold-path result after the response has gone out."""
+        try:
+            await self._doc_ref(key).set(self._document(fetch))
+        except Exception:
+            logger.exception("Failed to store followed-users cache for %s", user_did)
+            return
+        logger.info(
+            "Stored followed-users cache for %s follows=%d complete=%s",
+            user_did,
+            len(fetch.dids),
+            fetch.complete,
+        )
+
+    async def _claim(self, key: str) -> bool:
+        """Take the refresh lease for *key*, transactionally.
+
+        Returns ``False`` when another instance already refreshed the entry,
+        is refreshing it now under an unexpired lease, or failed so recently
+        that a retry would be pointless.
+        """
+        from ..documents import FollowedUsersCacheDocument  # cycle; see _read
+
+        ref = self._doc_ref(key)
+        lease = lease_seconds()
+        cooldown = retry_cooldown_seconds()
+
+        async def claim(transaction) -> bool:
+            now = datetime.now(timezone.utc)
+            snapshot = await ref.get(transaction=transaction)
+            data = snapshot.to_dict() if snapshot.exists else None
+            if data is not None:
+                try:
+                    entry = FollowedUsersCacheDocument.model_validate(data)
+                except Exception:
+                    # Unreadable: claim it and overwrite with a good one.
+                    entry = FollowedUsersCacheDocument()
+                else:
+                    if self._staleness(entry) is None:
+                        return False
+                started = _age_seconds(entry.refresh_started_at, now)
+                if started is not None and started < lease:
+                    return False
+                failed = _age_seconds(entry.refresh_failed_at, now)
+                if failed is not None and failed < cooldown:
+                    return False
+            transaction.set(ref, {"refresh_started_at": now}, merge=True)
+            return True
+
+        return await self._run_transaction(claim)
+
+    async def _run_transaction(self, body: Callable[..., Awaitable[bool]]) -> bool:
+        """Run *body* inside a Firestore transaction.
+
+        A seam: the SDK's transaction machinery is impractical to fake, so
+        tests substitute a plain transaction object here and exercise the
+        claim logic itself.
+        """
+        return await async_transactional(body)(self._db.transaction())
+
+    async def _refresh(self, key: str, user_did: str) -> None:
+        """Re-walk one user's follows, if this process wins the lease.
+
+        Runs detached from any request, so every failure is contained here:
+        the worst outcome is that the entry stays stale until the next request
+        tries again.
+        """
+        outcome = "error"
+        try:
+            if not await self._claim(key):
+                outcome = "skipped"
+                return
+            try:
+                fetch = await self._fetch(user_did, timeout_seconds=refresh_timeout_seconds())
+            except FollowedUsersLookupError:
+                logger.warning("Followed-users refresh for %s found nothing", user_did)
+                outcome = "failed"
+                await self._release(key, failed=True)
+                return
+
+            if not fetch.complete and not await self._may_overwrite(key):
+                # A partial walk must never shrink a complete entry. Leave it
+                # stale so the next request tries again.
+                logger.info(
+                    "Discarding partial followed-users refresh for %s (%d dids); "
+                    "keeping the complete entry",
+                    user_did,
+                    len(fetch.dids),
+                )
+                outcome = "partial_discarded"
+                await self._release(key, failed=True)
+                return
+
+            await self._doc_ref(key).set(self._document(fetch))
+            outcome = "success" if fetch.complete else "partial"
+            logger.info(
+                "Refreshed followed-users cache for %s follows=%d complete=%s",
+                user_did,
+                len(fetch.dids),
+                fetch.complete,
+            )
+        except Exception:
+            logger.exception("Followed-users cache refresh failed for %s", user_did)
+            await self._release(key, failed=True)
+        finally:
+            self._refreshing.discard(key)
+            if mc := get_metric_collector():
+                mc.record("follows_cache.refresh_count", 1, outcome=outcome)
+
+    async def _may_overwrite(self, key: str) -> bool:
+        """True when the stored entry is absent or itself incomplete."""
+        entry = await self._read(key)
+        return entry is None or not entry.complete
+
+    async def _release(self, key: str, *, failed: bool) -> None:
+        """Drop the lease so the next request can retry immediately.
+
+        The lease exists to exclude concurrent refreshes, not to impose a
+        penalty box; ``refresh_failed_at`` is what paces the retries.
+        """
+        update: dict = {"refresh_started_at": None}
+        if failed:
+            update["refresh_failed_at"] = datetime.now(timezone.utc)
+        try:
+            await self._doc_ref(key).set(update, merge=True)
+        except Exception:
+            # The lease expires on its own; nothing further to do.
+            logger.warning("Failed to release followed-users refresh lease for %s", key)
+
+    def _spawn(self, key: str, coro) -> None:
+        if key in self._refreshing:
+            coro.close()
+            return
+        self._refreshing.add(key)
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        task.add_done_callback(lambda _: self._refreshing.discard(key))
+
+    def _record(self, outcome: str) -> None:
+        if mc := get_metric_collector():
+            mc.record("follows_cache.lookup_count", 1, outcome=outcome)
+
+
+# ---------------------------------------------------------------------------
+# Process-level accessor
+#
+# Candidate generators are constructed at import time and their ``generate``
+# signature is fixed by the CandidateGenerator interface, so the cache is
+# reached the same way the metric collector and PostHog client are: a
+# process-level handle installed during app startup. When it is unset (unit
+# tests, scripts) callers fall through to a direct Bluesky walk.
+# ---------------------------------------------------------------------------
+
+_followed_users_cache: FollowedUsersCache | None = None
+
+
+def set_followed_users_cache(cache: FollowedUsersCache | None) -> None:
+    global _followed_users_cache
+    _followed_users_cache = cache
+
+
+def get_followed_users_cache() -> FollowedUsersCache | None:
+    return _followed_users_cache
+
+
+async def get_followed_dids_cached(user_did: str) -> list[str]:
+    """Followed DIDs for *user_did*, via the cache when one is installed.
+
+    Wrapped in the per-request cache so ``followed_users`` and
+    ``network_likes`` in the same feed request share one lookup instead of
+    each paying for a read.
+    """
+
+    async def lookup() -> list[str]:
+        cache = get_followed_users_cache()
+        if cache is None:
+            return (await fetch_followed_user_dids(user_did, MAX_FOLLOWED_USERS)).dids
+        return await cache.get_followed_dids(user_did)
+
+    request_cache = get_request_cache()
+    if request_cache is None:
+        return await lookup()
+    return await request_cache.get_or_compute(("followed_dids", user_did), lookup)

--- a/src/app/lib/followed_users_cache_test.py
+++ b/src/app/lib/followed_users_cache_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -58,12 +59,56 @@ class FakeDocRef:
             self._store["docs"][self._id] = dict(data)
 
 
+class FakeAggregation:
+    """Stands in for a Firestore count() aggregation query."""
+
+    def __init__(self, store: dict, predicate=None):
+        self._store = store
+        self._predicate = predicate
+
+    async def get(self):
+        docs = self._store["docs"].values()
+        if self._predicate is not None:
+            docs = [d for d in docs if self._predicate(d)]
+        return [[SimpleNamespace(value=len(list(docs)))]]
+
+
+class FakeQuery:
+    def __init__(self, store: dict, predicate):
+        self._store = store
+        self._predicate = predicate
+
+    def count(self) -> FakeAggregation:
+        return FakeAggregation(self._store, self._predicate)
+
+
+def _predicate_for(field_filter):
+    """Evaluate a real FieldFilter against a stored document dict."""
+    field, op, value = field_filter.field_path, field_filter.op_string, field_filter.value
+
+    def check(doc: dict) -> bool:
+        actual = doc.get(field)
+        if op == "==":
+            return actual == value
+        if op == "<":
+            return actual is not None and actual < value
+        raise AssertionError(f"unsupported op in fake: {op}")
+
+    return check
+
+
 class FakeCollection:
     def __init__(self, store: dict):
         self._store = store
 
     def document(self, doc_id: str) -> FakeDocRef:
         return self._store["refs"].setdefault(doc_id, FakeDocRef(self._store, doc_id))
+
+    def count(self) -> FakeAggregation:
+        return FakeAggregation(self._store)
+
+    def where(self, filter=None) -> FakeQuery:  # noqa: A002 - matches the SDK's kwarg
+        return FakeQuery(self._store, _predicate_for(filter))
 
 
 class FakeDb:
@@ -141,6 +186,37 @@ def origin(monkeypatch):
     fetcher = RecordingOrigin(FollowsFetch(dids=["did:plc:a"], complete=True))
     monkeypatch.setattr(cache_module, "fetch_followed_user_dids", fetcher)
     return fetcher
+
+
+class RecordingCollector:
+    def __init__(self):
+        self.records: list[tuple[str, float, dict]] = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+    def values(self, name: str) -> list[float]:
+        return [v for n, v, _ in self.records if n == name]
+
+    def labelled(self, name: str) -> dict[str, float]:
+        """Values for *name* keyed by their ``state`` label."""
+        return {a["state"]: v for n, v, a in self.records if n == name}
+
+
+@pytest.fixture
+def metrics(monkeypatch):
+    collector = RecordingCollector()
+    monkeypatch.setattr(cache_module, "get_metric_collector", lambda: collector)
+    return collector
+
+
+@pytest.fixture(autouse=True)
+def _reset_sweep_clock():
+    # The sweep is rate-limited per process; tests must not inherit each
+    # other's last-sweep timestamp.
+    cache_module.reset_sweep_clock()
+    yield
+    cache_module.reset_sweep_clock()
 
 
 @pytest.fixture(autouse=True)
@@ -494,3 +570,130 @@ class TestGetFollowedDidsCached:
         from .firestore import user_doc_id
 
         assert db.store["refs"][user_doc_id(USER)].read_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+class TestTelemetry:
+    @pytest.mark.asyncio
+    async def test_age_is_recorded_on_a_fresh_hit_too(self, origin, metrics):
+        # Recording age only when an entry is already stale makes the series
+        # structurally alarming: it would contain nothing but overdue entries,
+        # so the freshness of a healthy population is invisible.
+        db = FakeDb()
+        put(
+            db,
+            USER,
+            follows=["did:plc:a"],
+            complete=True,
+            generated_at=now() - timedelta(seconds=60),
+        )
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+
+        ages = metrics.values("follows_cache.age_seconds")
+        assert len(ages) == 1
+        assert 55 <= ages[0] <= 120
+
+    @pytest.mark.asyncio
+    async def test_refresh_records_how_much_the_follow_set_moved(self, origin, metrics):
+        # Churn per refresh is the only signal that distinguishes a cache that
+        # is confidently complete-but-wrong (jetstream deltas going missing)
+        # from one that is genuinely tracking Bluesky.
+        origin.results = [
+            FollowsFetch(dids=["did:plc:keep", "did:plc:added"], complete=True)
+        ]
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, USER, follows=["did:plc:keep", "did:plc:gone"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert metrics.values("follows_cache.refresh_added") == [1]
+        assert metrics.values("follows_cache.refresh_removed") == [1]
+
+    @pytest.mark.asyncio
+    async def test_steady_state_refresh_reports_no_churn(self, origin, metrics):
+        origin.results = [FollowsFetch(dids=["did:plc:a"], complete=True)]
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, USER, follows=["did:plc:a"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert metrics.values("follows_cache.refresh_added") == [0]
+        assert metrics.values("follows_cache.refresh_removed") == [0]
+
+    @pytest.mark.asyncio
+    async def test_population_sweep_counts_users_by_health(self, origin, metrics):
+        # Lookup metrics are request-weighted, so one heavy user stuck
+        # incomplete looks like many users briefly incomplete. This is the
+        # per-user view.
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, "did:plc:healthy1", follows=["a"], complete=True, generated_at=now())
+        put(db, "did:plc:healthy2", follows=["a"], complete=True, generated_at=now())
+        put(db, "did:plc:broken", follows=["a"], complete=False, generated_at=now())
+        put(db, "did:plc:overdue", follows=["a"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids("did:plc:healthy1")
+        await cache.drain()
+
+        assert metrics.labelled("follows_cache.users_rate") == {
+            "total": 4,
+            "incomplete": 1,
+            "stale": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_sweep_is_deferred_not_awaited_by_the_caller(self, origin, metrics):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:a"], complete=True, generated_at=now())
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+
+        # Nothing counted yet: the sweep must run after the response, not
+        # inside the request that triggered it.
+        assert metrics.labelled("follows_cache.users_rate") == {}
+        await cache.drain()
+        assert metrics.labelled("follows_cache.users_rate") != {}
+
+    @pytest.mark.asyncio
+    async def test_sweep_is_rate_limited_across_lookups(self, origin, metrics):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:a"], complete=True, generated_at=now())
+        cache = make_cache(db)
+
+        for _ in range(5):
+            await cache.get_followed_dids(USER)
+            await cache.drain()
+
+        # One aggregation pass per interval, not one per feed request.
+        assert metrics.values("follows_cache.users_rate").count(1.0) <= 3
+        assert len([v for n, v, a in metrics.records
+                    if n == "follows_cache.users_rate" and a["state"] == "total"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sweep_failure_never_breaks_a_lookup(self, origin, metrics):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:a"], complete=True, generated_at=now())
+        cache = make_cache(db)
+
+        async def boom():
+            raise RuntimeError("aggregation unavailable")
+
+        monkey = FakeCollection(db.store)
+        monkey.count = lambda: SimpleNamespace(get=boom)  # type: ignore[assignment]
+        db.collection = lambda name: monkey  # type: ignore[assignment]
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:a"]
+        await cache.drain()

--- a/src/app/lib/followed_users_cache_test.py
+++ b/src/app/lib/followed_users_cache_test.py
@@ -1,0 +1,496 @@
+"""Tests for the followed-users cache."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+
+from ..documents import FollowedUsersCacheDocument
+from . import followed_users_cache as cache_module
+from .bsky import FollowedUsersLookupError, FollowsFetch
+from .followed_users_cache import (
+    FOLLOWED_USERS_CACHE_COLLECTION,
+    FollowedUsersCache,
+    get_followed_dids_cached,
+    set_followed_users_cache,
+)
+from .request_cache import request_cache_scope
+
+
+# ---------------------------------------------------------------------------
+# A small stateful Firestore fake.  The cache reads, writes and runs a
+# transaction against the same document, so an in-memory store reads more
+# clearly here than a stack of mocks.
+# ---------------------------------------------------------------------------
+
+class FakeSnapshot:
+    def __init__(self, data: dict | None):
+        self._data = data
+
+    @property
+    def exists(self) -> bool:
+        return self._data is not None
+
+    def to_dict(self) -> dict | None:
+        return dict(self._data) if self._data is not None else None
+
+
+class FakeDocRef:
+    def __init__(self, store: dict, doc_id: str):
+        self._store = store
+        self._id = doc_id
+        self.read_count = 0
+
+    async def get(self, transaction=None) -> FakeSnapshot:
+        self.read_count += 1
+        if self._store.get("read_error"):
+            raise RuntimeError("firestore unavailable")
+        return FakeSnapshot(self._store["docs"].get(self._id))
+
+    async def set(self, data: dict, merge: bool = False) -> None:
+        if self._store.get("write_error"):
+            raise RuntimeError("firestore unavailable")
+        if merge and self._id in self._store["docs"]:
+            self._store["docs"][self._id].update(data)
+        else:
+            self._store["docs"][self._id] = dict(data)
+
+
+class FakeCollection:
+    def __init__(self, store: dict):
+        self._store = store
+
+    def document(self, doc_id: str) -> FakeDocRef:
+        return self._store["refs"].setdefault(doc_id, FakeDocRef(self._store, doc_id))
+
+
+class FakeDb:
+    def __init__(self):
+        self.store: dict = {"docs": {}, "refs": {}}
+        self.collections: list[str] = []
+
+    def collection(self, name: str) -> FakeCollection:
+        self.collections.append(name)
+        return FakeCollection(self.store)
+
+    def transaction(self):
+        return object()
+
+
+class FakeTransaction:
+    """Applies writes straight through; the seam under test is the claim logic."""
+
+    def __init__(self, store: dict):
+        self._store = store
+
+    def set(self, ref: FakeDocRef, data: dict, merge: bool = False) -> None:
+        doc_id = ref._id
+        if merge and doc_id in self._store["docs"]:
+            self._store["docs"][doc_id].update(data)
+        else:
+            self._store["docs"][doc_id] = dict(data)
+
+
+def make_cache(db: FakeDb) -> FollowedUsersCache:
+    """A cache whose transaction seam runs the claim body inline."""
+    cache = FollowedUsersCache(cast(Any, db))
+
+    async def run_transaction(body):
+        return await body(FakeTransaction(db.store))
+
+    cache._run_transaction = run_transaction  # type: ignore[method-assign]
+    return cache
+
+
+def now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def put(db: FakeDb, user_did: str, **fields) -> None:
+    from .firestore import user_doc_id
+
+    doc = FollowedUsersCacheDocument(**fields)
+    db.store["docs"][user_doc_id(user_did)] = doc.model_dump()
+
+
+def stored(db: FakeDb, user_did: str) -> FollowedUsersCacheDocument:
+    from .firestore import user_doc_id
+
+    return FollowedUsersCacheDocument.model_validate(db.store["docs"][user_doc_id(user_did)])
+
+
+class RecordingOrigin:
+    """Stands in for the Bluesky walk."""
+
+    def __init__(self, *results):
+        self.results = list(results)
+        self.calls: list[tuple[str, float | None]] = []
+
+    async def __call__(self, user_did, limit, timeout_seconds=None):
+        self.calls.append((user_did, timeout_seconds))
+        result = self.results.pop(0) if len(self.results) > 1 else self.results[0]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+@pytest.fixture
+def origin(monkeypatch):
+    fetcher = RecordingOrigin(FollowsFetch(dids=["did:plc:a"], complete=True))
+    monkeypatch.setattr(cache_module, "fetch_followed_user_dids", fetcher)
+    return fetcher
+
+
+@pytest.fixture(autouse=True)
+def _clear_process_cache():
+    set_followed_users_cache(None)
+    yield
+    set_followed_users_cache(None)
+
+
+USER = "did:plc:user1"
+
+
+# ---------------------------------------------------------------------------
+# Read path
+# ---------------------------------------------------------------------------
+
+class TestReadPath:
+    @pytest.mark.asyncio
+    async def test_fresh_complete_entry_is_served_without_touching_bluesky(self, origin):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:a", "did:plc:b"], complete=True, generated_at=now())
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:a", "did:plc:b"]
+        assert origin.calls == []
+        assert db.collections == [FOLLOWED_USERS_CACHE_COLLECTION]
+
+    @pytest.mark.asyncio
+    async def test_pending_adds_are_merged_in_read_order_without_duplicates(self, origin):
+        db = FakeDb()
+        put(
+            db,
+            USER,
+            follows=["did:plc:a", "did:plc:b"],
+            pending_adds=["did:plc:c", "did:plc:a"],
+            complete=True,
+            generated_at=now(),
+        )
+        cache = make_cache(db)
+
+        # A jetstream follow shows up immediately, before any refresh runs.
+        assert await cache.get_followed_dids(USER) == [
+            "did:plc:a",
+            "did:plc:b",
+            "did:plc:c",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stale_entry_is_served_immediately_and_refreshed_in_background(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, USER, follows=["did:plc:stale"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        # The caller is never made to wait on the refresh.
+        assert await cache.get_followed_dids(USER) == ["did:plc:stale"]
+        await cache.drain()
+
+        assert origin.calls == [(USER, cache_module.refresh_timeout_seconds())]
+        assert stored(db, USER).follows == ["did:plc:a"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_entry_refreshes_however_young_it_is(self, origin):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:partial"], complete=False, generated_at=now())
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:partial"]
+        await cache.drain()
+
+        assert len(origin.calls) == 1
+        assert stored(db, USER).complete is True
+
+    @pytest.mark.asyncio
+    async def test_invalidated_entry_refreshes(self, origin):
+        db = FakeDb()
+        put(
+            db,
+            USER,
+            follows=["did:plc:x"],
+            complete=True,
+            generated_at=now(),
+            invalidated_at=now(),
+        )
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:x"]
+        await cache.drain()
+
+        assert len(origin.calls) == 1
+        assert stored(db, USER).invalidated_at is None
+
+    @pytest.mark.asyncio
+    async def test_overfull_pending_adds_forces_a_refresh(self, origin):
+        db = FakeDb()
+        pending = [f"did:plc:p{i}" for i in range(cache_module.MAX_PENDING_ADDS + 1)]
+        put(db, USER, follows=[], complete=True, generated_at=now(), pending_adds=pending)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert len(origin.calls) == 1
+        assert stored(db, USER).pending_adds == []
+
+
+class TestColdStart:
+    @pytest.mark.asyncio
+    async def test_missing_document_fetches_on_the_request_path_and_stores(self, origin):
+        db = FakeDb()
+        cache = make_cache(db)
+
+        # No entry: behave exactly as the pre-cache code did, under the tight
+        # request-path budget rather than the refresh budget.
+        assert await cache.get_followed_dids(USER) == ["did:plc:a"]
+        assert origin.calls == [(USER, None)]
+
+        await cache.drain()
+        entry = stored(db, USER)
+        assert entry.follows == ["did:plc:a"]
+        assert entry.complete is True
+        assert entry.expires_at is not None
+
+    @pytest.mark.asyncio
+    async def test_partial_cold_fetch_is_stored_as_incomplete(self, origin):
+        origin.results = [FollowsFetch(dids=["did:plc:a"], complete=False)]
+        db = FakeDb()
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:a"]
+        await cache.drain()
+
+        # Serving it is fine; trusting it is not.
+        assert stored(db, USER).complete is False
+
+    @pytest.mark.asyncio
+    async def test_lease_only_document_is_treated_as_a_miss(self, origin):
+        # A refresh can stamp the lease onto a document that holds no follows
+        # yet (TTL reaped it, or a refresh died before writing). Validating
+        # that as an entry would serve an empty follow list — indistinguishable
+        # from "follows nobody" — and silently drop the generator's allocation.
+        db = FakeDb()
+        db.store["docs"][cache_module.user_doc_id(USER)] = {
+            "refresh_started_at": now(),
+        }
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:a"]
+        assert origin.calls == [(USER, None)]
+
+    @pytest.mark.asyncio
+    async def test_raises_when_nothing_cached_and_bluesky_fails(self, origin):
+        origin.results = [FollowedUsersLookupError("boom")]
+        db = FakeDb()
+        cache = make_cache(db)
+
+        with pytest.raises(FollowedUsersLookupError):
+            await cache.get_followed_dids(USER)
+
+    @pytest.mark.asyncio
+    async def test_firestore_read_failure_degrades_to_a_live_fetch(self, origin):
+        db = FakeDb()
+        db.store["read_error"] = True
+        cache = make_cache(db)
+
+        # A cache that is down must not break feed serving.
+        assert await cache.get_followed_dids(USER) == ["did:plc:a"]
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_partial_refresh_never_shrinks_a_complete_entry(self, origin):
+        origin.results = [FollowsFetch(dids=["did:plc:a"], complete=False)]
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        full = [f"did:plc:f{i}" for i in range(50)]
+        put(db, USER, follows=full, complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        entry = stored(db, USER)
+        assert entry.follows == full
+        assert entry.complete is True
+
+    @pytest.mark.asyncio
+    async def test_partial_refresh_replaces_an_incomplete_entry(self, origin):
+        origin.results = [FollowsFetch(dids=["did:plc:a", "did:plc:b"], complete=False)]
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:old"], complete=False, generated_at=now())
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert stored(db, USER).follows == ["did:plc:a", "did:plc:b"]
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_clears_the_lease_and_stamps_the_cooldown(self, origin):
+        origin.results = [FollowedUsersLookupError("boom")]
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, USER, follows=["did:plc:x"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        entry = stored(db, USER)
+        # The lease is for excluding concurrent refreshes, not a penalty box:
+        # the next request must be free to retry at once.
+        assert entry.refresh_started_at is None
+        assert entry.refresh_failed_at is not None
+        assert entry.follows == ["did:plc:x"]
+
+    @pytest.mark.asyncio
+    async def test_recent_failure_suppresses_another_refresh(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(
+            db,
+            USER,
+            follows=["did:plc:x"],
+            complete=True,
+            generated_at=old,
+            refresh_failed_at=now(),
+        )
+        cache = make_cache(db)
+
+        assert await cache.get_followed_dids(USER) == ["did:plc:x"]
+        await cache.drain()
+
+        assert origin.calls == []
+
+    @pytest.mark.asyncio
+    async def test_expired_cooldown_allows_a_retry(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(
+            db,
+            USER,
+            follows=["did:plc:x"],
+            complete=True,
+            generated_at=old,
+            refresh_failed_at=now()
+            - timedelta(seconds=cache_module.retry_cooldown_seconds() + 5),
+        )
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert len(origin.calls) == 1
+
+
+class TestLease:
+    @pytest.mark.asyncio
+    async def test_unexpired_lease_from_another_instance_blocks_the_claim(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(
+            db,
+            USER,
+            follows=["did:plc:x"],
+            complete=True,
+            generated_at=old,
+            refresh_started_at=now(),
+        )
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert origin.calls == []
+
+    @pytest.mark.asyncio
+    async def test_expired_lease_is_reclaimed(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(
+            db,
+            USER,
+            follows=["did:plc:x"],
+            complete=True,
+            generated_at=old,
+            refresh_started_at=now() - timedelta(seconds=cache_module.lease_seconds() + 5),
+        )
+        cache = make_cache(db)
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert len(origin.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_entry_refreshed_by_another_instance_is_not_refreshed_again(self, origin):
+        db = FakeDb()
+        old = now() - timedelta(seconds=cache_module.ttl_seconds() + 60)
+        put(db, USER, follows=["did:plc:x"], complete=True, generated_at=old)
+        cache = make_cache(db)
+
+        async def refreshed_meanwhile(body):
+            put(db, USER, follows=["did:plc:new"], complete=True, generated_at=now())
+            return await body(FakeTransaction(db.store))
+
+        cache._run_transaction = refreshed_meanwhile  # type: ignore[method-assign]
+
+        await cache.get_followed_dids(USER)
+        await cache.drain()
+
+        assert origin.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Module-level accessor used by the candidate generators
+# ---------------------------------------------------------------------------
+
+class TestGetFollowedDidsCached:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_a_direct_fetch_when_no_cache_is_installed(self, origin):
+        # Unit tests and scripts run without a Firestore client.
+        assert await get_followed_dids_cached(USER) == ["did:plc:a"]
+        assert origin.calls == [(USER, None)]
+
+    @pytest.mark.asyncio
+    async def test_uses_the_installed_cache(self, origin):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:cached"], complete=True, generated_at=now())
+        set_followed_users_cache(make_cache(db))
+
+        assert await get_followed_dids_cached(USER) == ["did:plc:cached"]
+        assert origin.calls == []
+
+    @pytest.mark.asyncio
+    async def test_both_generators_in_one_request_share_a_single_lookup(self, origin):
+        db = FakeDb()
+        put(db, USER, follows=["did:plc:cached"], complete=True, generated_at=now())
+        set_followed_users_cache(make_cache(db))
+
+        async with request_cache_scope():
+            first = await get_followed_dids_cached(USER)
+            second = await get_followed_dids_cached(USER)
+
+        assert first == second == ["did:plc:cached"]
+        # followed_users and network_likes must not each pay for a read.
+        from .firestore import user_doc_id
+
+        assert db.store["refs"][user_doc_id(USER)].read_count == 1

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -45,6 +45,7 @@ from .lib.es_client import SlowQueryLoggingES
 from .lib.eventloop_monitor import start_eventloop_monitor, stop_eventloop_monitor
 from .lib.candidates.popularity_cache import PopularityCache, set_popularity_cache
 from .lib.feed_cache import FirestoreFeedCache
+from .lib.followed_users_cache import FollowedUsersCache, set_followed_users_cache
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
 from .lib.perspective import close_perspective_client
@@ -148,6 +149,8 @@ async def lifespan(app: FastAPI):
     app.state.feed_cache = FirestoreFeedCache(app.state.firestore)
     app.state.popularity_cache = PopularityCache(app.state.firestore)
     set_popularity_cache(app.state.popularity_cache)
+    app.state.followed_users_cache = FollowedUsersCache(app.state.firestore)
+    set_followed_users_cache(app.state.followed_users_cache)
     try:
         init_firebase_auth()
     except Exception:
@@ -163,6 +166,11 @@ async def lifespan(app: FastAPI):
         set_popularity_cache(None)
         try:
             await app.state.popularity_cache.drain()
+        except Exception:
+            pass
+        set_followed_users_cache(None)
+        try:
+            await app.state.followed_users_cache.drain()
         except Exception:
             pass
         try:


### PR DESCRIPTION
Closes #83

The `followed_users` and `network_likes` candidate generators each walked `app.bsky.graph.getFollows` live on every feed request — up to ten sequential round-trips to `public.api.bsky.app` under a 1s budget, in front of the Elasticsearch query. When the budget expired the walk was silently truncated; when Bluesky hiccuped the generator returned `[]` and lost its whole allocation.

Follows change rarely, so they are now cached in Firestore (not Elasticsearch — ES is the loaded resource the caching is meant to protect). One document per user holding a plain list of DIDs.

# This PR

- Adds `lib/followed_users_cache.py`: read the entry, serve it, and refresh in the background under a transactional lease. No user request ever waits on Bluesky.
- Adds `FollowsFetch(dids, complete)` to `lib/bsky.py`. `complete` is true only when the cursor was exhausted or the 1000 cap was reached — not when a page failed or the budget expired. `get_followed_user_dids` still returns a plain list, so its existing callers and tests are unchanged.
- Persists that flag on the document. An incomplete entry is **always** stale however young, is still served, and refreshes on every read until one walk finishes. A partial refresh may never overwrite a complete entry, and a failed refresh clears the lease immediately (with a 60s cooldown) so the next request can retry at once.
- Migrates both call sites; consolidates the two duplicated `MAX_FOLLOWED_USERS` constants. Within one request the two generators share a lookup via the existing `RequestCache`.
- Merges `pending_adds` (written by jetstream, greenearth-social/ingex#455) at read time, so a new follow shows up before any refresh runs.
- Degrades to the pre-cache path everywhere: Firestore down means a live walk, Bluesky down means the last known follow list.

No in-process layer and no compression, deliberately — unlike `popularity_cache`, one small document per user is read about once per that user's request, so a local copy buys little and adds a second staleness window that can mask a jetstream delta.

Pairs with greenearth-social/frontend#73 (index exemption + TTL policy) and greenearth-social/ingex#455 (jetstream deltas). Neither blocks this one; deploy order is frontend → api → ingex.

# Testing

- `pipenv run pyright` clean; `pipenv run pytest -v` 1274 passed (30 new).
- devenv, `followed-users` feed: first render logged a 984ms live walk and stored 498 follows with `complete=True`; second render logged **3.7ms** and no Bluesky traffic.
- Inspected the emulator document: plain readable DIDs, `complete=true`, `expires_at` 30 days out.
- Cross-repo loop against the real emulator: the ingex Go writer appended a DID via `ArrayUnion`, and this cache served 499 follows with the new DID merged in; a `invalidated_at` stamp was then served stale (499) while the background refresh re-walked Bluesky, wrote 498, and cleared `invalidated_at`, `pending_adds` and the lease.
- No tracebacks in the api container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Telemetry (follow-up commit)

The first cut measured availability but not correctness. Added:

- **`follows_cache.age_seconds` now records on every served entry**, not only stale ones. As it stood the series contained nothing but overdue entries, so the freshness of a healthy population was invisible and the average read as alarming even when nothing was wrong.
- **`follows_cache.refresh_added` / `refresh_removed`** — how far each refresh moved the set from what was being served. This is the only correctness signal in the system: an entry that is confidently `complete` but *wrong*, because jetstream deltas were dropped and the TTL hadn't fired, is otherwise indistinguishable from a correct one. Steady state is near-zero churn; a rising delta at TTL boundaries means the live update path isn't working.
- **`follows_cache.users_rate{state=total|incomplete|stale}`** — a per-user population gauge. The lookup counters are request-weighted, so one heavy user stuck incomplete looks identical to many users briefly incomplete; this is the view that answers "is follow state broadly correct or degraded?". It runs as a **deferred task after the response is returned** — three Firestore count aggregations, never on the request path — rate-limited to one pass per `GE_FOLLOWS_CACHE_SWEEP_SEC` (default 300) per process, and a sweep failure can never affect a lookup.

Suggested alert shape: `users_rate{state="incomplete"} / users_rate{state="total"}` sustained above a few percent, and `refresh_count{outcome=~"failed|error|partial_discarded"}` non-zero over a window.

Paired with the writer counters in greenearth-social/ingex#456 — without those, a Firestore rejecting writes would leave this side looking perfectly healthy while its entries silently went stale.

Verified: 1315 tests pass (7 new). The population sweep was exercised against the real Firestore emulator with a deliberately mixed population (total=4, incomplete=1, stale=1), since the aggregation-query result shape is exactly what a fake can get wrong; and the deferred hook was confirmed firing from a live feed render, once, then rate-limited.
