### PR TITLE
Add production usage instructions for apikeys.py

### DIFF
--- a/scripts/apikeys.py
+++ b/scripts/apikeys.py
@@ -8,7 +8,14 @@ Run from the api/ directory:
     pipenv run python scripts/apikeys.py usage a1b2c3d4
 
 Reads Firestore connection from the same env vars as the API server:
-    GE_FIRESTORE_PROJECT, GE_FIRESTORE_DATABASE, GE_FIRESTORE_EMULATOR_HOST
+    GE_FIRESTORE_PROJECT      GCP project ID (default: greenearth-471522)
+    GE_FIRESTORE_DATABASE     Firestore database ID (default: "(default)")
+    GE_FIRESTORE_EMULATOR_HOST  Set for local emulator; leave unset for prod
+
+Production database is "greenearth-prod" — always pass it explicitly to avoid
+writing to the wrong database:
+    GE_FIRESTORE_PROJECT=greenearth-471522 GE_FIRESTORE_DATABASE=greenearth-prod \
+        pipenv run python scripts/apikeys.py generate someone@example.com
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Expands the `scripts/apikeys.py` docstring to document each Firestore env var with its default value
- Adds the exact command to run when issuing keys against the production `greenearth-prod` database, preventing accidental writes to the wrong database

## Motivation

I let my LLM execute the API-issuing script, and it set the firestore database env incorrectly, which ended up giving me the non-working API.

<img width="852" height="391" alt="Screenshot 2026-08-11 at 11 38 20 AM" src="https://github.com/user-attachments/assets/6c6bbd58-ff91-457d-92ff-f8624c836d92" />
