### PR TITLE
Gate event-loop lag sampling on in-flight requests

### DIFF
--- a/src/app/lib/eventloop_monitor.py
+++ b/src/app/lib/eventloop_monitor.py
@@ -5,6 +5,16 @@ deadline it actually woke up. Under a healthy loop the overshoot is ~0-2 ms;
 when coroutines or sync work monopolize the loop, every pending callback —
 including responses already received from ES/inference/Perspective — waits
 this long to run. See issue #343 for the attribution design.
+
+Samples are only recorded for intervals during which a request was in flight
+the whole time. Cloud Run runs this service with ``cpuIdle: true``, so an idle
+instance is CPU-throttled and this task's own wakeups are delayed by hundreds
+of milliseconds to seconds — throttling that no request ever experienced. Left
+ungated the metric reports that as loop lag: prod p99 was ~800 ms and p99.9
+~4.7 s while p50 sat at a healthy 1.5 ms, with the distribution splitting into
+two modes (74% under 3 ms, a second population from 25 ms up) that tracked
+instance idleness rather than load — flat across a 10x traffic swing. See
+issue #389.
 """
 
 from __future__ import annotations
@@ -12,6 +22,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+
+from . import inflight
 
 
 def get_metric_collector():
@@ -25,9 +37,12 @@ DEFAULT_INTERVAL_SEC = 0.25
 
 async def _monitor_loop(interval_sec: float) -> None:
     while True:
+        snap = inflight.snapshot()
         target = time.monotonic() + interval_sec
         await asyncio.sleep(interval_sec)
         lag_ms = max(0.0, (time.monotonic() - target) * 1000)
+        if not inflight.busy_throughout(snap):
+            continue
         collector = get_metric_collector()
         if collector is not None:
             collector.record("eventloop.lag_ms", lag_ms)

--- a/src/app/lib/eventloop_monitor_test.py
+++ b/src/app/lib/eventloop_monitor_test.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from app.lib import eventloop_monitor
+from app.lib import eventloop_monitor, inflight
 
 
 class _RecordingCollector:
@@ -13,11 +13,23 @@ class _RecordingCollector:
         self.records.append((name, value, attrs))
 
 
+@pytest.fixture(autouse=True)
+def _reset_inflight():
+    inflight.reset_for_test()
+    yield
+    inflight.reset_for_test()
+
+
+def _lags(collector):
+    return [v for n, v, _ in collector.records if n == "eventloop.lag_ms"]
+
+
 @pytest.mark.asyncio
-async def test_monitor_records_lag_samples(monkeypatch):
+async def test_monitor_records_lag_samples_while_requests_in_flight(monkeypatch):
     collector = _RecordingCollector()
     monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
 
+    inflight.begin()
     task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
     await asyncio.sleep(0.08)
     await eventloop_monitor.stop_eventloop_monitor(task)
@@ -30,10 +42,41 @@ async def test_monitor_records_lag_samples(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_monitor_records_nothing_while_idle(monkeypatch):
+    """On Cloud Run with cpuIdle=true an idle instance is CPU-throttled, so a
+    sample taken with no request in flight measures throttling, not loop lag."""
+    collector = _RecordingCollector()
+    monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
+
+    task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
+    await asyncio.sleep(0.08)
+    await eventloop_monitor.stop_eventloop_monitor(task)
+
+    assert _lags(collector) == []
+
+
+@pytest.mark.asyncio
+async def test_monitor_skips_interval_that_straddles_idle(monkeypatch):
+    """A window that began idle is partly throttled time and must be dropped."""
+    collector = _RecordingCollector()
+    monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
+
+    task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.05)
+    await asyncio.sleep(0.01)
+    inflight.begin()  # arrives mid-window
+    await asyncio.sleep(0.06)
+    await eventloop_monitor.stop_eventloop_monitor(task)
+
+    # The straddling window is skipped; only fully-busy windows may record.
+    assert len(_lags(collector)) <= 1
+
+
+@pytest.mark.asyncio
 async def test_monitor_measures_overshoot(monkeypatch):
     collector = _RecordingCollector()
     monkeypatch.setattr(eventloop_monitor, "get_metric_collector", lambda: collector)
 
+    inflight.begin()
     task = eventloop_monitor.start_eventloop_monitor(interval_sec=0.01)
     # Block the loop synchronously for ~50ms; the next sample must see it.
     await asyncio.sleep(0.02)
@@ -42,8 +85,7 @@ async def test_monitor_measures_overshoot(monkeypatch):
     await asyncio.sleep(0.02)
     await eventloop_monitor.stop_eventloop_monitor(task)
 
-    lags = [v for n, v, _ in collector.records if n == "eventloop.lag_ms"]
-    assert max(lags) >= 30  # ms — blocked well past the 10ms interval
+    assert max(_lags(collector)) >= 30  # ms — blocked well past the 10ms interval
 
 
 @pytest.mark.asyncio

--- a/src/app/lib/inflight.py
+++ b/src/app/lib/inflight.py
@@ -1,0 +1,64 @@
+"""Process-wide in-flight HTTP request tracking.
+
+Cloud Run runs this service with ``cpuIdle: true``, which throttles the
+container's CPU to near zero whenever no request is being handled. Any
+background task that keeps running while the instance is idle — notably the
+event-loop lag monitor — is descheduled for as long as the throttle lasts,
+and cannot tell that apart from the event loop being blocked by real work.
+
+This module provides the "was CPU allocated for the whole of this window?"
+predicate that lets such a task discard contaminated samples. A window only
+counts as busy if a request was in flight at both ends *and* the count never
+touched zero in between; ``idle_epoch`` increments on every drop to zero, so
+a window that dipped idle mid-flight is detectable even though the count is
+non-zero again by the time it is checked.
+
+Not thread-safe by design: a single uvicorn worker runs one event loop, and
+every mutation here happens on that loop thread.
+"""
+
+from __future__ import annotations
+
+_in_flight = 0
+_idle_epoch = 0
+
+Snapshot = tuple[int, int]
+
+
+def begin() -> int:
+    """Record a request entering the service. Returns the new in-flight count."""
+    global _in_flight
+    _in_flight += 1
+    return _in_flight
+
+
+def end() -> int:
+    """Record a request leaving the service. Returns the new in-flight count."""
+    global _in_flight, _idle_epoch
+    if _in_flight <= 0:
+        return 0
+    _in_flight -= 1
+    if _in_flight == 0:
+        _idle_epoch += 1
+    return _in_flight
+
+
+def current() -> int:
+    return _in_flight
+
+
+def snapshot() -> Snapshot:
+    """Opaque marker for the start of a measurement window."""
+    return (_in_flight, _idle_epoch)
+
+
+def busy_throughout(snap: Snapshot) -> bool:
+    """True if a request was in flight continuously since *snap* was taken."""
+    in_flight_at_start, epoch_at_start = snap
+    return in_flight_at_start > 0 and _in_flight > 0 and _idle_epoch == epoch_at_start
+
+
+def reset_for_test() -> None:
+    global _in_flight, _idle_epoch
+    _in_flight = 0
+    _idle_epoch = 0

--- a/src/app/lib/inflight_test.py
+++ b/src/app/lib/inflight_test.py
@@ -1,0 +1,64 @@
+import pytest
+
+from app.lib import inflight
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    inflight.reset_for_test()
+    yield
+    inflight.reset_for_test()
+
+
+def test_starts_idle():
+    assert inflight.current() == 0
+    assert not inflight.busy_throughout(inflight.snapshot())
+
+
+def test_begin_marks_process_busy():
+    inflight.begin()
+    assert inflight.current() == 1
+    assert inflight.busy_throughout(inflight.snapshot())
+
+
+def test_busy_throughout_false_when_snapshot_taken_while_idle():
+    snap = inflight.snapshot()
+    inflight.begin()
+    # A request that arrived *after* the snapshot does not make the preceding
+    # window busy — part of it was still idle (and therefore CPU-throttled).
+    assert not inflight.busy_throughout(snap)
+
+
+def test_busy_throughout_false_when_process_went_idle_mid_window():
+    inflight.begin()
+    snap = inflight.snapshot()
+    inflight.end()
+    inflight.begin()
+    # Busy at both ends of the window, but idle in between: the sample is
+    # contaminated by throttled time and must not be recorded.
+    assert inflight.current() == 1
+    assert not inflight.busy_throughout(snap)
+
+
+def test_busy_throughout_true_across_overlapping_requests():
+    inflight.begin()
+    snap = inflight.snapshot()
+    inflight.begin()
+    inflight.end()
+    # Never dropped to zero, so the whole window had CPU allocated.
+    assert inflight.current() == 1
+    assert inflight.busy_throughout(snap)
+
+
+def test_end_without_begin_does_not_go_negative():
+    inflight.end()
+    assert inflight.current() == 0
+
+
+def test_counter_returns_to_zero_and_bumps_idle_epoch():
+    _, epoch_before = inflight.snapshot()
+    inflight.begin()
+    inflight.end()
+    _, epoch_after = inflight.snapshot()
+    assert inflight.current() == 0
+    assert epoch_after == epoch_before + 1

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -49,7 +49,8 @@ from .lib.followed_users_cache import FollowedUsersCache, set_followed_users_cac
 from .lib.firestore import init_firestore_client
 from .lib.http_client import close_http_client, init_http_client
 from .lib.perspective import close_perspective_client
-from .lib.metrics import MetricCollector, set_metric_collector
+from .lib import inflight
+from .lib.metrics import MetricCollector, get_metric_collector, set_metric_collector
 from .lib.posthog_client import get_posthog_client, init_posthog_client, set_posthog_client
 from .lib.profiling import install_profiling
 from .lib.request_context import (
@@ -378,6 +379,30 @@ async def request_id_mw(request: Request, call_next):
             reset_endpoint(endpoint_token)
     response.headers["x-request-id"] = rid
     return response
+
+
+# Registered last so it is the outermost middleware: the in-flight window has
+# to enclose everything else on the request path, or the event-loop monitor
+# will see intervals that are only partly covered by a request and discard
+# samples it should have kept.
+@app.middleware("http")
+async def inflight_mw(request: Request, call_next):
+    """Track concurrent in-flight requests for the whole process.
+
+    Gates the event-loop lag monitor (see ``lib/eventloop_monitor.py``): a
+    CPU-throttled idle instance must not contribute samples. ``http.in_flight``
+    is also the per-instance concurrency signal for right-sizing Cloud Run's
+    ``--concurrency``, which Cloud Run's own ``max_request_concurrencies``
+    only reports as a coarse per-minute maximum (issue #389).
+    """
+    count = inflight.begin()
+    collector = get_metric_collector()
+    if collector is not None:
+        collector.record("http.in_flight", count)
+    try:
+        return await call_next(request)
+    finally:
+        inflight.end()
 
 
 app.include_router(candidates.router)

--- a/src/app/main_test.py
+++ b/src/app/main_test.py
@@ -2,7 +2,9 @@
 
 import pytest
 from fastapi import Request
+from fastapi.testclient import TestClient
 
+from .lib import inflight
 from .main import _es_connections_per_node, _is_deployed_environment, _resolve_endpoint, app
 
 
@@ -72,3 +74,45 @@ def test_is_deployed_environment_checks_ge_environment_fallback(monkeypatch):
     monkeypatch.delenv("ENVIRONMENT", raising=False)
     monkeypatch.setenv("GE_ENVIRONMENT", "prod")
     assert _is_deployed_environment() is True
+
+
+def test_inflight_middleware_tracks_and_releases_requests():
+    """The counter must rise inside the handler and return to zero after."""
+    inflight.reset_for_test()
+    seen: list[int] = []
+
+    @app.get("/_inflight_probe")
+    async def _probe():
+        seen.append(inflight.current())
+        return {"ok": True}
+
+    try:
+        # No context manager: entering it would run the lifespan, which
+        # requires real ES/Firestore configuration this test does not need.
+        assert TestClient(app).get("/_inflight_probe").status_code == 200
+    finally:
+        app.router.routes = [
+            r for r in app.router.routes if getattr(r, "path", None) != "/_inflight_probe"
+        ]
+
+    assert seen == [1]
+    assert inflight.current() == 0
+
+
+def test_inflight_middleware_releases_on_handler_exception():
+    """A failing handler must not leak the process into a permanently-busy state,
+    which would make the event-loop monitor record throttled samples forever."""
+    inflight.reset_for_test()
+
+    @app.get("/_inflight_boom")
+    async def _boom():
+        raise RuntimeError("boom")
+
+    try:
+        TestClient(app, raise_server_exceptions=False).get("/_inflight_boom")
+    finally:
+        app.router.routes = [
+            r for r in app.router.routes if getattr(r, "path", None) != "/_inflight_boom"
+        ]
+
+    assert inflight.current() == 0


### PR DESCRIPTION
Part of #389

`greenearth-api-prod` runs on Cloud Run with `cpuIdle: true`, which throttles the container's CPU to near zero whenever no request is being handled. The `eventloop.lag_ms` monitor sleeps on a fixed 250ms interval regardless, so an idle instance's own wakeups get descheduled — and the metric reported that throttling as event-loop lag.

Measured on prod before this change: p50 **1.50ms** (healthy) but p90 112ms, p99 802ms, p99.9 4.7s. The distribution is bimodal — 74% of probes under 3ms, a near-empty trough from 3–25ms, then a second population from 25ms to 5s — and the windowed profile is **flat across a 10x traffic swing** (3.4 → 32 req/min), with stage showing the same shape at ~zero traffic. Lag that doesn't move with load isn't being caused by the request path; `mmr_rerank` and the rest of the pipeline are not implicated.

# This PR

- Add `lib/inflight.py`: a process-wide in-flight request counter plus an `idle_epoch` that increments on every drop to zero, giving a `busy_throughout(snapshot)` predicate — "was a request in flight for this entire window?"
- Gate `_monitor_loop` on that predicate, so a window that was idle at any point is discarded rather than recorded.
- Register `inflight_mw` as the outermost HTTP middleware so the in-flight window encloses the whole request path, and record `http.in_flight` (the per-instance concurrency signal, finer-grained than Cloud Run's per-minute `max_request_concurrencies`).

**Behavioural consequence worth reviewing:** the gate is strict, so only requests that outlast the 250ms probe interval can produce samples. Feed serving qualifies (prod `getFeedSkeleton` p50 is ~0.55–1.3s); sub-millisecond `/health` probes no longer contribute, which is the intent. The metric now means "lag while actually serving" rather than "lag, mostly while throttled".

Concurrency right-sizing is deliberately **not** in this PR — it needs a clean baseline from the gated metric first, and it's a separate concern.

# Testing

- `pipenv run pyright` — 0 errors, 0 warnings
- `pipenv run pytest -v` — 1326 passed
- Same suite inside the devenv container: `devctl --name issue389 test api` — 1326 passed
- Real feed through the pipeline: `devctl --name issue389 feed random --limit 5`
- Gating verified against the real ASGI stack in-container under sustained concurrency (10 workers, requests longer than the probe interval): 0 samples while idle, 51 under load, 0 after going idle again, peak in-flight 10, counter returned to 0, `http.in_flight` recorded 70 samples with max 10
- devenv instance nuked after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
