### PR TITLE
Serve something to logged-out feed viewers

### DIFF
--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -22,6 +22,13 @@ from .models import (
 
 DEFAULT_SOCIAL_RADIUS: int = 3
 
+# The post served, on its own, to logged-out viewers of feeds that need a
+# signed-in user to mean anything (``logged_out="explain"``). A feed with no
+# items reads as a broken feed, so show something that says why (issue #384).
+# The GreenEarth account's "This feed is personalized for you, so you must be
+# logged in to see it."
+LOGGED_OUT_POST_URI: str = "at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msw6wzvh7k2k"
+
 # Social-radius preset generator weights for your-feed.
 # Index 3 (balanced) matches the default weights defined in the "your-feed"
 # FeedConfig below — keep them in sync when tuning.
@@ -111,6 +118,8 @@ FEEDS: dict[str, FeedConfig] = {
         diversify=False,
         exclude_seen_posts=False,
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetia5l7y2j",
+        # Random posts don't depend on who's asking, so it works logged out.
+        logged_out="serve",
         gen_request_template=CandidateGenerateRequest.model_construct(
             generators=[GeneratorSpec(name="random_posts", weight=1.0)],
             infill=None,
@@ -128,6 +137,7 @@ FEEDS: dict[str, FeedConfig] = {
         avatar="assets/icons/green-earth.png",
         controls=("source_weights", "freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetfgpr3t2s",
+        logged_out="explain",
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
         # min_rank_score=0.425 maps the old -0.15 floor into the current [0, 1]
@@ -163,6 +173,7 @@ FEEDS: dict[str, FeedConfig] = {
         avatar="assets/icons/best-of-friends.png",
         controls=("freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetho32pa2g",
+        logged_out="explain",
         # Slate-cutoff starting points — tune from the feed.slate.kept_share and
         # feed.slate.cutoff_count metrics once live (see issue #248). min_rank_score
         # matches your-feed's empirically-calibrated value above; this feed's own

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -91,12 +91,18 @@ SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES: dict[int, list[GeneratorSpec]] = {
 # NOTE: published display names are limited to 24 graphemes. Internal ("debug")
 # feeds are published as "GE <internal_display_name> <git_sha>" (see issue #228),
 # so keep internal_display_name to 13 chars or fewer. feeds_test.py enforces this.
+#
+# NOTE: every private (development) feed sets logged_out="deny" — a feed nobody
+# is meant to see has nothing to say to a logged-out visitor. Public feeds take
+# the "explain" default, or "serve" when they work without a user. feeds_test.py
+# enforces this too.
 FEEDS: dict[str, FeedConfig] = {
     "unranked-your-feed": FeedConfig(
         display_name="Unranked YF",
         description="Development feed — same as green-earth but without ranking.",
         internal_rkey="e2-s",
         internal_display_name="e2 S",
+        logged_out="deny",
         avatar="assets/icons/unranked-your-feed.png",
         preference_source="your-feed",
         gen_request_template=CandidateGenerateRequest.model_construct(
@@ -201,6 +207,7 @@ FEEDS: dict[str, FeedConfig] = {
         "limits enabled, for observing and tuning thresholds (see issue #248).",
         internal_rkey="qr-cp",
         internal_display_name="qr CP",
+        logged_out="deny",
         preference_source="your-feed",
         # Same generator mix as your-feed, so cutoff behavior here previews what
         # real users would see.
@@ -248,6 +255,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — followed-users candidates only.",
         internal_rkey="ij-fu",
         internal_display_name="ij FU",
+        logged_out="deny",
         avatar="assets/icons/followed-users.png",
         diversify=False,
         exclude_seen_posts=False,
@@ -265,6 +273,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — network-likes candidates only.",
         internal_rkey="kl-nl",
         internal_display_name="kl NL",
+        logged_out="deny",
         avatar="assets/icons/network-likes.png",
         diversify=False,
         exclude_seen_posts=False,
@@ -282,6 +291,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — popularity candidates only.",
         internal_rkey="mn-p",
         internal_display_name="mn P",
+        logged_out="deny",
         avatar="assets/icons/popularity.png",
         diversify=False,
         exclude_seen_posts=False,
@@ -299,6 +309,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — two-tower candidates only.",
         internal_rkey="op-tt",
         internal_display_name="op TT",
+        logged_out="deny",
         avatar="assets/icons/two-tower.png",
         diversify=False,
         exclude_seen_posts=False,
@@ -316,6 +327,7 @@ FEEDS: dict[str, FeedConfig] = {
         description="Development feed — two-tower candidates for a user with no like history.",
         internal_rkey="tt-eh",
         internal_display_name="tt EH",
+        logged_out="deny",
         avatar="assets/icons/two-tower.png",
         diversify=False,
         exclude_seen_posts=False,
@@ -336,6 +348,7 @@ FEEDS: dict[str, FeedConfig] = {
         public=False,
         internal_rkey="mf-cs",
         internal_display_name="mf CS",
+        logged_out="deny",
         avatar="assets/icons/green-earth.png",
         max_render_share=0.5,
         min_rank_score=0.425,

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -137,7 +137,6 @@ FEEDS: dict[str, FeedConfig] = {
         avatar="assets/icons/green-earth.png",
         controls=("source_weights", "freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetfgpr3t2s",
-        logged_out="explain",
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
         # min_rank_score=0.425 maps the old -0.15 floor into the current [0, 1]
@@ -173,7 +172,6 @@ FEEDS: dict[str, FeedConfig] = {
         avatar="assets/icons/best-of-friends.png",
         controls=("freshness", "purpose"),
         pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetho32pa2g",
-        logged_out="explain",
         # Slate-cutoff starting points — tune from the feed.slate.kept_share and
         # feed.slate.cutoff_count metrics once live (see issue #248). min_rank_score
         # matches your-feed's empirically-calibrated value above; this feed's own

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -125,22 +125,30 @@ class TestFeedsRegistry:
         assert cfg.min_rank_score == pytest.approx(0.425)
         assert cfg.min_mmr_score == pytest.approx(-0.05)
 
-    def test_every_feed_shows_something_when_logged_out(self):
-        """No feed answers a logged-out visitor with nothing: an empty feed reads
-        as a broken one (issue #384). A feed opts into 401 deliberately or not
-        at all."""
+    def test_public_feeds_show_something_when_logged_out(self):
+        """A published feed is visible to logged-out visitors, who would otherwise
+        see it as empty and therefore broken (issue #384)."""
         for feed_name, cfg in FEEDS.items():
+            if not cfg.public:
+                continue
             assert cfg.logged_out in ("explain", "serve"), feed_name
 
+    def test_private_feeds_deny_logged_out_requests(self):
+        """Nobody is meant to be looking at a development feed, so it has nothing
+        to say to a visitor without a session."""
+        for feed_name, cfg in FEEDS.items():
+            if cfg.public:
+                continue
+            assert cfg.logged_out == "deny", feed_name
+
     def test_random_is_the_only_feed_that_serves_itself_logged_out(self):
-        """Its candidates don't depend on the caller. Every other feed is
-        personalized, so it takes the default and explains instead."""
+        """Its candidates don't depend on the caller."""
         serving = {name for name, cfg in FEEDS.items() if cfg.logged_out == "serve"}
         assert serving == {"random"}
 
     def test_personalized_feeds_explain_themselves_when_logged_out(self):
         """These need a user to rank for, so there is nothing to serve without one.
-        Neither declares it — this is the default."""
+        Neither declares it — 'explain' is the FeedConfig default."""
         for feed_name in ("your-feed", "best-of-friends"):
             assert FEEDS[feed_name].logged_out == "explain"
 

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -125,6 +125,29 @@ class TestFeedsRegistry:
         assert cfg.min_rank_score == pytest.approx(0.425)
         assert cfg.min_mmr_score == pytest.approx(-0.05)
 
+    def test_public_feeds_show_something_when_logged_out(self):
+        """A published feed is visible to logged-out visitors, who would
+        otherwise see it as empty and therefore broken (issue #384)."""
+        for feed_name, cfg in FEEDS.items():
+            if not cfg.public:
+                continue
+            assert cfg.logged_out in ("explain", "serve"), feed_name
+
+    def test_private_feeds_stay_authenticated_only(self):
+        for feed_name, cfg in FEEDS.items():
+            if cfg.public:
+                continue
+            assert cfg.logged_out == "deny", feed_name
+
+    def test_personalized_feeds_explain_themselves_when_logged_out(self):
+        """These need a user to rank for, so there is nothing to serve without one."""
+        for feed_name in ("your-feed", "best-of-friends"):
+            assert FEEDS[feed_name].logged_out == "explain"
+
+    def test_random_feed_serves_logged_out(self):
+        """Random candidates don't depend on the caller, so no login is needed."""
+        assert FEEDS["random"].logged_out == "serve"
+
     def test_unranked_feeds_have_no_slate_cutoffs(self):
         for feed_name, cfg in FEEDS.items():
             if cfg.rank_request_template is not None:

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -125,28 +125,24 @@ class TestFeedsRegistry:
         assert cfg.min_rank_score == pytest.approx(0.425)
         assert cfg.min_mmr_score == pytest.approx(-0.05)
 
-    def test_public_feeds_show_something_when_logged_out(self):
-        """A published feed is visible to logged-out visitors, who would
-        otherwise see it as empty and therefore broken (issue #384)."""
+    def test_every_feed_shows_something_when_logged_out(self):
+        """No feed answers a logged-out visitor with nothing: an empty feed reads
+        as a broken one (issue #384). A feed opts into 401 deliberately or not
+        at all."""
         for feed_name, cfg in FEEDS.items():
-            if not cfg.public:
-                continue
             assert cfg.logged_out in ("explain", "serve"), feed_name
 
-    def test_private_feeds_stay_authenticated_only(self):
-        for feed_name, cfg in FEEDS.items():
-            if cfg.public:
-                continue
-            assert cfg.logged_out == "deny", feed_name
+    def test_random_is_the_only_feed_that_serves_itself_logged_out(self):
+        """Its candidates don't depend on the caller. Every other feed is
+        personalized, so it takes the default and explains instead."""
+        serving = {name for name, cfg in FEEDS.items() if cfg.logged_out == "serve"}
+        assert serving == {"random"}
 
     def test_personalized_feeds_explain_themselves_when_logged_out(self):
-        """These need a user to rank for, so there is nothing to serve without one."""
+        """These need a user to rank for, so there is nothing to serve without one.
+        Neither declares it — this is the default."""
         for feed_name in ("your-feed", "best-of-friends"):
             assert FEEDS[feed_name].logged_out == "explain"
-
-    def test_random_feed_serves_logged_out(self):
-        """Random candidates don't depend on the caller, so no login is needed."""
-        assert FEEDS["random"].logged_out == "serve"
 
     def test_unranked_feeds_have_no_slate_cutoffs(self):
         for feed_name, cfg in FEEDS.items():

--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -180,7 +180,8 @@ class MetricCollector:
         When recorded on a request path, the metric is automatically tagged
         with an ``endpoint`` label naming the originating API endpoint (e.g.
         ``get_feed_skeleton`` vs ``candidates_generate``) and a ``traffic``
-        label naming the traffic class (``real`` | ``probe`` | ``load_test``).
+        label naming the traffic class (``real`` | ``probe`` | ``load_test`` |
+        ``logged_out``).
         Both are read from ContextVars set on the request path, so every
         callsite gets them for free — including background tasks, which inherit
         the context at spawn time. Explicitly passed attributes win.

--- a/src/app/lib/request_context.py
+++ b/src/app/lib/request_context.py
@@ -30,8 +30,9 @@ _request_id: ContextVar[str | None] = ContextVar("ge_request_id", default=None)
 _endpoint: ContextVar[str | None] = ContextVar("ge_endpoint", default=None)
 
 # The traffic class of the current request: ``real`` (a genuine user or the
-# default), ``probe`` (Cloud Scheduler liveness probe), or ``load_test`` (a
-# simulated load-test session). Set by the feed endpoint so that every metric
+# default), ``probe`` (Cloud Scheduler liveness probe), ``load_test`` (a
+# simulated load-test session), or ``logged_out`` (a feed served to an
+# unauthenticated visitor). Set by the feed endpoint so that every metric
 # recorded on the request path — including from background tasks, which inherit
 # this context at spawn time — can be split by traffic class and test traffic
 # filtered out of dashboards. Propagates through ``asyncio`` like ``rid``.
@@ -67,7 +68,7 @@ def get_traffic() -> str | None:
 
 
 def set_traffic(traffic: str) -> Token:
-    """Set the traffic class (``real`` | ``probe`` | ``load_test``)."""
+    """Set the traffic class (``real`` | ``probe`` | ``load_test`` | ``logged_out``)."""
     return _traffic.set(traffic)
 
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -14,12 +14,13 @@ FeedControlName = Literal[
 # What a feed does when the AppView calls getFeedSkeleton with no (or an
 # unverifiable) AT Protocol JWT — i.e. someone viewing the feed logged out.
 #
-#   "deny"    — 401. For private/development feeds that nobody should see.
-#   "explain" — serve a single post explaining that the feed needs a login.
-#               For personalized feeds, which have nothing to show without a
-#               user (see issue #384).
+#   "explain" — the default: serve a single post explaining that the feed
+#               needs a login. Right for any personalized feed, which has
+#               nothing to show without a user (see issue #384).
 #   "serve"   — run the normal pipeline anonymously. For feeds whose
 #               candidates don't depend on who is asking.
+#   "deny"    — 401. Nothing in the catalog selects this today; it's here for
+#               a feed that must not respond at all without a caller.
 LoggedOutBehavior = Literal["deny", "explain", "serve"]
 
 
@@ -252,10 +253,10 @@ class FeedConfig(BaseModel):
         description="AT URI of a post to pin at the top of the first page of this feed.",
     )
     logged_out: LoggedOutBehavior = Field(
-        "deny",
-        description="How this feed responds to an unauthenticated request: 401 ('deny'), "
-        "a single explanatory post ('explain'), or the normal pipeline run anonymously "
-        "('serve').",
+        "explain",
+        description="How this feed responds to an unauthenticated request: a single "
+        "explanatory post ('explain', the default), the normal pipeline run anonymously "
+        "('serve'), or 401 ('deny').",
     )
     logged_out_post_uri: str | None = Field(
         None,

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -11,6 +11,17 @@ FeedControlName = Literal[
     "purpose",
 ]
 
+# What a feed does when the AppView calls getFeedSkeleton with no (or an
+# unverifiable) AT Protocol JWT — i.e. someone viewing the feed logged out.
+#
+#   "deny"    — 401. For private/development feeds that nobody should see.
+#   "explain" — serve a single post explaining that the feed needs a login.
+#               For personalized feeds, which have nothing to show without a
+#               user (see issue #384).
+#   "serve"   — run the normal pipeline anonymously. For feeds whose
+#               candidates don't depend on who is asking.
+LoggedOutBehavior = Literal["deny", "explain", "serve"]
+
 
 class FeedCursor(BaseModel):
     """Opaque pagination cursor for scrolling through feed results.
@@ -239,6 +250,17 @@ class FeedConfig(BaseModel):
     pinned_post_uri: str | None = Field(
         None,
         description="AT URI of a post to pin at the top of the first page of this feed.",
+    )
+    logged_out: LoggedOutBehavior = Field(
+        "deny",
+        description="How this feed responds to an unauthenticated request: 401 ('deny'), "
+        "a single explanatory post ('explain'), or the normal pipeline run anonymously "
+        "('serve').",
+    )
+    logged_out_post_uri: str | None = Field(
+        None,
+        description="AT URI of the post served on its own to logged-out callers. Only "
+        "read when logged_out is 'explain'; defaults to feeds.LOGGED_OUT_POST_URI.",
     )
     max_render_share: float | None = Field(
         None,

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -19,8 +19,8 @@ FeedControlName = Literal[
 #               nothing to show without a user (see issue #384).
 #   "serve"   — run the normal pipeline anonymously. For feeds whose
 #               candidates don't depend on who is asking.
-#   "deny"    — 401. Nothing in the catalog selects this today; it's here for
-#               a feed that must not respond at all without a caller.
+#   "deny"    — 401. For the private development feeds, which nobody is meant
+#               to be looking at in the first place.
 LoggedOutBehavior = Literal["deny", "explain", "serve"]
 
 

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -58,6 +58,19 @@ class TestFeedConfig:
         uri = "at://did:plc:example/app.bsky.feed.post/abc123"
         assert _minimal_feed_cfg(pinned_post_uri=uri).pinned_post_uri == uri
 
+    def test_logged_out_defaults_to_explain(self):
+        """A new feed is personalized until proven otherwise, so the safe default
+        is to tell a logged-out visitor why it's empty rather than 401."""
+        assert _minimal_feed_cfg().logged_out == "explain"
+
+    def test_logged_out_rejects_an_unknown_behavior(self):
+        with pytest.raises(ValidationError):
+            _minimal_feed_cfg(logged_out="ignore")
+
+    def test_logged_out_post_uri_defaults_to_none(self):
+        """None means the shared feeds.LOGGED_OUT_POST_URI."""
+        assert _minimal_feed_cfg().logged_out_post_uri is None
+
     def test_avatar_defaults_to_none(self):
         assert _minimal_feed_cfg().avatar is None
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -42,6 +42,7 @@ from ..documents import (
 from ..feeds import (
     DEFAULT_SOCIAL_RADIUS,
     FEEDS,
+    LOGGED_OUT_POST_URI,
     SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
     SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,  # noqa: F401 - compatibility export
     canonical_feed_name,
@@ -222,6 +223,13 @@ def _get_hostname() -> str:
 
 def _feed_uri(feed_name: str) -> str:
     return f"at://{_get_service_did()}/app.bsky.feed.generator/{feed_name}"
+
+
+# Stand-in identity for a logged-out caller on a feed that serves anonymously
+# (``logged_out="serve"``). Deliberately not a resolvable ``did:plc``, so it can
+# never collide with a real user: nothing keyed on a user is written for these
+# requests, and this makes any such write obvious if one is ever added.
+ANONYMOUS_DID = "did:ge:anonymous"
 
 
 def dev_session_did(request: Request) -> str | None:
@@ -968,7 +976,7 @@ def _make_feed_context(
     )
 
 
-def _skeleton_items(uris: list[str], feed_context: str) -> list[SkeletonItem]:
+def _skeleton_items(uris: list[str], feed_context: str | None) -> list[SkeletonItem]:
     return [SkeletonItem(post=uri, feed_context=feed_context) for uri in uris]
 
 
@@ -1439,6 +1447,11 @@ async def get_feed_skeleton(
     if is_load_test:
         is_probe = False
 
+    # A logged-out caller has no identity, so nothing that is keyed on a user
+    # (Firestore reads and writes, preferences, feature flags, analytics) runs
+    # for the request — see the guards on ``is_anonymous`` below.
+    is_anonymous = False
+
     if _dev_session_did is not None:
         user_did = _dev_session_did
     elif is_load_test:
@@ -1453,18 +1466,41 @@ async def get_feed_skeleton(
         if not user_did:
             if request.headers.get("Authorization"):
                 logger.warning("Auth header present but verification failed for feed %s", feed_name)
-            else:
-                logger.warning("No auth header present for feed %s", feed_name)
-            raise HTTPException(
-                status_code=401,
-                detail="Authentication required",
-                headers={"WWW-Authenticate": "Bearer"},
-            )
+
+            # Bluesky renders these feeds to logged-out visitors too, and an
+            # empty feed reads as a broken one. What we can show depends on
+            # whether the feed needs to know who is asking (issue #384).
+            if feed_cfg.logged_out == "deny":
+                logger.warning("Unauthenticated request for feed %s", feed_name)
+                raise HTTPException(
+                    status_code=401,
+                    detail="Authentication required",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            if feed_cfg.logged_out == "explain":
+                # Nothing to personalize, so skip the pipeline entirely and say
+                # why the feed is empty. No cursor: this is the whole feed.
+                set_traffic("logged_out")
+                return FeedSkeletonResponse(
+                    feed=[SkeletonItem(post=feed_cfg.logged_out_post_uri or LOGGED_OUT_POST_URI)]
+                )
+
+            is_anonymous = True
+            user_did = ANONYMOUS_DID
 
     # Tag every metric on this request path (incl. background tasks, which
     # inherit this context at spawn time) with its traffic class so test and
     # probe traffic can be filtered out of dashboards.
-    set_traffic("load_test" if is_load_test else "probe" if is_probe else "real")
+    set_traffic(
+        "logged_out"
+        if is_anonymous
+        else "load_test"
+        if is_load_test
+        else "probe"
+        if is_probe
+        else "real"
+    )
 
     # Record authenticated users in Firestore for backend analytics. Runs in
     # the background since this isn't essential for serving.
@@ -1473,7 +1509,10 @@ async def get_feed_skeleton(
         logger.error("Firestore client not initialized")
         raise HTTPException(status_code=500, detail="Firestore unavailable")
 
-    _spawn_background(_record_session(request, user_did, feed_name, db, is_load_test=is_load_test))
+    if not is_anonymous:
+        _spawn_background(
+            _record_session(request, user_did, feed_name, db, is_load_test=is_load_test)
+        )
 
     uses_network_likes_flag = feed_name in (
         "your-feed",
@@ -1485,6 +1524,9 @@ async def get_feed_skeleton(
         flag_keys.append(NETWORK_LIKES_FLAG)
 
     posthog_client = get_posthog_client()
+    # Flags are evaluated per user, and an anonymous caller isn't one: it would
+    # be a single synthetic identity shared by every logged-out request. Take
+    # the flag defaults instead.
     feature_flags = (
         await asyncio.to_thread(
             evaluate_feature_flags,
@@ -1492,7 +1534,7 @@ async def get_feed_skeleton(
             user_did,
             flag_keys,
         )
-        if posthog_client is not None
+        if posthog_client is not None and not is_anonymous
         else {}
     )
     set_fail_fast_for_request(feature_flags.get(FAIL_FAST_FLAG, False))
@@ -1502,11 +1544,12 @@ async def get_feed_skeleton(
     # to no-debug rather than breaking feed serving.
     debug_enabled = False
     user_doc = None
-    try:
-        user_doc = await get_user(db, user_did)
-        debug_enabled = bool(user_doc and user_doc.debug_feeds)
-    except Exception:
-        logger.exception("Failed to read debug flag for user '%s'", user_did)
+    if not is_anonymous:
+        try:
+            user_doc = await get_user(db, user_did)
+            debug_enabled = bool(user_doc and user_doc.debug_feeds)
+        except Exception:
+            logger.exception("Failed to read debug flag for user '%s'", user_did)
 
     # Purpose controls the relative influence of the engaging and constructive
     # rankers only for feeds that declare it. Apply it to a request-local copy;
@@ -1560,6 +1603,23 @@ async def get_feed_skeleton(
 
     feed_cache = _get_feed_cache(request)
 
+    def feed_context_for(request_id: str) -> str | None:
+        """Signed interaction token for this response, or None when anonymous.
+
+        ``sendInteractions`` carries no auth of its own — the token is the only
+        thing tying a reported interaction to a user, and a logged-out request
+        has no user to tie it to. Omitting it drops those interactions.
+        """
+        if is_anonymous:
+            return None
+        return _make_feed_context(user_did, feed_name, request_id, load_test=is_load_test)
+
+    async def generation_exclusions() -> list[str]:
+        """Post URIs to exclude — none for an anonymous caller, who has no history."""
+        if is_anonymous:
+            return []
+        return await _generation_exclusions(db, user_did, feed_cfg)
+
     async with timed(
         logger,
         "feed.render.duration_ms",
@@ -1604,9 +1664,7 @@ async def get_feed_skeleton(
                     _record_similarity_metric(
                         page, scores_by_uri, feed_name, batch=parsed.offset // limit
                     )
-                    feed_context = _make_feed_context(
-                        user_did, feed_name, parsed.id, load_test=is_load_test
-                    )
+                    feed_context = feed_context_for(parsed.id)
                     cached_snapshot = FeedSnapshotDocument(
                         request_id=parsed.id,
                         items=cached_uris,
@@ -1618,7 +1676,7 @@ async def get_feed_skeleton(
                         applied_social_radius=cache_doc.applied_social_radius,
                         items_meta=cache_doc.items_meta,
                     )
-                    if not is_probe:
+                    if not is_probe and not is_anonymous:
                         await _write_feed_snapshot_background(
                             db,
                             user_did,
@@ -1633,7 +1691,7 @@ async def get_feed_skeleton(
 
                 # Offset is at or past the end — regenerate with exclusions.
                 batch = _batch_size(limit)
-                excluded = await _generation_exclusions(db, user_did, feed_cfg)
+                excluded = await generation_exclusions()
                 # Dedup while preserving order; the cached batch and the
                 # seen/discarded posts can overlap.
                 exclude_uris = list(dict.fromkeys(cached_uris + excluded))
@@ -1659,7 +1717,7 @@ async def get_feed_skeleton(
                     debug_enabled=debug_enabled,
                     applied_social_radius=applied_social_radius,
                 )
-                if low_score_uris:
+                if low_score_uris and not is_anonymous:
                     _spawn_background(
                         _record_discarded(db, user_did, low_score_uris, load_test=is_load_test)
                     )
@@ -1684,10 +1742,8 @@ async def get_feed_skeleton(
                         _record_similarity_metric(
                             page, scores_by_uri, feed_name, batch=parsed.offset // limit
                         )
-                        feed_context = _make_feed_context(
-                            user_did, feed_name, parsed.id, load_test=is_load_test
-                        )
-                        if not is_probe:
+                        feed_context = feed_context_for(parsed.id)
+                        if not is_probe and not is_anonymous:
                             await _write_feed_snapshot_background(
                                 db,
                                 user_did,
@@ -1710,6 +1766,9 @@ async def get_feed_skeleton(
         # ------------------------------------------------------------------
         reuse_future: Future[FeedSkeletonResponse] | None = None
         if cursor is None and not is_probe:
+            # Logged-out callers all share ANONYMOUS_DID, so concurrent ones
+            # coalesce onto a single pipeline run and get the same page. That's
+            # the point: unauthenticated traffic is the cheapest to send us.
             is_leader, reuse_future = _claim_initial_request(
                 user_did, feed_name, limit, is_load_test
             )
@@ -1719,7 +1778,7 @@ async def get_feed_skeleton(
 
         try:
             batch = _batch_size(limit)
-            exclude_uris = await _generation_exclusions(db, user_did, feed_cfg)
+            exclude_uris = await generation_exclusions()
             gen_request = feed_cfg.gen_request_template.model_copy(
                 update={
                     "user_did": user_did,
@@ -1747,7 +1806,7 @@ async def get_feed_skeleton(
                 debug_enabled=debug_enabled,
                 applied_social_radius=applied_social_radius,
             )
-            if low_score_uris:
+            if low_score_uris and not is_anonymous:
                 _spawn_background(
                     _record_discarded(db, user_did, low_score_uris, load_test=is_load_test)
                 )
@@ -1771,7 +1830,7 @@ async def get_feed_skeleton(
                 page, scores_by_uri, feed_name, batch=0, exclude_uri=feed_cfg.pinned_post_uri
             )
 
-            if not is_probe:
+            if not is_probe and not is_anonymous:
                 await _write_feed_snapshot_background(
                     db,
                     user_did,
@@ -1810,9 +1869,7 @@ async def get_feed_skeleton(
                     )
                 next_cursor = FeedCursor(id=request_id, offset=consumed).encode()
 
-            feed_context = _make_feed_context(
-                user_did, feed_name, request_id, load_test=is_load_test
-            )
+            feed_context = feed_context_for(request_id)
             response = FeedSkeletonResponse(
                 feed=_skeleton_items(page, feed_context),
                 cursor=next_cursor,

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1327,17 +1327,20 @@ class TestGetFeedSkeletonAuth:
             )
         assert resp.status_code == 200
 
-    def test_unauthenticated_request_uses_empty_did(self):
-        """Without auth header, endpoint should reject the request."""
+    def test_unauthenticated_request_gets_the_logged_out_post(self):
+        """Without an auth header there is no user to personalize for, so the
+        feed explains itself rather than running the pipeline (issue #384)."""
         with self._patch_generators(_make_candidates("p", 2)):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI},
             )
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
-    def test_invalid_jwt_still_returns_feed(self):
-        """Invalid JWT should be rejected."""
+    def test_invalid_jwt_is_treated_as_logged_out(self):
+        """An unverifiable JWT is no identity at all, so it takes the same path
+        as no JWT — not the authenticated one."""
         from atproto_server.exceptions import TokenInvalidSignatureError
 
         with (
@@ -1353,7 +1356,8 @@ class TestGetFeedSkeletonAuth:
                 params={"feed": FEED_URI},
                 headers={"Authorization": "Bearer bad.jwt.token"},
             )
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
     def test_authenticated_request_upserts_user(self):
         """Authenticated requests should upsert the user in Firestore."""
@@ -1480,7 +1484,7 @@ class TestGetFeedSkeletonAuth:
                 params={"feed": FEED_URI},
             )
 
-        assert resp.status_code == 401
+        assert resp.status_code == 200
         mock_upsert.assert_not_awaited()
 
     def test_authenticated_request_records_feed_activity(self):
@@ -2832,22 +2836,24 @@ class TestGetFeedSkeletonProbe:
         assert resp.status_code == 200
         snapshot_write.assert_not_awaited()
 
-    def test_wrong_probe_secret_returns_401(self):
-        """Wrong X-Probe-Secret still 401s (no bypass)."""
+    # A request that fails to engage the bypass falls through to ordinary auth,
+    # which for an unauthenticated caller means the logged-out post rather than
+    # a feed generated as the probe user (issue #384). Getting that response is
+    # what proves the bypass didn't engage.
+    def test_wrong_probe_secret_does_not_bypass(self):
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
             headers={"X-Probe-Secret": "wrong-secret"},
         )
-        assert resp.status_code == 401
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
-    def test_missing_probe_header_returns_401(self):
-        """No header at all still 401s."""
+    def test_missing_probe_header_does_not_bypass(self):
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
         )
-        assert resp.status_code == 401
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
     def test_probe_secret_env_unset_ignores_header(self, monkeypatch):
         """When GE_PROBE_SECRET is not configured, any header value is ignored."""
@@ -2857,7 +2863,7 @@ class TestGetFeedSkeletonProbe:
             params={"feed": FEED_URI},
             headers={"X-Probe-Secret": self.PROBE_SECRET},
         )
-        assert resp.status_code == 401
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
 
 class TestLoadTestSession:
@@ -2936,13 +2942,15 @@ class TestLoadTestSession:
             )
         assert resp.status_code == 200
 
-    def test_wrong_secret_returns_401(self):
+    # As with the probe: falling through to the logged-out post is what shows
+    # the bypass didn't engage and no session was stood up for LT_DID.
+    def test_wrong_secret_does_not_bypass(self):
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
             headers=self._headers(secret="nope"),
         )
-        assert resp.status_code == 401
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
     def test_env_unset_ignores_header(self, monkeypatch):
         monkeypatch.delenv("GE_LOAD_TEST_SECRET", raising=False)
@@ -2951,7 +2959,7 @@ class TestLoadTestSession:
             params={"feed": FEED_URI},
             headers=self._headers(),
         )
-        assert resp.status_code == 401
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
     def test_writes_then_deletes_observability_snapshot(self):
         """Load test performs the snapshot write (contrast with the probe, which
@@ -4090,10 +4098,20 @@ class TestGetFeedSkeletonMetrics:
         }
 
     def test_auth_failure_records_failure_count_401(self):
-        with patch(
-            "app.routers.xrpc.verify_auth_header",
-            new_callable=AsyncMock,
-            return_value=None,
+        """Only feeds that opt into logged_out='deny' 401 at all, so this needs one."""
+        from app.routers import xrpc as xrpc_mod
+
+        patched_feeds = {
+            **FEEDS,
+            FEED_RKEY: FEEDS[FEED_RKEY].model_copy(update={"logged_out": "deny"}),
+        }
+        with (
+            patch.object(xrpc_mod, "FEEDS", patched_feeds),
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
         ):
             response = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -4107,6 +4125,20 @@ class TestGetFeedSkeletonMetrics:
             "feed_name": FEED_RKEY,
             "status_code": "401",
         }
+
+    def test_logged_out_render_records_success_not_failure(self):
+        """The explainer is a served feed, not a failed one — logged-out traffic
+        must not read as a failure spike on the dashboards."""
+        response = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI},
+        )
+
+        assert response.status_code == 200
+        assert not [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
+        success_calls = [call for call in self.mc.calls if call[0] == "feed.render.success_count"]
+        assert len(success_calls) == 1
+        assert success_calls[0][2]["feed_name"] == FEED_RKEY
 
     def test_pipeline_timeout_records_failure_count_504(self, monkeypatch):
         monkeypatch.setenv("GE_FEED_REQUEST_TIMEOUT_SEC", "0.05")
@@ -4495,14 +4527,35 @@ class TestLoggedOut:
         get_user_mock.assert_not_awaited()
         upsert_mock.assert_not_awaited()
 
-    def test_private_feed_still_requires_auth(self):
-        """Development feeds nobody should see stay 401 rather than explaining themselves."""
+    def test_feed_can_opt_into_requiring_auth(self):
+        """No feed in the catalog selects 'deny' today, but the escape hatch has
+        to keep working for one that must not answer without a caller."""
+        from app.routers import xrpc as xrpc_mod
+
+        patched_feeds = {
+            **FEEDS,
+            "unranked-your-feed": FEEDS["unranked-your-feed"].model_copy(
+                update={"logged_out": "deny"}
+            ),
+        }
+        with patch.object(xrpc_mod, "FEEDS", patched_feeds):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": FEED_URI},
+            )
+
+        assert resp.status_code == 401
+        assert resp.headers["WWW-Authenticate"] == "Bearer"
+
+    def test_development_feed_explains_itself_by_default(self):
+        """Nothing declares 'deny', so a dev feed takes the default too."""
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
         )
 
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
 
     def test_random_feed_serves_posts_without_auth(self):
         candidates = _make_candidates("did:plc:a", 5, "random_posts")

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -12,7 +12,7 @@ from ..documents import (
     FeedCacheDocument,
     PipelineItemMeta,
 )
-from ..feeds import FEEDS
+from ..feeds import FEEDS, LOGGED_OUT_POST_URI
 from ..lib.candidates.base import CandidateResult
 from ..lib.embeddings import encode_float32_b64
 from ..lib.feed_cache import FeedCache
@@ -4430,3 +4430,152 @@ class TestFailFastFeatureFlag:
             )
 
         mock_set.assert_called_once_with(False)
+
+
+# ---------------------------------------------------------------------------
+# Logged-out requests
+# ---------------------------------------------------------------------------
+
+
+class TestLoggedOut:
+    """What a signed-out Bluesky visitor gets from getFeedSkeleton (issue #384).
+
+    Every request here has no Authorization header, which is exactly how the
+    AppView calls us when nobody is signed in.
+    """
+
+    def _patch_random_generator(self, candidates):
+        generator = AsyncMock()
+        generator.generate.return_value = CandidateResult(
+            generator_name="random_posts", candidates=candidates
+        )
+        return patch("app.lib.candidates.generate.get_generator", return_value=generator)
+
+    @pytest.mark.parametrize("feed_uri", [RANKED_FEED_URI, BEST_OF_FRIENDS_FEED_URI])
+    def test_personalized_feed_serves_only_the_explainer_post(self, feed_uri):
+        with patch("app.lib.candidates.generate.get_generator") as get_generator:
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": feed_uri},
+            )
+
+        assert resp.status_code == 200
+        # One post, no cursor (this is the whole feed) and no feedContext —
+        # there is no user to attribute an interaction to.
+        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        get_generator.assert_not_called()
+
+    def test_feed_can_override_the_explainer_post(self):
+        from app.routers import xrpc as xrpc_mod
+
+        override = "at://did:plc:explainer/app.bsky.feed.post/loggedout"
+        patched_feeds = {
+            **FEEDS,
+            "your-feed": FEEDS["your-feed"].model_copy(update={"logged_out_post_uri": override}),
+        }
+        with patch.object(xrpc_mod, "FEEDS", patched_feeds):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            )
+
+        assert [item["post"] for item in resp.json()["feed"]] == [override]
+
+    def test_explainer_response_touches_no_user_data(self):
+        with (
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock) as get_user_mock,
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock) as upsert_mock,
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            )
+
+        assert resp.status_code == 200
+        get_user_mock.assert_not_awaited()
+        upsert_mock.assert_not_awaited()
+
+    def test_private_feed_still_requires_auth(self):
+        """Development feeds nobody should see stay 401 rather than explaining themselves."""
+        resp = client.get(
+            "/xrpc/app.bsky.feed.getFeedSkeleton",
+            params={"feed": FEED_URI},
+        )
+
+        assert resp.status_code == 401
+
+    def test_random_feed_serves_posts_without_auth(self):
+        candidates = _make_candidates("did:plc:a", 5, "random_posts")
+        with self._patch_random_generator(candidates):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10},
+            )
+
+        assert resp.status_code == 200
+        items = resp.json()["feed"]
+        posts = [item["post"] for item in items]
+        assert posts[0] == FEEDS["random"].pinned_post_uri
+        assert "at://did:plc:a/0" in posts
+        # No feedContext: interactions reported for these can't be attributed.
+        assert all("feedContext" not in item for item in items)
+
+    def test_random_feed_records_nothing_for_an_anonymous_caller(self):
+        candidates = _make_candidates("did:plc:a", 5, "random_posts")
+        with (
+            self._patch_random_generator(candidates),
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock) as get_user_mock,
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock) as upsert_mock,
+            patch("app.routers.xrpc.merge_feed_snapshot", new_callable=AsyncMock) as snapshot_mock,
+        ):
+            resp = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10},
+            )
+
+        assert resp.status_code == 200
+        get_user_mock.assert_not_awaited()
+        upsert_mock.assert_not_awaited()
+        snapshot_mock.assert_not_awaited()
+
+    def test_random_feed_pages_without_auth(self):
+        candidates = _make_candidates("did:plc:a", 12, "random_posts")
+        with self._patch_random_generator(candidates):
+            first = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 5},
+            ).json()
+            assert first["cursor"]
+            second = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 5, "cursor": first["cursor"]},
+            ).json()
+
+        first_posts = [item["post"] for item in first["feed"]]
+        second_posts = [item["post"] for item in second["feed"]]
+        assert second_posts
+        assert not set(first_posts) & set(second_posts)
+
+    def test_explainer_is_tagged_as_logged_out_traffic(self):
+        """Metrics recorded on this path carry traffic=logged_out, so signed-out
+        views can be told apart from real ones on the dashboards."""
+        with patch("app.routers.xrpc.set_traffic") as set_traffic_mock:
+            client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            )
+
+        set_traffic_mock.assert_called_once_with("logged_out")
+
+    def test_anonymous_feed_is_tagged_as_logged_out_traffic(self):
+        candidates = _make_candidates("did:plc:a", 5, "random_posts")
+        with (
+            self._patch_random_generator(candidates),
+            patch("app.routers.xrpc.set_traffic") as set_traffic_mock,
+        ):
+            client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANDOM_FEED_URI, "limit": 10},
+            )
+
+        set_traffic_mock.assert_called_once_with("logged_out")

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -1327,20 +1327,17 @@ class TestGetFeedSkeletonAuth:
             )
         assert resp.status_code == 200
 
-    def test_unauthenticated_request_gets_the_logged_out_post(self):
-        """Without an auth header there is no user to personalize for, so the
-        feed explains itself rather than running the pipeline (issue #384)."""
+    def test_unauthenticated_request_uses_empty_did(self):
+        """Without auth header, endpoint should reject the request."""
         with self._patch_generators(_make_candidates("p", 2)):
             resp = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
                 params={"feed": FEED_URI},
             )
-        assert resp.status_code == 200
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
-    def test_invalid_jwt_is_treated_as_logged_out(self):
-        """An unverifiable JWT is no identity at all, so it takes the same path
-        as no JWT — not the authenticated one."""
+    def test_invalid_jwt_still_returns_feed(self):
+        """Invalid JWT should be rejected."""
         from atproto_server.exceptions import TokenInvalidSignatureError
 
         with (
@@ -1356,8 +1353,7 @@ class TestGetFeedSkeletonAuth:
                 params={"feed": FEED_URI},
                 headers={"Authorization": "Bearer bad.jwt.token"},
             )
-        assert resp.status_code == 200
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
     def test_authenticated_request_upserts_user(self):
         """Authenticated requests should upsert the user in Firestore."""
@@ -1484,7 +1480,7 @@ class TestGetFeedSkeletonAuth:
                 params={"feed": FEED_URI},
             )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 401
         mock_upsert.assert_not_awaited()
 
     def test_authenticated_request_records_feed_activity(self):
@@ -2836,24 +2832,22 @@ class TestGetFeedSkeletonProbe:
         assert resp.status_code == 200
         snapshot_write.assert_not_awaited()
 
-    # A request that fails to engage the bypass falls through to ordinary auth,
-    # which for an unauthenticated caller means the logged-out post rather than
-    # a feed generated as the probe user (issue #384). Getting that response is
-    # what proves the bypass didn't engage.
-    def test_wrong_probe_secret_does_not_bypass(self):
+    def test_wrong_probe_secret_returns_401(self):
+        """Wrong X-Probe-Secret still 401s (no bypass)."""
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
             headers={"X-Probe-Secret": "wrong-secret"},
         )
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
-    def test_missing_probe_header_does_not_bypass(self):
+    def test_missing_probe_header_returns_401(self):
+        """No header at all still 401s."""
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
         )
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
     def test_probe_secret_env_unset_ignores_header(self, monkeypatch):
         """When GE_PROBE_SECRET is not configured, any header value is ignored."""
@@ -2863,7 +2857,7 @@ class TestGetFeedSkeletonProbe:
             params={"feed": FEED_URI},
             headers={"X-Probe-Secret": self.PROBE_SECRET},
         )
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
 
 class TestLoadTestSession:
@@ -2942,15 +2936,13 @@ class TestLoadTestSession:
             )
         assert resp.status_code == 200
 
-    # As with the probe: falling through to the logged-out post is what shows
-    # the bypass didn't engage and no session was stood up for LT_DID.
-    def test_wrong_secret_does_not_bypass(self):
+    def test_wrong_secret_returns_401(self):
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
             headers=self._headers(secret="nope"),
         )
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
     def test_env_unset_ignores_header(self, monkeypatch):
         monkeypatch.delenv("GE_LOAD_TEST_SECRET", raising=False)
@@ -2959,7 +2951,7 @@ class TestLoadTestSession:
             params={"feed": FEED_URI},
             headers=self._headers(),
         )
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
     def test_writes_then_deletes_observability_snapshot(self):
         """Load test performs the snapshot write (contrast with the probe, which
@@ -4098,20 +4090,10 @@ class TestGetFeedSkeletonMetrics:
         }
 
     def test_auth_failure_records_failure_count_401(self):
-        """Only feeds that opt into logged_out='deny' 401 at all, so this needs one."""
-        from app.routers import xrpc as xrpc_mod
-
-        patched_feeds = {
-            **FEEDS,
-            FEED_RKEY: FEEDS[FEED_RKEY].model_copy(update={"logged_out": "deny"}),
-        }
-        with (
-            patch.object(xrpc_mod, "FEEDS", patched_feeds),
-            patch(
-                "app.routers.xrpc.verify_auth_header",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value=None,
         ):
             response = client.get(
                 "/xrpc/app.bsky.feed.getFeedSkeleton",
@@ -4127,18 +4109,18 @@ class TestGetFeedSkeletonMetrics:
         }
 
     def test_logged_out_render_records_success_not_failure(self):
-        """The explainer is a served feed, not a failed one — logged-out traffic
-        must not read as a failure spike on the dashboards."""
+        """A public feed's explainer is a served feed, not a failed one — logged-out
+        traffic must not read as a failure spike on the dashboards (issue #384)."""
         response = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
-            params={"feed": FEED_URI},
+            params={"feed": RANKED_FEED_URI},
         )
 
         assert response.status_code == 200
         assert not [call for call in self.mc.calls if call[0] == "feed.render.failure_count"]
         success_calls = [call for call in self.mc.calls if call[0] == "feed.render.success_count"]
         assert len(success_calls) == 1
-        assert success_calls[0][2]["feed_name"] == FEED_RKEY
+        assert success_calls[0][2]["feed_name"] == RANKED_FEED_RKEY
 
     def test_pipeline_timeout_records_failure_count_504(self, monkeypatch):
         monkeypatch.setenv("GE_FEED_REQUEST_TIMEOUT_SEC", "0.05")
@@ -4527,35 +4509,14 @@ class TestLoggedOut:
         get_user_mock.assert_not_awaited()
         upsert_mock.assert_not_awaited()
 
-    def test_feed_can_opt_into_requiring_auth(self):
-        """No feed in the catalog selects 'deny' today, but the escape hatch has
-        to keep working for one that must not answer without a caller."""
-        from app.routers import xrpc as xrpc_mod
-
-        patched_feeds = {
-            **FEEDS,
-            "unranked-your-feed": FEEDS["unranked-your-feed"].model_copy(
-                update={"logged_out": "deny"}
-            ),
-        }
-        with patch.object(xrpc_mod, "FEEDS", patched_feeds):
-            resp = client.get(
-                "/xrpc/app.bsky.feed.getFeedSkeleton",
-                params={"feed": FEED_URI},
-            )
-
-        assert resp.status_code == 401
-        assert resp.headers["WWW-Authenticate"] == "Bearer"
-
-    def test_development_feed_explains_itself_by_default(self):
-        """Nothing declares 'deny', so a dev feed takes the default too."""
+    def test_private_feed_still_requires_auth(self):
+        """Development feeds nobody should see stay 401 rather than explaining themselves."""
         resp = client.get(
             "/xrpc/app.bsky.feed.getFeedSkeleton",
             params={"feed": FEED_URI},
         )
 
-        assert resp.status_code == 200
-        assert resp.json() == {"feed": [{"post": LOGGED_OUT_POST_URI}]}
+        assert resp.status_code == 401
 
     def test_random_feed_serves_posts_without_auth(self):
         candidates = _make_candidates("did:plc:a", 5, "random_posts")


### PR DESCRIPTION
Closes #384.

`getFeedSkeleton` 401'd every unauthenticated request, so a signed-out visitor to one of our feeds on bsky.app got an empty feed — which reads as a broken feed.

Feeds now declare what they do when nobody is signed in, via `logged_out` on `FeedConfig`:

| behavior | feeds | response |
|---|---|---|
| `explain` (default) | your-feed, best-of-friends | one post: _"This feed is personalized for you, so you must be logged in to see it."_ |
| `serve` | random | the normal pipeline, run anonymously |
| `deny` | the eight private dev feeds | 401, as before |

`random` needs no identity to pick candidates, so it works logged out. The public personalized feeds have nothing to rank without a user, so they skip the pipeline and say why — neither declares anything, since that's the default a new feed should get. The private feeds keep 401'ing: nobody is meant to be looking at them. `feeds_test.py` enforces the split both ways.

Anonymous requests stand in an `ANONYMOUS_DID` sentinel and skip everything keyed on a user: session/user upserts, PostHog flag evaluation, the debug-flag read, seen/discarded exclusions, snapshot writes, discarded recording. Items carry no `feedContext`, so any interaction the AppView reports against them is dropped rather than attributed to a synthetic identity. Paging still works — the feed cache is keyed by request id, not by user. Both logged-out paths tag their metrics `traffic=logged_out`, and the explainer counts as a render success rather than a failure, so signed-out traffic doesn't read as a failure spike on the dashboards.

## Verification

Unit suite: 1296 passing, including a `TestLoggedOut` class and the registry invariants above. No pre-existing test needed changing.

Against the devenv, with no `Authorization` header:

| feed | result |
|---|---|
| your-feed, best-of-friends | 200, single explainer post |
| random | 200, pinned post + real posts, paging across cursors |
| unranked-your-feed, cutoff-preview, cold-start, popularity, two-tower | 401 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)