### PR TITLE
Right-size Cloud Run concurrency: 80 -> 20, max-instances 10 -> 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Available configuration inputs across `gcp_setup.sh` and `deploy.sh`:
 - `GE_INFERENCE_DOMAIN` - Domain-mapped inference host used when base URL override is not set
 - `GE_ENABLE_INFERENCE_DOMAIN_MAPPING` - Toggle mapped-domain resolution in `deploy.sh` (default: true)
 - `API_INSTANCES_MIN` - Minimum instances (default: 1)
-- `API_INSTANCES_MAX` - Maximum instances (default: 10)
+- `API_INSTANCES_MAX` - Maximum instances (default: 20)
 
 For occasional local inference development while keeping stage/prod defaults:
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -42,7 +42,14 @@ GE_POSTHOG_HOST="https://us.i.posthog.com"
 
 # Service configuration
 API_INSTANCES_MIN="1"
-API_INSTANCES_MAX="10"
+# Sized from prod telemetry (issue #389): a CPU-vs-concurrency regression over
+# two load tests puts this 1-vCPU instance's saturation point at ~25 concurrent
+# requests; --concurrency below is set well under that. Cutting concurrency
+# from its previous 80 quarters the per-instance capacity, so the ceiling here
+# is raised to compensate -- CPU-throughput math (~0.34 CPU-s/request) says the
+# already-observed peak (460 req/min) needs only ~4 instances at a sane
+# per-instance utilization target, so 20 leaves several times that headroom.
+API_INSTANCES_MAX="20"
 API_REQUEST_TIMEOUT="60"
 
 # Colors for output
@@ -297,7 +304,12 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --cpu=1"
     deploy_cmd="$deploy_cmd --memory=512Mi"
     deploy_cmd="$deploy_cmd --timeout=$API_REQUEST_TIMEOUT"
-    deploy_cmd="$deploy_cmd --concurrency=80"
+    # See the API_INSTANCES_MAX comment above (issue #389): 80 let far more
+    # requests pile onto this 1-vCPU instance than it could actually run
+    # concurrently, so the autoscaler didn't add instances until CPU was
+    # already saturated. 20 keeps typical per-instance utilization ~75%,
+    # comfortably under the ~25-concurrency point where CPU saturates.
+    deploy_cmd="$deploy_cmd --concurrency=20"
 
     # Tag the service/revision with the git sha so past deployments are
     # identifiable when picking a rollback target (see issue #228).
@@ -510,7 +522,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --two-tower-knn-index IDX  Index for two-tower kNN (default: posts_recent_quality;"
             echo "                             use posts_recent if the quality corpus is not backfilled)"
             echo "  --min-instances N        Minimum instances (default: 1)"
-            echo "  --max-instances N        Maximum instances (default: 10)"
+            echo "  --max-instances N        Maximum instances (default: 20)"
             echo "  --timeout SECONDS        Cloud Run request timeout (default: 60)"
             echo "  --help                   Show this help message"
             exit 0


### PR DESCRIPTION
Closes #389

The gated `eventloop.lag_ms` monitor (#402, merged/deployed) ruled out request-path blocking as the cause of the original p99 lag report — the metric was mostly reporting `cpuIdle: true` throttling on an idle instance, and lag was flat across a 10x traffic swing. This PR addresses the concurrency-sizing half of the issue directly from production telemetry, independent of that fix.

# Data

Paired per-minute samples of `container/cpu/utilizations` (p99) against `container/max_request_concurrencies` (p99) across two load tests (2026-07-31, 2026-08-08), restricted to the genuinely-loaded regime (concurrency 5–17; excludes cold-start transients where a freshly-spun instance briefly inflated the concurrency reading with near-zero CPU):

```
utilization ≈ 0.043 + 0.0376 × concurrency     (n=37, R² = 0.52)

concurrency at 70% util:  17.5
concurrency at 75% util:  18.8
concurrency at 100% util (saturation): 25.5
```

This 1-vCPU instance saturates around **concurrency ≈ 25**. The previous `concurrency=80` let more than 3x that many requests pile onto one core before Cloud Run added another instance — its scale-out trigger is a fraction of the configured concurrency, so with 80 configured it didn't fire until each instance already carried 50+ concurrent requests, well past the point of CPU contention. Instance-count telemetry from the 08-08 test confirms this mechanism directly: the autoscaler plateaued at 7 instances for 20 minutes during a sustained ~460 req/min burst while CPU p99 sat at 0.6–0.66 and request p99 latency ran 6–7s.

# This PR

- `--concurrency`: 80 → **20** (~75% typical utilization at that point, comfortably under the ~25 saturation ceiling)
- `API_INSTANCES_MAX` default: 10 → **20**, to compensate. Cutting concurrency 4x without raising the instance ceiling would make the same burst *worse* — the same traffic now needs proportionally more instances just to hold steady. CPU-throughput math (mean ~0.34 CPU-s/request across the four clean load-test snapshots) says the already-observed peak (460 req/min) needs only ~4 instances at a 70% per-instance target under correctly-tuned autoscaling, so 20 leaves several times that headroom for growth without a standing cost — Cloud Run only bills for instances actually in use.

Both values are config passed to `gcloud run deploy`; no application code changes.

# Testing

- `pipenv run pyright` — 0 errors, 0 warnings
- `pipenv run pytest -v` — 1344 passed
- `bash -n scripts/deploy.sh` — syntax check
- No devenv verification: this is Cloud Run deploy configuration, not application behavior — devenv doesn't run under Cloud Run's autoscaler or CPU throttling, so it can't exercise this change. The next real deploy to stage is the actual verification point; recommend watching `container/cpu/utilizations` and `container/max_request_concurrencies` on stage for a day before promoting to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
