### PR TITLE
Collapse network_likes' serial likes/hydrate paging into one round trip

### DIFF
--- a/src/app/lib/candidates/generate.py
+++ b/src/app/lib/candidates/generate.py
@@ -150,6 +150,16 @@ async def run_generate(
                     generator_name=spec.name,
                     is_infill="false",
                 )
+                # Share of the requested allocation actually returned, so a
+                # generator that quietly under-fills for some users is visible
+                # without reading the feed slate.
+                returned = sum(len(result.candidates) for result in results)
+                mc.record(
+                    "candidates.generate.fill_share",
+                    min(returned / count, 1.0),
+                    generator_name=spec.name,
+                    is_infill="false",
+                )
             return [
                 result.model_copy(
                     update={"status": "empty", "reason": result.reason or "no_candidates"}

--- a/src/app/lib/candidates/generate_test.py
+++ b/src/app/lib/candidates/generate_test.py
@@ -311,6 +311,21 @@ class TestGeneratorTimeout:
         _, _, attrs = success_calls[0]
         assert attrs == {"generator_name": "popular", "is_infill": "false"}
 
+    @pytest.mark.asyncio
+    async def test_success_records_fill_share_metric(self, monkeypatch):
+        """A generator that under-fills its allocation is visible per generator."""
+        _stub_generators(monkeypatch, {"popular": _EmptyGenerator("popular")})
+        mc = FakeMetricCollector()
+        set_metric_collector(cast(MetricCollector, mc))
+
+        await run_generate(_make_request("popular", num_candidates=4), es=None)
+
+        fill_calls = [c for c in mc.calls if c[0] == "candidates.generate.fill_share"]
+        assert len(fill_calls) == 1
+        _, value, attrs = fill_calls[0]
+        assert value == 0.0
+        assert attrs == {"generator_name": "popular", "is_infill": "false"}
+
 
 # ---------------------------------------------------------------------------
 # Infill generator timeout/error tests

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -21,6 +21,7 @@ from ..bsky import FollowedUsersLookupError
 from ..config import fail_fast
 from ..elasticsearch import unwrap_es_response
 from ..followed_users_cache import MAX_FOLLOWED_USERS, get_followed_dids_cached
+from ..metrics import get_metric_collector
 from ..telemetry import timed
 from .base import CandidateGenerator, CandidateResult
 from .utils import CANDIDATE_SOURCE_FIELDS, candidate_posts_from_es_response
@@ -169,6 +170,40 @@ async def fetch_posts_by_uris(
     ]
 
 
+def _record_scan_telemetry(
+    *,
+    scanned_likes: int,
+    scan_size: int,
+    unique_uris: int,
+    hydrated_uris: int,
+    hydrated_hits: int,
+) -> None:
+    """Report whether either single-query limit was the binding constraint.
+
+    Scanning once instead of paging trades round trips for the risk of
+    under-filling a user's request. These say whether that happened and which
+    limit caused it: a saturated scan means more recent likes existed than the
+    scan window covered, a truncated hydrate means the scan found more unique
+    URIs than one hydrate query carries, and the hit share is the measured
+    likes-to-candidates yield the two limits are sized against.
+    """
+    if not hydrated_uris:
+        return
+
+    collector = get_metric_collector()
+    if collector is None:
+        return
+
+    collector.record(
+        "candidates.network_likes.hydrate_hit_share",
+        hydrated_hits / hydrated_uris,
+    )
+    if scanned_likes >= scan_size:
+        collector.record("candidates.network_likes.likes_scan_saturated_count", 1)
+    if unique_uris > hydrated_uris:
+        collector.record("candidates.network_likes.hydrate_truncated_count", 1)
+
+
 async def network_likes_search(
     es,
     user_did: str,
@@ -235,6 +270,14 @@ async def network_likes_search(
             exclude_uris=exclude_uris,
             max_age_hours=max_age_hours,
         )
+
+    _record_scan_telemetry(
+        scanned_likes=len(liked_uris),
+        scan_size=scan_size,
+        unique_uris=len(like_counts),
+        hydrated_uris=len(ranked_uris),
+        hydrated_hits=len(hydrated),
+    )
 
     # fetch_posts_by_uris preserves the requested URI order, which is already
     # the final ranking.

--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -2,19 +2,19 @@
 
 The likes index and posts index are not perfectly aligned: a recent like can
 point at a post that is missing from our posts index, filtered out, a reply, or
-otherwise unavailable as a candidate. To avoid guessing one fixed number of
-liked URIs up front, this generator pages through recent likes with
-``search_after`` until it has enough matching posts or reaches a hard scan cap.
+otherwise unavailable as a candidate. Rather than paging through likes until
+enough posts match — which cost ~5 serial ES round trips inside a 4s budget —
+this generator overfetches recent likes in a single query and hydrates the
+resulting URIs in a single second query.
 
-As pages are scanned, repeated likes for the same post are deduplicated before
-querying the posts index, but the repeated like count is retained and used as
-the candidate score. Final ordering is by like count descending, with
-last-seen like recency as the tie-breaker.
+Repeated likes for the same post are deduplicated before querying the posts
+index, but the repeated like count is retained and used as the candidate score.
+Ordering is by like count descending, with last-seen like recency as the
+tie-breaker; that same ordering picks which URIs are hydrated when the scan
+yields more unique URIs than one hydrate query should carry.
 """
 
 import logging
-from dataclasses import dataclass
-from typing import Any
 
 from ...models import CandidatePost, MaxAgeHours
 from ..bsky import FollowedUsersLookupError
@@ -36,38 +36,57 @@ logger = logging.getLogger(__name__)
 # imported from followed_users_cache so the fetch cap and the query cap cannot
 # drift apart.
 
-# Minimum number of recent likes to fetch in each page.
-LIKED_POSTS_PAGE_SIZE = 100
+# Likes scanned per requested candidate. Only a minority of recent likes point
+# at a post that survives hydration, so the single scan overfetches heavily.
+LIKES_OVERFETCH_FACTOR = 20
+
+# Floor on the single likes scan, so small candidate requests still see enough
+# likes to survive index skew without a second round trip.
+MIN_LIKES_SCANNED = 1_000
 
 # Hard cap on how many like documents to scan while looking for post hits.
 MAX_LIKES_SCANNED = 5_000
 
+# Hydrated docs carry embeddings, so the hydrate query is bounded more tightly
+# than the likes scan: only the best-ranked URIs from the scan are hydrated.
+HYDRATE_OVERFETCH_FACTOR = 10
+MIN_HYDRATED_URIS = 300
+MAX_HYDRATED_URIS = 1_000
+
 # Lookback window for finding the matching posts
 MAX_AGE_HOURS = 168
+
+
+def liked_post_scan_size(num_candidates: int) -> int:
+    """Number of like documents to pull in the generator's single likes query."""
+    return min(
+        max(MIN_LIKES_SCANNED, num_candidates * LIKES_OVERFETCH_FACTOR),
+        MAX_LIKES_SCANNED,
+    )
+
+
+def hydrated_uri_limit(num_candidates: int) -> int:
+    """Number of scanned URIs to send to the generator's single hydrate query."""
+    return min(
+        max(MIN_HYDRATED_URIS, num_candidates * HYDRATE_OVERFETCH_FACTOR),
+        MAX_HYDRATED_URIS,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Query helper
 # ---------------------------------------------------------------------------
 
-@dataclass(frozen=True)
-class LikedPostUriPage:
-    uris: list[str]
-    next_search_after: list[Any] | None
-    hit_count: int
-
-
-async def fetch_recent_liked_post_uri_page(
+async def fetch_recent_liked_post_uris(
     es,
     user_dids: list[str],
     size: int,
-    search_after: list[Any] | None = None,
     max_age_hours: MaxAgeHours = MAX_AGE_HOURS,
     exclude_uris: list[str] | None = None,
-) -> LikedPostUriPage:
-    """Return one page of recently liked post URIs for the given users."""
+) -> list[str]:
+    """Return recently liked post URIs for the given users, most recent first."""
     if not user_dids or size <= 0:
-        return LikedPostUriPage(uris=[], next_search_after=None, hit_count=0)
+        return []
 
     query = {
         "bool": {
@@ -82,10 +101,6 @@ async def fetch_recent_liked_post_uri_page(
             {"terms": {"subject_uri": exclude_uris}},
         ]
 
-    search_kwargs: dict[str, Any] = {}
-    if search_after is not None:
-        search_kwargs["search_after"] = search_after
-
     resp = await es.search(
         index="likes",
         op="likes",
@@ -93,7 +108,6 @@ async def fetch_recent_liked_post_uri_page(
         size=size,
         sort=[{"created_at": "desc"}],
         _source=["subject_uri"],
-        **search_kwargs,
     )
 
     data = unwrap_es_response(resp)
@@ -104,15 +118,7 @@ async def fetch_recent_liked_post_uri_page(
         if uri:
             uris.append(uri)
 
-    next_search_after = None
-    if hits:
-        next_search_after = hits[-1].get("sort")
-
-    return LikedPostUriPage(
-        uris=uris,
-        next_search_after=next_search_after,
-        hit_count=len(hits),
-    )
+    return uris
 
 
 async def fetch_posts_by_uris(
@@ -191,75 +197,52 @@ async def network_likes_search(
     if not followed_dids:
         return []
 
-    page_size = min(
-        max(LIKED_POSTS_PAGE_SIZE, num_candidates * 3),
-        MAX_LIKES_SCANNED,
-    )
-    search_after: list[Any] | None = None
-    scanned_likes = 0
-    queried_uris: set[str] = set()
+    scan_size = liked_post_scan_size(num_candidates)
     like_counts: dict[str, int] = {}
     last_seen_order: dict[str, int] = {}
-    liked_uri_order = 0
-    candidates_by_uri: dict[str, CandidatePost] = {}
 
     async with timed(
         logger,
         "es_network_likes_search",
         n_followed=len(followed_dids),
         num_candidates=num_candidates,
+        scan_size=scan_size,
     ):
-        while len(candidates_by_uri) < num_candidates and scanned_likes < MAX_LIKES_SCANNED:
-            remaining_budget = MAX_LIKES_SCANNED - scanned_likes
-            page = await fetch_recent_liked_post_uri_page(
-                es,
-                followed_dids,
-                size=min(page_size, remaining_budget),
-                search_after=search_after,
-                max_age_hours=max_age_hours,
-                exclude_uris=exclude_uris,
-            )
-
-            if page.hit_count == 0:
-                break
-
-            scanned_likes += page.hit_count
-
-            new_uris: list[str] = []
-            for uri in page.uris:
-                like_counts[uri] = like_counts.get(uri, 0) + 1
-                last_seen_order[uri] = liked_uri_order
-                liked_uri_order += 1
-                if uri not in queried_uris:
-                    queried_uris.add(uri)
-                    new_uris.append(uri)
-
-            for candidate in await fetch_posts_by_uris(
-                es,
-                new_uris,
-                generator_name=generator_name,
-                video_only=video_only,
-                exclude_uris=exclude_uris,
-                max_age_hours=max_age_hours,
-            ):
-                if candidate.at_uri:
-                    candidates_by_uri[candidate.at_uri] = candidate
-
-            if page.next_search_after is None or page.hit_count < min(page_size, remaining_budget):
-                break
-            search_after = page.next_search_after
-
-    candidates = [
-        candidate.model_copy(update={"score": float(like_counts[at_uri])})
-        for at_uri, candidate in candidates_by_uri.items()
-        if at_uri in like_counts
-    ]
-    candidates.sort(
-        key=lambda candidate: (
-            -(candidate.score or 0.0),
-            last_seen_order.get(candidate.at_uri or "", liked_uri_order),
+        liked_uris = await fetch_recent_liked_post_uris(
+            es,
+            followed_dids,
+            size=scan_size,
+            max_age_hours=max_age_hours,
+            exclude_uris=exclude_uris,
         )
-    )
+
+        for order, uri in enumerate(liked_uris):
+            like_counts[uri] = like_counts.get(uri, 0) + 1
+            last_seen_order[uri] = order
+
+        # Likes come back most-recent-first, so a lower last-seen order means a
+        # more recent like.
+        ranked_uris = sorted(
+            like_counts,
+            key=lambda uri: (-like_counts[uri], last_seen_order[uri]),
+        )[:hydrated_uri_limit(num_candidates)]
+
+        hydrated = await fetch_posts_by_uris(
+            es,
+            ranked_uris,
+            generator_name=generator_name,
+            video_only=video_only,
+            exclude_uris=exclude_uris,
+            max_age_hours=max_age_hours,
+        )
+
+    # fetch_posts_by_uris preserves the requested URI order, which is already
+    # the final ranking.
+    candidates = [
+        candidate.model_copy(update={"score": float(like_counts[candidate.at_uri])})
+        for candidate in hydrated
+        if candidate.at_uri in like_counts
+    ]
     return candidates[:num_candidates]
 
 

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -462,6 +462,99 @@ class TestNetworkLikesSearch:
         assert es.calls == []
 
 
+class _RecordingCollector:
+    def __init__(self):
+        self.records = []
+
+    def record(self, name, value, **attrs):
+        self.records.append((name, value, attrs))
+
+    def value(self, name):
+        return next(value for recorded, value, _ in self.records if recorded == name)
+
+    def names(self):
+        return [name for name, _, _ in self.records]
+
+
+class TestNetworkLikesTelemetry:
+    """Under-fill is the risk of scanning once instead of paging: these metrics
+    say whether it happened and which limit caused it."""
+
+    @pytest.fixture
+    def collector(self, monkeypatch):
+        collector = _RecordingCollector()
+        monkeypatch.setattr(network_likes_module, "get_metric_collector", lambda: collector)
+        return collector
+
+    @pytest.mark.asyncio
+    async def test_records_hydrate_yield_and_no_saturation_when_under_the_limits(
+        self,
+        collector,
+        monkeypatch,
+    ):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        es = FakeEs(
+            likes=likes_response([
+                like_hit("at://post/a", 3),
+                like_hit("at://missing/1", 2),
+                like_hit("at://missing/2", 1),
+            ]),
+            posts_by_uri={"at://post/a": post_hit("at://post/a")},
+        )
+
+        await network_likes_search(es, "did:plc:user1", num_candidates=10)
+
+        assert collector.value("candidates.network_likes.hydrate_hit_share") == 1 / 3
+        assert "candidates.network_likes.likes_scan_saturated_count" not in collector.names()
+        assert "candidates.network_likes.hydrate_truncated_count" not in collector.names()
+
+    @pytest.mark.asyncio
+    async def test_counts_a_saturated_likes_scan(self, collector, monkeypatch):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        monkeypatch.setattr(network_likes_module, "MIN_LIKES_SCANNED", 2)
+        monkeypatch.setattr(network_likes_module, "MAX_LIKES_SCANNED", 2)
+        es = FakeEs(
+            likes=likes_response([
+                like_hit("at://post/a", 2),
+                like_hit("at://post/b", 1),
+            ]),
+            posts_by_uri={"at://post/a": post_hit("at://post/a")},
+        )
+
+        await network_likes_search(es, "did:plc:user1", num_candidates=10)
+
+        assert collector.value("candidates.network_likes.likes_scan_saturated_count") == 1
+
+    @pytest.mark.asyncio
+    async def test_counts_a_truncated_hydrate(self, collector, monkeypatch):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        monkeypatch.setattr(network_likes_module, "MAX_HYDRATED_URIS", 1)
+        es = FakeEs(
+            likes=likes_response([
+                like_hit("at://post/a", 2),
+                like_hit("at://post/b", 1),
+            ]),
+            posts_by_uri={"at://post/a": post_hit("at://post/a")},
+        )
+
+        await network_likes_search(es, "did:plc:user1", num_candidates=10)
+
+        assert collector.value("candidates.network_likes.hydrate_truncated_count") == 1
+
+    @pytest.mark.asyncio
+    async def test_records_nothing_when_there_are_no_likes_to_hydrate(
+        self,
+        collector,
+        monkeypatch,
+    ):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        es = FakeEs(likes=likes_response([]))
+
+        await network_likes_search(es, "did:plc:user1", num_candidates=10)
+
+        assert collector.names() == []
+
+
 class TestNetworkLikesCandidateGenerator:
     @pytest.mark.asyncio
     async def test_name(self, generator):

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -7,7 +7,9 @@ from ..candidates import network_likes as network_likes_module
 from ..candidates.network_likes import (
     NetworkLikesCandidateGenerator,
     fetch_posts_by_uris,
-    fetch_recent_liked_post_uri_page,
+    fetch_recent_liked_post_uris,
+    hydrated_uri_limit,
+    liked_post_scan_size,
     network_likes_search,
 )
 from ..embeddings import MINILM_L12_EMBEDDING_KEY
@@ -54,11 +56,11 @@ class FakeEs:
     def __init__(
         self,
         *,
-        likes_pages: list[dict] | None = None,
+        likes: dict | None = None,
         posts_by_uri: dict[str, dict] | None = None,
         posts_return_order: list[str] | None = None,
     ):
-        self.likes_pages = list(likes_pages or [])
+        self.likes = likes
         self.posts_by_uri = posts_by_uri or {}
         self.posts_return_order = posts_return_order
         self.calls: list[dict] = []
@@ -85,24 +87,22 @@ class FakeEs:
         })
 
         if index == "likes":
-            if self.likes_pages:
-                response = self.likes_pages.pop(0)
-                query_body = query if isinstance(query, dict) else {}
-                excluded_uris = {
-                    uri
-                    for clause in query_body.get("bool", {}).get("must_not", [])
-                    for uri in clause.get("terms", {}).get("subject_uri", [])
-                }
-                if excluded_uris:
-                    hits = response.get("hits", {}).get("hits", [])
-                    return likes_response([
-                        hit
-                        for hit in hits
-                        if (hit.get("_source") or {}).get("subject_uri")
-                        not in excluded_uris
-                    ])
-                return response
-            return likes_response([])
+            if self.likes is None:
+                return likes_response([])
+            query_body = query if isinstance(query, dict) else {}
+            excluded_uris = {
+                uri
+                for clause in query_body.get("bool", {}).get("must_not", [])
+                for uri in clause.get("terms", {}).get("subject_uri", [])
+            }
+            hits = self.likes.get("hits", {}).get("hits", [])
+            if excluded_uris:
+                hits = [
+                    hit
+                    for hit in hits
+                    if (hit.get("_source") or {}).get("subject_uri") not in excluded_uris
+                ]
+            return likes_response(hits[: size or len(hits)])
 
         if index == "posts_recent":
             assert query is not None
@@ -130,29 +130,50 @@ def stub_followed_dids(monkeypatch, dids: list[str]):
     )
 
 
-class TestFetchRecentLikedPostUriPage:
-    @pytest.mark.asyncio
-    async def test_returns_uris_and_next_search_after(self):
-        es = FakeEs(likes_pages=[
-            likes_response([
-                like_hit("at://post/1", 3),
-                like_hit(None, 2),
-                like_hit("at://post/2", 1),
-            ])
-        ])
+class TestLikedPostScanSize:
+    def test_scales_with_num_candidates_between_floor_and_cap(self):
+        assert liked_post_scan_size(1) == network_likes_module.MIN_LIKES_SCANNED
+        assert liked_post_scan_size(1_000_000) == network_likes_module.MAX_LIKES_SCANNED
 
-        page = await fetch_recent_liked_post_uri_page(
+        num_candidates = network_likes_module.MIN_LIKES_SCANNED
+        assert liked_post_scan_size(num_candidates) == min(
+            num_candidates * network_likes_module.LIKES_OVERFETCH_FACTOR,
+            network_likes_module.MAX_LIKES_SCANNED,
+        )
+
+
+class TestHydratedUriLimit:
+    def test_scales_with_num_candidates_between_floor_and_cap(self):
+        assert hydrated_uri_limit(1) == network_likes_module.MIN_HYDRATED_URIS
+        assert hydrated_uri_limit(1_000_000) == network_likes_module.MAX_HYDRATED_URIS
+        assert hydrated_uri_limit(50) == max(
+            network_likes_module.MIN_HYDRATED_URIS,
+            50 * network_likes_module.HYDRATE_OVERFETCH_FACTOR,
+        )
+
+    def test_never_exceeds_the_likes_scan(self):
+        for num_candidates in (1, 30, 100, 10_000):
+            assert hydrated_uri_limit(num_candidates) <= liked_post_scan_size(num_candidates)
+
+
+class TestFetchRecentLikedPostUris:
+    @pytest.mark.asyncio
+    async def test_returns_uris_in_like_recency_order(self):
+        es = FakeEs(likes=likes_response([
+            like_hit("at://post/1", 3),
+            like_hit(None, 2),
+            like_hit("at://post/2", 1),
+        ]))
+
+        uris = await fetch_recent_liked_post_uris(
             es,
             ["did:plc:follow1"],
             size=50,
-            search_after=["cursor"],
             max_age_hours=48,
             exclude_uris=["at://post/seen"],
         )
 
-        assert page.uris == ["at://post/1", "at://post/2"]
-        assert page.next_search_after == [1]
-        assert page.hit_count == 3
+        assert uris == ["at://post/1", "at://post/2"]
 
         call = es.calls[0]
         assert call["index"] == "likes"
@@ -170,17 +191,13 @@ class TestFetchRecentLikedPostUriPage:
         assert call["size"] == 50
         assert call["sort"] == [{"created_at": "desc"}]
         assert call["_source"] == ["subject_uri"]
-        assert call["search_after"] == ["cursor"]
+        assert call["search_after"] is None
 
     @pytest.mark.asyncio
     async def test_skips_es_when_input_is_empty(self):
         es = FakeEs()
 
-        page = await fetch_recent_liked_post_uri_page(es, [], size=50)
-
-        assert page.uris == []
-        assert page.next_search_after is None
-        assert page.hit_count == 0
+        assert await fetch_recent_liked_post_uris(es, [], size=50) == []
         assert es.calls == []
 
 
@@ -245,27 +262,20 @@ class TestFetchPostsByUris:
 
 class TestNetworkLikesSearch:
     @pytest.mark.asyncio
-    async def test_paginates_until_enough_post_hits_and_scores_by_like_count(
+    async def test_uses_one_likes_and_one_hydrate_call_and_scores_by_like_count(
         self,
         monkeypatch,
     ):
         stub_followed_dids(monkeypatch, ["did:plc:follow1", "did:plc:follow2"])
-        monkeypatch.setattr(network_likes_module, "LIKED_POSTS_PAGE_SIZE", 1)
-        monkeypatch.setattr(network_likes_module, "MAX_LIKES_SCANNED", 10)
         es = FakeEs(
-            likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 60),
-                    like_hit("at://missing/1", 50),
-                    like_hit("at://missing/2", 40),
-                    like_hit("at://post/a", 30),
-                    like_hit("at://missing/3", 20),
-                    like_hit("at://missing/4", 10),
-                ]),
-                likes_response([
-                    like_hit("at://post/b", 1),
-                ]),
-            ],
+            likes=likes_response([
+                like_hit("at://post/a", 60),
+                like_hit("at://missing/1", 50),
+                like_hit("at://missing/2", 40),
+                like_hit("at://post/a", 30),
+                like_hit("at://missing/3", 20),
+                like_hit("at://post/b", 10),
+            ]),
             posts_by_uri={
                 "at://post/a": post_hit("at://post/a"),
                 "at://post/b": post_hit("at://post/b"),
@@ -289,23 +299,54 @@ class TestNetworkLikesSearch:
         ]
 
         likes_calls = [call for call in es.calls if call["index"] == "likes"]
-        assert [call["search_after"] for call in likes_calls] == [None, [10]]
-
         posts_calls = [call for call in es.calls if call["index"] == "posts_recent"]
+        assert len(likes_calls) == 1
+        assert len(posts_calls) == 1
+        assert likes_calls[0]["size"] == liked_post_scan_size(2)
         assert post_terms_from_query(posts_calls[0]["query"]) == [
             "at://post/a",
             "at://missing/1",
             "at://missing/2",
             "at://missing/3",
-            "at://missing/4",
+            "at://post/b",
         ]
-        assert post_terms_from_query(posts_calls[1]["query"]) == ["at://post/b"]
+
+    @pytest.mark.asyncio
+    async def test_hydrates_only_the_most_liked_uris_when_over_the_cap(self, monkeypatch):
+        stub_followed_dids(monkeypatch, ["did:plc:follow1"])
+        monkeypatch.setattr(network_likes_module, "MAX_HYDRATED_URIS", 2)
+        es = FakeEs(
+            likes=likes_response([
+                like_hit("at://post/cold", 5),
+                like_hit("at://post/hot", 4),
+                like_hit("at://post/hot", 3),
+                like_hit("at://post/warm", 2),
+                like_hit("at://post/warm", 1),
+            ]),
+            posts_by_uri={
+                "at://post/hot": post_hit("at://post/hot"),
+                "at://post/warm": post_hit("at://post/warm"),
+                "at://post/cold": post_hit("at://post/cold"),
+            },
+        )
+
+        candidates = await network_likes_search(es, "did:plc:user1", num_candidates=3)
+
+        posts_call = next(call for call in es.calls if call["index"] == "posts_recent")
+        assert post_terms_from_query(posts_call["query"]) == [
+            "at://post/hot",
+            "at://post/warm",
+        ]
+        assert [candidate.at_uri for candidate in candidates] == [
+            "at://post/hot",
+            "at://post/warm",
+        ]
 
     @pytest.mark.asyncio
     async def test_applies_requested_freshness_to_likes_and_posts(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
-            likes_pages=[likes_response([like_hit("at://post/a", 1)])],
+            likes=likes_response([like_hit("at://post/a", 1)]),
             posts_by_uri={"at://post/a": post_hit("at://post/a")},
         )
 
@@ -327,12 +368,10 @@ class TestNetworkLikesSearch:
     async def test_excludes_seen_uris_from_likes_query(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
-            likes_pages=[
-                likes_response([
-                    like_hit("at://post/seen", 2),
-                    like_hit("at://post/a", 1),
-                ])
-            ],
+            likes=likes_response([
+                like_hit("at://post/seen", 2),
+                like_hit("at://post/a", 1),
+            ]),
             posts_by_uri={
                 "at://post/seen": post_hit("at://post/seen"),
                 "at://post/a": post_hit("at://post/a"),
@@ -357,16 +396,13 @@ class TestNetworkLikesSearch:
     @pytest.mark.asyncio
     async def test_respects_hard_likes_scan_cap(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
-        monkeypatch.setattr(network_likes_module, "LIKED_POSTS_PAGE_SIZE", 1)
         monkeypatch.setattr(network_likes_module, "MAX_LIKES_SCANNED", 4)
-        es = FakeEs(likes_pages=[
-            likes_response([
-                like_hit("at://missing/1", 4),
-                like_hit("at://missing/2", 3),
-                like_hit("at://missing/3", 2),
-                like_hit("at://missing/4", 1),
-            ])
-        ])
+        es = FakeEs(likes=likes_response([
+            like_hit("at://missing/1", 4),
+            like_hit("at://missing/2", 3),
+            like_hit("at://missing/3", 2),
+            like_hit("at://missing/4", 1),
+        ]))
 
         candidates = await network_likes_search(es, "did:plc:user1", num_candidates=2)
 
@@ -379,14 +415,12 @@ class TestNetworkLikesSearch:
     async def test_equal_like_counts_tie_break_by_last_seen_recency(self, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
-            likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 4),
-                    like_hit("at://post/b", 3),
-                    like_hit("at://post/b", 2),
-                    like_hit("at://post/a", 1),
-                ])
-            ],
+            likes=likes_response([
+                like_hit("at://post/a", 4),
+                like_hit("at://post/b", 3),
+                like_hit("at://post/b", 2),
+                like_hit("at://post/a", 1),
+            ]),
             posts_by_uri={
                 "at://post/a": post_hit("at://post/a"),
                 "at://post/b": post_hit("at://post/b"),
@@ -437,12 +471,10 @@ class TestNetworkLikesCandidateGenerator:
     async def test_generate(self, generator, monkeypatch):
         stub_followed_dids(monkeypatch, ["did:plc:follow1"])
         es = FakeEs(
-            likes_pages=[
-                likes_response([
-                    like_hit("at://post/a", 2),
-                    like_hit("at://post/a", 1),
-                ])
-            ],
+            likes=likes_response([
+                like_hit("at://post/a", 2),
+                like_hit("at://post/a", 1),
+            ]),
             posts_by_uri={"at://post/a": post_hit("at://post/a")},
         )
 


### PR DESCRIPTION
Closes #390

network_likes averaged ~5 serial ES calls per run (2.6 likes pages + 2.6 hydrates, p95 ~1s each) inside a 4s budget. The paging existed to absorb likes/posts index skew, not a bsky limit, so this overfetches once instead of discovering how far to page.

# This PR

Replaces the `search_after` paging loop with a single likes scan followed by a single hydrate — 2 ES round trips regardless of index skew — and instruments the under-fill risk that trade introduces. Specifically:

- Replace `fetch_recent_liked_post_uri_page` (and `LikedPostUriPage`) with `fetch_recent_liked_post_uris`, which takes no cursor and returns URIs directly
- Scan `liked_post_scan_size(num_candidates)` likes in one query: `num_candidates * 20`, floored at 1000 and capped at the existing `MAX_LIKES_SCANNED` (5000). The old loop averaged ~260 likes to fill 30 candidates (2.6 pages x 100), i.e. ~1 surviving candidate per 9 likes; the factor of 20 is ~2.2x that yield and the 1000 floor is ~3.8x the average scan, so the tail that was driving the extra pages is covered in one shot. Enlarging this query is cheap: `_source` is one keyword field, the filter is terms + range, the sort is an indexed date
- Rank all scanned URIs by like count desc, then last-seen like recency, and hydrate only the top `hydrated_uri_limit(num_candidates)` (`num_candidates * 10`, floored at 300, capped at 1000). Hydrated docs carry embeddings, so the hydrate is deliberately decoupled from the scan — otherwise this trades 3 round trips for a much fatter fetch phase. 300 URIs at `num_candidates=30` is what the old loop hydrated in total across its pages, so fetch cost stays in today's range
- Ranking semantics are unchanged (like count desc, last-seen recency tie-break), but like counts are now computed over the whole scan rather than only the pages visited before the loop exited, so scores are a stronger signal

## Telemetry

The factors above are derived from the mean in #390 (2.6 pages), not from a measured p95 page count or per-URI hit rate, so the open question is whether some users now get fewer candidates than the paging loop would have found. These metrics answer it:

- `candidates.generate.fill_share` (labels: `generator_name`, `is_infill`) — share of a generator's requested allocation actually returned. Not generator-specific by design: it makes under-fill visible for every generator and gives network_likes a baseline to be compared against. Recorded on the primary path only — the infill path deliberately requests `shortfall * 2`, so a fill share against that denominator would read as chronic under-fill by construction
- `candidates.network_likes.likes_scan_saturated_count` — the scan returned a full window, i.e. more recent likes existed than it covered (the scan size is the binding constraint)
- `candidates.network_likes.hydrate_truncated_count` — the scan found more unique URIs than one hydrate query carries (the hydrate limit is the binding constraint)
- `candidates.network_likes.hydrate_hit_share` — measured likes-to-candidates yield, i.e. the 1-in-9 assumption both limits are sized against

Together these separate "this user has thin network activity" from "our limits cut them off", and say which limit to move.

# Testing

- Full suite on the host: `pytest -q` -> 1353 passed; `pyright` on the changed files -> 0 errors; `ruff check` on the changed files adds no new findings (the 7 reported are pre-existing lines)
- Full suite inside the devenv api container (instance `issue390`, own worktree, shared read-only ES): `devctl --name issue390 exec api pipenv run pytest -q` -> 1348 passed (run against the first commit; the telemetry commit adds no ES surface)
- Real ES client / real queries inside the container, 134 followed DIDs sampled from the likes index, `num_candidates=30`:
  - `max_age_hours=168` -> 1 ES call (`likes` size=1000), 0 candidates, no hydrate issued
  - `max_age_hours=720` -> 2 ES calls (`likes` size=1000, `posts_recent` 300 terms), 49ms, 30 candidates, like-count scores up to 4.0
- Real HTTP path: `POST /candidates/generate` with `network_likes` -> 200, `es_network_likes_search` timing line clean, no traceback in `devctl logs api`
- New metric names recorded through a real `MetricCollector` (unit tests use a fake): all four export, and both `_share` metrics pick up `RATIO_BOUNDARIES` rather than the SDK default that buckets all of [0, 1] together
- `devctl feed network-likes` returns empty on this instance because the shared fixture's newest post is 309h old and the API caps `max_age_hours` at 168 — pre-existing data drift, reproduced identically before the change; not re-seeded, since the ES data is shared with other instances
- Baseline comparison on the same data: `main` made 2 calls (`likes` 100, `posts_recent` 92) and topped out at score 2.0. The dev fixture is dense enough that `main` fills its quota on page one, so it does not reproduce the ~5-call production case; the new path is 2 round trips in both the dense and the skewed case