### PR TITLE
Size network_likes' single scan for the real 3-6 candidate allocation

### DIFF
--- a/src/app/lib/candidates/network_likes.py
+++ b/src/app/lib/candidates/network_likes.py
@@ -37,21 +37,31 @@ logger = logging.getLogger(__name__)
 # imported from followed_users_cache so the fetch cap and the query cap cannot
 # drift apart.
 
-# Likes scanned per requested candidate. Only a minority of recent likes point
-# at a post that survives hydration, so the single scan overfetches heavily.
+# Sizing is against the allocation this generator actually receives: prod feeds
+# request 30 candidates total and split them by weight, leaving network_likes
+# with 3-6 (the num_candidates=30 in its debug feed is a single-generator
+# budget, not the real path). Floors sized for 30 bound every real request
+# instead of only unusual ones, which is what made #390 a p50 regression.
+
+# Likes scanned per requested candidate. Prod measures ~0.40 of hydrated URIs
+# coming back as posts and roughly half the scanned likes deduplicating away,
+# so ~5 likes per candidate is the working yield; 20 is 4x that headroom.
 LIKES_OVERFETCH_FACTOR = 20
 
-# Floor on the single likes scan, so small candidate requests still see enough
-# likes to survive index skew without a second round trip.
-MIN_LIKES_SCANNED = 1_000
+# Floor on the single likes scan. Matches what the old paging loop consumed in
+# total for a typical request (~2 pages of 100), so index skew is absorbed
+# without reintroducing the round trips.
+MIN_LIKES_SCANNED = 200
 
 # Hard cap on how many like documents to scan while looking for post hits.
 MAX_LIKES_SCANNED = 5_000
 
 # Hydrated docs carry embeddings, so the hydrate query is bounded more tightly
 # than the likes scan: only the best-ranked URIs from the scan are hydrated.
+# At the measured 0.40 hit share the floor still yields ~20 posts for a 3-6
+# candidate allocation.
 HYDRATE_OVERFETCH_FACTOR = 10
-MIN_HYDRATED_URIS = 300
+MIN_HYDRATED_URIS = 50
 MAX_HYDRATED_URIS = 1_000
 
 # Lookback window for finding the matching posts

--- a/src/app/lib/candidates/network_likes_test.py
+++ b/src/app/lib/candidates/network_likes_test.py
@@ -142,6 +142,24 @@ class TestLikedPostScanSize:
         )
 
 
+class TestSizingAtTheRealAllocation:
+    """Prod feeds split num_candidates=30 across generators by weight, so
+    network_likes is asked for 3-6 — never the 30 of its debug feed. Sizing the
+    floors for 30 made every real request scan and hydrate ~10x what it needed
+    (see #416); these pin the numbers the real path actually gets."""
+
+    def test_scan_and_hydrate_are_sized_for_three_to_six_candidates(self):
+        assert [liked_post_scan_size(c) for c in (3, 6)] == [200, 200]
+        assert [hydrated_uri_limit(c) for c in (3, 6)] == [50, 60]
+
+    def test_hydrate_covers_the_measured_yield_with_headroom(self):
+        # Measured in prod: candidates.network_likes.hydrate_hit_share ~= 0.40.
+        measured_hit_share = 0.40
+        for num_candidates in (3, 6):
+            expected = hydrated_uri_limit(num_candidates) * measured_hit_share
+            assert expected >= num_candidates * 3
+
+
 class TestHydratedUriLimit:
     def test_scales_with_num_candidates_between_floor_and_cap(self):
         assert hydrated_uri_limit(1) == network_likes_module.MIN_HYDRATED_URIS


### PR DESCRIPTION
Closes #416

#390 collapsed network_likes' likes/hydrate paging into one round trip. It removed the round trips, but prod metrics since 04b72e2 show a p50 regression rather than a win, because the sizing floors were derived from the wrong `num_candidates`.

| network_likes, real traffic | before #390 | after #390 |
|---|---|---|
| p50 | 200-300ms | 400-500ms |
| p90 | 800-1000ms | 1250-1500ms |
| p95 | 1500-1750ms | 1500-1750ms |
| p99 | 1750-2000ms | 1750-2000ms |

`followed_users`, `popularity` and `two_tower` are flat or better over the same windows, so this is #390 and not the environment.

Prod feeds request `num_candidates=30` **in total** and split it across generators by weight; network_likes carries 0.10-0.20 in the social-radius presets, so `allocate_counts` hands it **3-6 candidates per request**. The `num_candidates=30` #390 sized against is the single-generator debug feed's whole budget and never occurs on the real path. The result was that `MIN_LIKES_SCANNED=1000` and `MIN_HYDRATED_URIS=300` bound on 100% of real requests: 1000 likes scanned and 300 embedding-bearing docs hydrated to return 3-6 posts.

# This PR

Keeps the single round trip and re-sizes the floors against the real allocation and the yield #390's telemetry measured:

- `MIN_LIKES_SCANNED` 1000 -> 200 — roughly what the old paging loop consumed in total for a typical request (~2 pages of 100), so index skew is still absorbed in one shot
- `MIN_HYDRATED_URIS` 300 -> 50 — at the measured 0.40 hydrate hit share that is ~20 posts for a 3-6 candidate allocation
- Both overfetch factors are unchanged, so a caller that genuinely asks for 30+ (the debug feeds, `/candidates/generate`) still scales up to the same ceilings
- Adds tests pinning the numbers the real path receives, and a comment recording why the sizing is anchored to 3-6

Measured evidence behind the new numbers, from the telemetry added in #390 (50 min of prod traffic, cold start excluded):

- `hydrate_hit_share` = 0.40 (#390 assumed ~0.11)
- `likes_scan_saturated_count` and `hydrate_truncated_count` each fired on ~91% of real runs — both caps bound on nearly every request
- `fill_share` for network_likes = 0.91, vs 0.96 followed_users and 1.00 popularity

## Not included: routing

I tried adding `routing=",".join(user_dids)` to the likes scan, mirroring the helpers in `lib/elasticsearch.py` whose comment says it "searches one shard per weekly index instead of fanning out". Measured against a real ES 9.0.0 with `_routing` required and docs indexed `routing=author_did` (as ingex does), routing returns an identical hit set and order — but it only prunes shards while the number of distinct routing values is below the shard count:

```
index has 5 shards
  routing on  1 dids -> shards queried: 1  (unrouted: 5)
  routing on  3 dids -> shards queried: 3  (unrouted: 5)
  routing on  5 dids -> shards queried: 5  (unrouted: 5)
  routing on 12 dids -> shards queried: 5  (unrouted: 5)
```

With `MAX_FOLLOWED_USERS=1000` every shard is queried anyway, and the routing string would add ~32KB to each request. So it is not a lever at our follow counts — worth knowing before someone else tries it, and the comment in `lib/elasticsearch.py` overstates the benefit for the 1000-DID lookups.

# Testing

- `pytest -q` -> 1398 passed; `pyright` on the changed files -> 0 errors; `ruff check` adds no new findings
- Routing behavior measured against a throwaway real Elasticsearch 9.0.0 (identical hit sets, shard-pruning table above), which is what led to dropping it
- **Not run: devenv.** The local Docker VM was wiped (no images, containers or volumes survive), so `devctl` needs a full `bootstrap` before any instance can start. Given the change is three constants plus tests, with the behavior they feed already exercised in #390's devenv run, I did not rebuild the environment to re-verify — worth a `devctl feed` pass if the environment gets rebuilt before merge
- The real check for this one is prod: after deploy, `candidates.generate.duration_ms{generator_name=network_likes}` p50 should return to ~200-300ms, `likes_scan_saturated_count` should stop firing on nearly every request, and `fill_share` should hold at ~0.91 or better. If fill drops, the floors are too low and the scan floor is the knob to raise