### PR TITLE
Degradation metrics and Pinned Posts deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ export API_KEY="your-fast-api-client-key-here"
 # e.g. did:web:your-subdomain.ngrok.dev  or  did:web:your-domain.example.com
 export GE_FEED_GENERATOR_DID="did:web:your-subdomain.ngrok.dev"
 
+# Optional local overrides for repository-managed public feed pins. The
+# deployment script publishes/reuses these posts and sets the values itself.
+export GE_PINNED_POST_YOUR_FEED_URI=""
+export GE_PINNED_POST_BEST_OF_FRIENDS_URI=""
+export GE_PINNED_POST_RANDOM_URI=""
+
 # Bluesky app password for the account that publishes the feed records
 export GE_BSKY_APP_PASSWORD="xxxx-xxxx-xxxx-xxxx"
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The deployment script will:
 - Build the container using Google Cloud buildpacks
 - Deploy to Cloud Run with proper environment variables and secrets
 - Stamp the deployed git sha onto the revision and the debug feed records
+- Preserve existing public feed descriptions while syncing other generator metadata
 
 API deployments do not change Firebase configuration. Deploy Firebase rules,
 indexes, TTL policies, Functions, and Hosting from the frontend repository.
@@ -516,6 +517,74 @@ Other useful `publish_feed.py` flags:
 - `--generator-did` — override `GE_FEED_GENERATOR_DID`
 - `--pds` — use a different PDS (default: `https://bsky.social`)
 
+#### One-time public feed-description migration
+
+Public feed descriptions are account-managed copy. Routine deployments preserve
+their current `description` and `descriptionFacets`; they do not append or
+recompose the attribution line. Use the dedicated migration script when that
+copy intentionally changes.
+
+The current migration replaces only either legacy attribution:
+
+```text
+Built by GreenEarth (www.greenearth.social).
+Built by GreenEarth (https://www.greenearth.social).
+```
+
+with:
+
+```text
+Built by Green Earth (https://www.greenearth.social).
+```
+
+Everything else in each existing description is retained. The script is
+idempotent, will not append the new text when no legacy attribution is present,
+and exits non-zero if a targeted record is missing or needs manual attention.
+It reads the appropriate Bluesky app password from GCP Secret Manager unless
+`GE_BSKY_APP_PASSWORD` or `--app-password` is supplied.
+
+Preview and then apply it once in each environment:
+
+```bash
+pipenv run python scripts/update_feed_descriptions.py --environment stage --dry-run
+pipenv run python scripts/update_feed_descriptions.py --environment stage
+
+pipenv run python scripts/update_feed_descriptions.py --environment prod --dry-run
+pipenv run python scripts/update_feed_descriptions.py --environment prod
+```
+
+Stage targets the public feed configurations published under their Caterpie
+rkeys; production targets `your-feed`, `best-of-friends`, and `random` on the
+GreenEarth account. Records with description facets are deliberately left for
+manual review because changing text would invalidate their byte offsets.
+
+Public feed pins are managed from the `pinned_post_content` entries in
+`src/app/feeds.py`. Their SETTINGS links use markdown syntax, which
+`scripts/manage_pinned_posts.py` converts into Bluesky rich-text facets.
+
+The deployment lifecycle is deliberately change-aware:
+
+- The script fingerprints the three configured messages and its managed-post
+  schema version. The fingerprint and resolved URIs are stored on the Cloud Run
+  revision as `GE_PINNED_POST_CONFIG_SHA` and `GE_PINNED_POST_<FEED>_URI`.
+- If the fingerprint matches the currently deployed revision, `deploy.sh`
+  reuses its URIs without logging into Bluesky.
+- A changed message/link, a missing deployed state, or an intentional schema
+  version bump runs the authenticated sync. It scans the publisher's post
+  records for an exact text-and-link match; an existing match is reused, while
+  changed content is published as a normal TID-keyed Bluesky post with a new URI.
+- `./scripts/deploy.sh --sync-pinned-posts` forces an authenticated verification
+  when recovering from a deleted record. It still does not create a
+  duplicate when an exact matching post already exists.
+- Previous managed posts are retained because an older Cloud Run revision or
+  rollback may still reference them. A required pin-sync failure stops deployment
+  before Cloud Run is changed.
+
+Production publishes pins under `greenearth-social.bsky.social`; stage/dev uses
+`caterpie-internal.bsky.social`. Feed generator metadata is synchronized later
+in the same deployment, but existing public descriptions are preserved. Managed
+pinned-post publication remains part of the deployment lifecycle described above.
+
 #### 6. View the feed in Bluesky
 
 Open [bsky.app](https://bsky.app), log in as the dev account, and navigate to
@@ -756,6 +825,8 @@ greenearth/api/
 │   ├── gcp_setup.sh               # GCP environment setup
 │   ├── apikeys.py                 # API key management
 │   ├── feed_debug.py              # CLI debug tool
+│   ├── manage_pinned_posts.py     # Change-aware public feed pin publication
+│   ├── update_feed_descriptions.py # One-time public description migration
 │   └── publish_feed.py            # Publish/update feed generator records
 ├── .gcloudignore                  # Files to exclude from deployment
 ├── .python-version

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -102,6 +102,7 @@ Read a regression off the dashboard as a decision table.
 | `rank.model.duration_ms` ↑ with `inference.predict.duration_ms` ↑ | **inference-service capacity** | row 2 gap chart |
 | `rank.model.duration_ms` ↑ with `inference.predict.duration_ms` flat | **api-side queuing to inference** | row 2 gap chart + row 3 client charts |
 | `perspective` duration ↑ with 429s | **external rate limit** | row 2 |
+| `feed.render.degraded_count` ↑ | Group by `stage` and `component` to identify the primary soft-failed dependency without changing the degraded-render total | row 1 |
 | `es.query.duration − took` gap ↑ on every `op`, `took` flat, `eventloop.lag_ms` flat, CPU well below 100%; `es.client.in_flight` pinned at the pool cap | **ES client connection-pool starvation** (client-side queuing per dependency, not loop-wide) | row 4 gap chart + row 3 lag/CPU + row 3 in-flight chart |
 | Any dependency's client-side duration ↑ with its server-side signal flat; that client's `in_flight` pinned at its cap | **client-side queuing for that dependency** (any pooled client or capped parallel workflow) | row 3 in-flight chart, paired with the matching row-2/row-4 backend series |
 | Connection-class failures (`status_code=connection` / `error=connection`) spike on ≥2 dependencies at once; backend `took` / server latencies flat | **process-wide client/transport pathology** (event-loop or fd bookkeeping, e.g. uvloop fd race) | row 3 dependency-failure chart |

--- a/monitoring/dashboards/bottleneck.json.tmpl
+++ b/monitoring/dashboards/bottleneck.json.tmpl
@@ -117,9 +117,9 @@
               {
                 "plotType": "LINE",
                 "targetAxis": "Y1",
-                "legendTemplate": "degraded % of renders",
+                "legendTemplate": "degraded stage=${metric.labels.stage} component=${metric.labels.component}",
                 "timeSeriesQuery": {
-                  "prometheusQuery": "100 * (sum(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.degraded_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) or vector(0)) / clamp_min((sum(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.success_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) or vector(0)) + (sum(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.failure_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) or vector(0)), 0.0001)"
+                  "prometheusQuery": "100 * sum by (stage, component)(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.degraded_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) / on() group_left clamp_min((sum(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.success_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) or vector(0)) + (sum(rate({__name__=\"custom.googleapis.com/greenearth-api/feed.render.failure_count\", monitored_resource=\"generic_task\", namespace=\"${NAMESPACE}\"}[5m])) or vector(0)), 0.0001)"
                 }
               },
               {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,6 +35,14 @@ GE_INFERENCE_BASE_URL=""
 # records so we can identify exactly what code is live (see issue #228).
 GIT_SHA=""
 
+# Resolved by sync_pinned_posts before the Cloud Run revision is created.
+GE_PINNED_POST_YOUR_FEED_URI=""
+GE_PINNED_POST_BEST_OF_FRIENDS_URI=""
+GE_PINNED_POST_RANDOM_URI=""
+GE_PINNED_POST_CONFIG_SHA=""
+DEPLOYED_PINNED_POST_CONFIG_SHA=""
+FORCE_SYNC_PINNED_POSTS=false
+
 # PostHog configuration. Each environment is a separate PostHog project (separate
 # API key, provisioned via scripts/gcp_setup.sh), but all projects live on the same
 # PostHog Cloud host, so the host is a constant here rather than a per-env secret.
@@ -278,6 +286,10 @@ deploy_api_service() {
     deploy_cmd="$deploy_cmd --set-env-vars=GE_CANDIDATE_GENERATOR_TIMEOUT_SEC=4"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_RANK_MODEL_TIMEOUT_SEC=2.5"
     deploy_cmd="$deploy_cmd --set-env-vars=GE_EMBED_HYDRATION_TIMEOUT_SEC=1.5"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_PINNED_POST_YOUR_FEED_URI=$GE_PINNED_POST_YOUR_FEED_URI"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_PINNED_POST_BEST_OF_FRIENDS_URI=$GE_PINNED_POST_BEST_OF_FRIENDS_URI"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_PINNED_POST_RANDOM_URI=$GE_PINNED_POST_RANDOM_URI"
+    deploy_cmd="$deploy_cmd --set-env-vars=GE_PINNED_POST_CONFIG_SHA=$GE_PINNED_POST_CONFIG_SHA"
     # Below the AppView's 10s abort on getFeedSkeleton calls (confirmed via
     # atproto source, see #291) so a hung downstream call (ES, ranker)
     # surfaces as a logged, metered 504 instead of losing the race against
@@ -384,6 +396,107 @@ resolve_generator_did() {
     echo "did:web:$service_host"
 }
 
+sync_pinned_posts() {
+    local bsky_handle="caterpie-internal.bsky.social"
+    local bsky_secret="bsky-app-password-caterpie"
+    if [ "$ENVIRONMENT" = "prod" ]; then
+        bsky_handle="greenearth-social.bsky.social"
+        bsky_secret="bsky-app-password-prod"
+    fi
+
+    local bsky_password
+    bsky_password=$(gcloud secrets versions access latest \
+        --secret="$bsky_secret" --project="$PROJECT_ID" 2>/dev/null)
+    if [ -z "$bsky_password" ]; then
+        log_error "Could not fetch the pinned-post app password from '$bsky_secret'"
+        log_error "Refusing to deploy a revision whose managed pin URIs are unresolved."
+        exit 1
+    fi
+
+    log_info "Publishing/reusing managed feed pins → $bsky_handle..."
+    GE_PINNED_POST_YOUR_FEED_URI=""
+    GE_PINNED_POST_BEST_OF_FRIENDS_URI=""
+    GE_PINNED_POST_RANDOM_URI=""
+    local pin_output
+    if ! pin_output=$(pipenv run python scripts/manage_pinned_posts.py \
+        --handle "$bsky_handle" \
+        --app-password "$bsky_password" \
+        --format tsv); then
+        log_error "Managed pinned-post sync failed; Cloud Run was not changed."
+        exit 1
+    fi
+
+    local feed_name
+    local post_uri
+    while IFS=$'\t' read -r feed_name post_uri; do
+        case "$feed_name" in
+            your-feed) GE_PINNED_POST_YOUR_FEED_URI="$post_uri" ;;
+            best-of-friends) GE_PINNED_POST_BEST_OF_FRIENDS_URI="$post_uri" ;;
+            random) GE_PINNED_POST_RANDOM_URI="$post_uri" ;;
+        esac
+    done <<< "$pin_output"
+
+    if [ -z "$GE_PINNED_POST_YOUR_FEED_URI" ] \
+        || [ -z "$GE_PINNED_POST_BEST_OF_FRIENDS_URI" ] \
+        || [ -z "$GE_PINNED_POST_RANDOM_URI" ]; then
+        log_error "Pinned-post sync did not return all three public feed URIs."
+        exit 1
+    fi
+    log_info "Managed feed pins are ready."
+}
+
+load_deployed_pinned_post_state() {
+    local service_json
+    if ! service_json=$(gcloud run services describe "greenearth-api-$ENVIRONMENT" \
+        --region="$REGION" --project="$PROJECT_ID" --format=json 2>/dev/null); then
+        return 1
+    fi
+
+    local pin_state
+    if ! pin_state=$(pipenv run python scripts/manage_pinned_posts.py \
+        --extract-deployed-state <<< "$service_json"); then
+        return 1
+    fi
+
+    local env_name
+    local env_value
+    while IFS=$'\t' read -r env_name env_value; do
+        case "$env_name" in
+            GE_PINNED_POST_CONFIG_SHA) DEPLOYED_PINNED_POST_CONFIG_SHA="$env_value" ;;
+            GE_PINNED_POST_YOUR_FEED_URI) GE_PINNED_POST_YOUR_FEED_URI="$env_value" ;;
+            GE_PINNED_POST_BEST_OF_FRIENDS_URI) GE_PINNED_POST_BEST_OF_FRIENDS_URI="$env_value" ;;
+            GE_PINNED_POST_RANDOM_URI) GE_PINNED_POST_RANDOM_URI="$env_value" ;;
+        esac
+    done <<< "$pin_state"
+}
+
+prepare_pinned_posts() {
+    GE_PINNED_POST_CONFIG_SHA=$(pipenv run python scripts/manage_pinned_posts.py --config-sha)
+    if [ -z "$GE_PINNED_POST_CONFIG_SHA" ]; then
+        log_error "Could not calculate the managed pinned-post configuration fingerprint."
+        exit 1
+    fi
+
+    load_deployed_pinned_post_state || true
+    if [ "$FORCE_SYNC_PINNED_POSTS" = false ] \
+        && [ "$DEPLOYED_PINNED_POST_CONFIG_SHA" = "$GE_PINNED_POST_CONFIG_SHA" ] \
+        && [ -n "$GE_PINNED_POST_YOUR_FEED_URI" ] \
+        && [ -n "$GE_PINNED_POST_BEST_OF_FRIENDS_URI" ] \
+        && [ -n "$GE_PINNED_POST_RANDOM_URI" ]; then
+        log_info "Managed pin configuration is unchanged; reusing deployed URIs."
+        return 0
+    fi
+
+    if [ "$FORCE_SYNC_PINNED_POSTS" = true ]; then
+        log_info "Managed pin sync forced by --sync-pinned-posts."
+    elif [ -z "$DEPLOYED_PINNED_POST_CONFIG_SHA" ]; then
+        log_info "No deployed managed-pin state found; an initial sync is required."
+    else
+        log_info "Managed pin configuration changed; publishing/reusing the new records."
+    fi
+    sync_pinned_posts
+}
+
 _sync_feeds_to_account() {
     local account_label="$1"
     local bsky_handle="$2"
@@ -427,8 +540,8 @@ sync_feeds() {
 
     if [ "$ENVIRONMENT" = "prod" ]; then
         # Prod: two-pass sync
-        #   Pass 1 — public feeds → GreenEarth account (original names, "| GreenEarth" descriptions)
-        #   Pass 2 — internal feeds → Caterpie account (obfuscated names, "Built by Caterpie")
+        #   Pass 1 — public feeds → GreenEarth account (original names)
+        #   Pass 2 — internal feeds → Caterpie account (obfuscated names)
         _sync_feeds_to_account \
             "GreenEarth" \
             "greenearth-social.bsky.social" \
@@ -470,6 +583,7 @@ main() {
 
     get_elasticsearch_internal_lb_ip
     generate_requirements
+    prepare_pinned_posts
     deploy_api_service
     sync_feeds
 
@@ -511,6 +625,10 @@ while [[ $# -gt 0 ]]; do
             API_REQUEST_TIMEOUT="$2"
             shift 2
             ;;
+        --sync-pinned-posts)
+            FORCE_SYNC_PINNED_POSTS=true
+            shift
+            ;;
         --help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -524,6 +642,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --min-instances N        Minimum instances (default: 1)"
             echo "  --max-instances N        Maximum instances (default: 20)"
             echo "  --timeout SECONDS        Cloud Run request timeout (default: 60)"
+            echo "  --sync-pinned-posts      Force Bluesky pin verification/publication"
             echo "  --help                   Show this help message"
             exit 0
             ;;

--- a/scripts/manage_pinned_posts.py
+++ b/scripts/manage_pinned_posts.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Publish repository-managed posts used as the first item in public feeds.
+
+An unchanged deployment is skipped by the deploy-time configuration fingerprint.
+When synchronization is needed, this script reuses an exact text-and-link match
+from the publisher's repository or creates a normal TID-keyed Bluesky post.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import sys
+from datetime import UTC, datetime
+
+from atproto import Client, client_utils, models
+from dotenv import load_dotenv
+
+# Allow imports from both src/ and scripts/ when run from the repository root.
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from manage_post import parse_content  # type: ignore  # noqa: E402
+
+from app.feeds import FEEDS  # type: ignore  # noqa: E402
+
+POST_COLLECTION = "app.bsky.feed.post"
+# Bump when managed-post construction or matching changes and deployment should
+# perform an authenticated verification even if the configured copy is unchanged.
+MANAGED_POST_SCHEMA_VERSION = 1
+DEPLOYED_PIN_ENV_NAMES = (
+    "GE_PINNED_POST_CONFIG_SHA",
+    "GE_PINNED_POST_YOUR_FEED_URI",
+    "GE_PINNED_POST_BEST_OF_FRIENDS_URI",
+    "GE_PINNED_POST_RANDOM_URI",
+)
+
+
+def managed_pinned_post_config() -> dict[str, str]:
+    """Return the public feed-name/content mapping owned by this script."""
+    return {
+        name: cfg.pinned_post_content
+        for name, cfg in FEEDS.items()
+        if cfg.public and cfg.pinned_post_content
+    }
+
+
+def pinned_post_config_sha(config: dict[str, str] | None = None) -> str:
+    """Fingerprint only the inputs that can change managed post URIs."""
+    posts = managed_pinned_post_config() if config is None else config
+    payload = json.dumps(
+        {"schema_version": MANAGED_POST_SCHEMA_VERSION, "posts": posts},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def deployed_pin_state(service: dict) -> dict[str, str]:
+    """Extract managed-pin environment values from a Cloud Run service document."""
+    containers = service.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    env = containers[0].get("env", []) if containers else []
+    values = {item.get("name"): item.get("value") for item in env if item.get("name")}
+    return {name: values[name] for name in DEPLOYED_PIN_ENV_NAMES if values.get(name)}
+
+
+def build_post_record(content: str) -> models.AppBskyFeedPost.Record:
+    """Convert configured markdown links into a Bluesky post record."""
+    builder = client_utils.TextBuilder()
+    for segment in parse_content(content):
+        if segment["type"] == "link":
+            builder.link(segment["text"], segment["url"])
+        else:
+            builder.text(segment["text"])
+    return models.AppBskyFeedPost.Record(
+        text=builder.build_text(),
+        facets=builder.build_facets(),
+        created_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def _field(value: object, name: str, default=None):
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _post_signature(record: object) -> tuple[str, tuple[str, ...]]:
+    """Return visible text and link targets for exact managed-post matching."""
+    links: list[str] = []
+    for facet in _field(record, "facets", []) or []:
+        for feature in _field(facet, "features", []) or []:
+            uri = _field(feature, "uri")
+            if isinstance(uri, str) and uri:
+                links.append(uri)
+    text = _field(record, "text", "")
+    return text if isinstance(text, str) else "", tuple(links)
+
+
+def list_repo_posts(client: Client, repo_did: str) -> list[object]:
+    """Read the publisher's post records, newest first, following pagination."""
+    records: list[object] = []
+    cursor: str | None = None
+    while True:
+        response = client.com.atproto.repo.list_records(
+            models.ComAtprotoRepoListRecords.Params(
+                repo=repo_did,
+                collection=POST_COLLECTION,
+                limit=100,
+                cursor=cursor,
+                reverse=True,
+            )
+        )
+        records.extend(response.records)
+        cursor = response.cursor
+        if not cursor:
+            return records
+
+
+def ensure_pinned_post(
+    client: Client,
+    repo_did: str,
+    feed_name: str,
+    content: str,
+    existing_posts: list[object] | None = None,
+) -> str:
+    """Return the desired post URI, creating a normal Bluesky post only when absent."""
+    desired = build_post_record(content)
+    posts = list_repo_posts(client, repo_did) if existing_posts is None else existing_posts
+    desired_signature = _post_signature(desired)
+    for existing in posts:
+        if _post_signature(_field(existing, "value")) == desired_signature:
+            uri = _field(existing, "uri")
+            if uri:
+                print(f"Reusing managed pin for {feed_name}: {uri}", file=sys.stderr)
+                return uri
+
+    builder = client_utils.TextBuilder()
+    for segment in parse_content(content):
+        if segment["type"] == "link":
+            builder.link(segment["text"], segment["url"])
+        else:
+            builder.text(segment["text"])
+    result = client.send_post(builder)
+    print(f"Published managed pin for {feed_name}: {result.uri}", file=sys.stderr)
+    return result.uri
+
+
+def sync_pinned_posts(handle: str, password: str) -> dict[str, str]:
+    """Ensure every public feed's configured pin exists under *handle*."""
+    client = Client()
+    profile = client.login(handle, password)
+    repo_did = profile.did
+
+    configured = managed_pinned_post_config()
+    if not configured:
+        raise RuntimeError("No public managed pinned posts are configured")
+
+    existing_posts = list_repo_posts(client, repo_did)
+    return {
+        name: ensure_pinned_post(client, repo_did, name, content, existing_posts)
+        for name, content in configured.items()
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish repository-managed feed pins.")
+    parser.add_argument("--handle")
+    parser.add_argument("--app-password", default=None)
+    parser.add_argument(
+        "--config-sha",
+        action="store_true",
+        help="Print the managed-post configuration fingerprint without contacting Bluesky.",
+    )
+    parser.add_argument(
+        "--extract-deployed-state",
+        action="store_true",
+        help="Read Cloud Run service JSON from stdin and print managed pin values as TSV.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["human", "tsv"],
+        default="human",
+        help="Use tsv for deploy.sh machine-readable feed-name/URI output.",
+    )
+    args = parser.parse_args()
+
+    if args.config_sha and args.extract_deployed_state:
+        parser.error("--config-sha and --extract-deployed-state are mutually exclusive")
+    if args.config_sha:
+        print(pinned_post_config_sha())
+        return
+    if args.extract_deployed_state:
+        for name, value in deployed_pin_state(json.load(sys.stdin)).items():
+            print(f"{name}\t{value}")
+        return
+    if not args.handle:
+        parser.error("--handle is required when publishing pinned posts")
+
+    load_dotenv()
+    password = args.app_password or os.environ.get("GE_BSKY_APP_PASSWORD")
+    if not password:
+        parser.error("--app-password is required (or set GE_BSKY_APP_PASSWORD)")
+
+    posts = sync_pinned_posts(args.handle, password)
+    if args.format == "tsv":
+        for feed_name, uri in posts.items():
+            print(f"{feed_name}\t{uri}")
+    else:
+        print("Managed pinned posts:")
+        for feed_name, uri in posts.items():
+            print(f"  {feed_name}: {uri}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/manage_pinned_posts_test.py
+++ b/scripts/manage_pinned_posts_test.py
@@ -1,0 +1,118 @@
+"""Tests for repository-managed Bluesky feed pins."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from manage_pinned_posts import (
+    POST_COLLECTION,
+    build_post_record,
+    deployed_pin_state,
+    ensure_pinned_post,
+    list_repo_posts,
+    pinned_post_config_sha,
+    sync_pinned_posts,
+)
+
+
+def test_config_sha_changes_only_with_managed_content():
+    config = {"your-feed": "first", "random": "same"}
+    assert pinned_post_config_sha(config) == pinned_post_config_sha(dict(reversed(config.items())))
+    assert pinned_post_config_sha(config) != pinned_post_config_sha(
+        {"your-feed": "second", "random": "same"}
+    )
+
+
+def test_extracts_deployed_pin_state_from_cloud_run_service_json():
+    service = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "env": [
+                                {"name": "GE_GIT_SHA", "value": "abc123"},
+                                {"name": "GE_PINNED_POST_CONFIG_SHA", "value": "pin-sha"},
+                                {"name": "GE_PINNED_POST_RANDOM_URI", "value": "at://random"},
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    assert deployed_pin_state(service) == {
+        "GE_PINNED_POST_CONFIG_SHA": "pin-sha",
+        "GE_PINNED_POST_RANDOM_URI": "at://random",
+    }
+
+
+def test_build_post_record_creates_settings_link_facet():
+    record = build_post_record(
+        "Click [SETTINGS](https://app.greenearth.social/#/settings/your-feed) now."
+    )
+    assert record.text == "Click SETTINGS now."
+    assert len(record.facets or []) == 1
+    feature = record.facets[0].features[0]
+    assert feature.uri == "https://app.greenearth.social/#/settings/your-feed"
+
+
+def test_existing_exact_post_is_reused():
+    client = MagicMock()
+    content = "Click [SETTINGS](https://example.com/settings) now."
+    existing = SimpleNamespace(
+        uri="at://did:plc:account/app.bsky.feed.post/validtid",
+        value=build_post_record(content),
+    )
+
+    uri = ensure_pinned_post(
+        client, "did:plc:account", "random", content, existing_posts=[existing]
+    )
+
+    assert uri.endswith("/validtid")
+    client.send_post.assert_not_called()
+
+
+def test_missing_post_is_published():
+    client = MagicMock()
+    client.send_post.return_value = SimpleNamespace(
+        uri="at://did:plc:account/app.bsky.feed.post/new"
+    )
+
+    uri = ensure_pinned_post(
+        client, "did:plc:account", "your-feed", "new content", existing_posts=[]
+    )
+
+    assert uri.endswith("/new")
+    builder = client.send_post.call_args.args[0]
+    assert builder.build_text() == "new content"
+
+
+def test_list_repo_posts_follows_cursors():
+    client = MagicMock()
+    client.com.atproto.repo.list_records.side_effect = [
+        SimpleNamespace(records=["new"], cursor="next"),
+        SimpleNamespace(records=["old"], cursor=None),
+    ]
+
+    assert list_repo_posts(client, "did:plc:account") == ["new", "old"]
+    first, second = client.com.atproto.repo.list_records.call_args_list
+    assert first.args[0].collection == POST_COLLECTION
+    assert first.args[0].cursor is None
+    assert second.args[0].cursor == "next"
+
+
+@patch("manage_pinned_posts.Client")
+def test_sync_publishes_all_three_public_feed_pins(MockClient):
+    client = MockClient.return_value
+    client.login.return_value = SimpleNamespace(did="did:plc:account")
+    client.com.atproto.repo.list_records.return_value = SimpleNamespace(records=[], cursor=None)
+    client.send_post.side_effect = [
+        SimpleNamespace(uri=f"at://did:plc:account/{POST_COLLECTION}/tid-{index}")
+        for index in range(3)
+    ]
+
+    posts = sync_pinned_posts("greenearth-social.bsky.social", "password")
+
+    assert set(posts) == {"your-feed", "best-of-friends", "random"}
+    assert client.com.atproto.repo.list_records.call_count == 1
+    assert client.send_post.call_count == 3

--- a/scripts/publish_feed.py
+++ b/scripts/publish_feed.py
@@ -470,7 +470,11 @@ def _resolve_feed_publish_params(
     """
     is_greenearth = normalized_env == "prod" and feed_cfg.public
     if is_greenearth:
-        return rkey, feed_cfg.display_name, f"{feed_cfg.description}\nBuilt by GreenEarth (https://www.greenearth.social)."
+        return (
+            rkey,
+            feed_cfg.display_name,
+            f"{feed_cfg.description}\nBuilt by Green Earth (https://www.greenearth.social).",
+        )
     published_rkey = feed_cfg.internal_rkey
     base_display_name = feed_cfg.internal_display_name
     if normalized_env in ("dev", "stage"):
@@ -501,6 +505,12 @@ def sync_feeds(
 
     *git_sha*, when provided, is stamped onto internal (debug) feed records so
     testers can identify the deployed code behind a feed.
+
+    Existing public-feed descriptions are deliberately preserved. Their
+    description migrations are separate, explicit operations so an ordinary
+    API deployment cannot overwrite account-managed copy or reapply a one-time
+    migration. Internal debug descriptions remain deployment-owned because
+    they carry the deployed git sha.
     """
     feed_items = list(FEEDS.items())
     if visibility == "public":
@@ -521,6 +531,10 @@ def sync_feeds(
 
         existing_records = _list_records(client, pds, access_jwt, repo_did)
         existing_rkeys = {r["uri"].split("/")[-1] for r in existing_records}
+        existing_by_rkey = {
+            record["uri"].split("/")[-1]: record.get("value", {})
+            for record in existing_records
+        }
 
         from datetime import datetime, timezone
 
@@ -539,6 +553,19 @@ def sync_feeds(
                 "acceptsInteractions": True,
                 "createdAt": datetime.now(timezone.utc).isoformat(),
             }
+            existing_value = (
+                existing_by_rkey.get(published_rkey) if feed_cfg.public else None
+            )
+            if isinstance(existing_value, dict):
+                existing_description = existing_value.get("description")
+                if isinstance(existing_description, str):
+                    record["description"] = existing_description
+                    # Facet byte offsets are coupled to the description.
+                    # Preserve them only with their corresponding text.
+                    if "descriptionFacets" in existing_value:
+                        record["descriptionFacets"] = existing_value[
+                            "descriptionFacets"
+                        ]
             if avatar_blob is not None:
                 record["avatar"] = avatar_blob
             _put_record(client, pds, access_jwt, repo_did, published_rkey, record)

--- a/scripts/publish_feed_test.py
+++ b/scripts/publish_feed_test.py
@@ -734,6 +734,56 @@ class TestSyncFeeds:
 
     @patch("publish_feed._upload_blob", return_value=None)
     @patch("publish_feed.httpx.Client")
+    def test_preserves_existing_description_and_facets(
+        self, MockClient, mock_upload_blob
+    ):
+        """Routine sync must not overwrite separately managed description copy."""
+        client = MagicMock()
+        MockClient.return_value.__enter__ = MagicMock(return_value=client)
+        MockClient.return_value.__exit__ = MagicMock(return_value=False)
+
+        existing_description = (
+            "Account-managed copy.\n"
+            "Built by Green Earth (https://www.greenearth.social)."
+        )
+        existing_facets = [{"index": {"byteStart": 0, "byteEnd": 7}, "features": []}]
+        existing = {
+            "uri": f"at://{REPO_DID}/app.bsky.feed.generator/best-of-friends",
+            "value": {
+                "$type": "app.bsky.feed.generator",
+                "description": existing_description,
+                "descriptionFacets": existing_facets,
+            },
+        }
+        public_count = sum(feed.public for feed in FEEDS.values())
+        client.post.side_effect = [
+            _mock_response(200, SESSION_RESPONSE),
+            *[_mock_response(200, {"cid": "bafyabc"}) for _ in range(public_count)],
+        ]
+        client.get.return_value = _mock_response(200, {"records": [existing]})
+
+        sync_feeds(
+            handle=HANDLE,
+            password=PASSWORD,
+            generator_did=GENERATOR_DID,
+            environment="prod",
+            visibility="public",
+            pds=PDS,
+        )
+
+        published_records = [
+            call.kwargs["json"]
+            for call in client.post.call_args_list
+            if call.args[0].endswith("com.atproto.repo.putRecord")
+        ]
+        best_of_friends = next(
+            item for item in published_records if item["rkey"] == "best-of-friends"
+        )
+        assert best_of_friends["record"]["description"] == existing_description
+        assert best_of_friends["record"]["descriptionFacets"] == existing_facets
+
+    @patch("publish_feed._upload_blob", return_value=None)
+    @patch("publish_feed.httpx.Client")
     def test_internal_only_does_not_delete_public_feed_caterpie_records(self, MockClient, mock_upload_blob, capsys):
         """A prod --internal-only sync must not delete public feeds' Caterpie
         records that were published by an earlier stage (unfiltered) deployment."""
@@ -790,7 +840,8 @@ class TestResolveFeedPublishParams:
         rkey, name, desc = _resolve_feed_publish_params("best-of-friends", feed, "prod")
         assert rkey == "best-of-friends"
         assert name == feed.display_name
-        assert "GreenEarth" in desc
+        assert "Built by Green Earth (https://www.greenearth.social)." in desc
+        assert "Built by GreenEarth" not in desc
 
     def test_prod_internal_uses_caterpie_path(self):
         feed = self._internal_feed()

--- a/scripts/update_feed_descriptions.py
+++ b/scripts/update_feed_descriptions.py
@@ -67,13 +67,14 @@ class UpdateSummary:
 
 def replace_legacy_attribution(description: str) -> tuple[str, str]:
     """Return the migrated text and ``updated``/``current``/``not_found``."""
-    migrated = description
-    for legacy in LEGACY_ATTRIBUTIONS:
-        migrated = migrated.replace(legacy, NEW_ATTRIBUTION)
-    if migrated != description:
-        return migrated, "updated"
+    # The current copy intentionally contains one of the legacy attribution
+    # strings. Recognize the complete current value before looking for a legacy
+    # substring so the migration remains idempotent and never nests its prefix.
     if NEW_ATTRIBUTION in description:
         return description, "current"
+    for legacy in LEGACY_ATTRIBUTIONS:
+        if legacy in description:
+            return description.replace(legacy, NEW_ATTRIBUTION), "updated"
     return description, "not_found"
 
 

--- a/scripts/update_feed_descriptions.py
+++ b/scripts/update_feed_descriptions.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""One-time migration for the public Green Earth feed descriptions.
+
+This script reads each existing generator record and replaces only the legacy
+attribution text. It does not append a footer or reconstruct the rest of the
+description. Normal deployments preserve the resulting description.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+
+import httpx
+from dotenv import load_dotenv
+from publish_feed import (
+    DEFAULT_PDS,
+    FEEDS,
+    _create_session,
+    _list_records,
+    _put_record,
+    _resolve_feed_publish_params,
+)
+
+NEW_ATTRIBUTION = (
+    "Part of the Green Earth feed family. Built by GreenEarth (https://www.greenearth.social)."
+)
+LEGACY_ATTRIBUTIONS = (
+    "Built by GreenEarth (www.greenearth.social).",
+    "Built by GreenEarth (https://www.greenearth.social).",
+)
+
+
+@dataclass(frozen=True)
+class EnvironmentTarget:
+    handle: str
+    secret: str
+
+
+ENVIRONMENT_TARGETS = {
+    "prod": EnvironmentTarget(
+        handle="greenearth-social.bsky.social",
+        secret="bsky-app-password-prod",
+    ),
+    "stage": EnvironmentTarget(
+        handle="caterpie-internal.bsky.social",
+        secret="bsky-app-password-caterpie",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class UpdateSummary:
+    updated: int
+    already_current: int
+    no_legacy_text: int
+    missing: int
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.no_legacy_text > 0 or self.missing > 0
+
+
+def replace_legacy_attribution(description: str) -> tuple[str, str]:
+    """Return the migrated text and ``updated``/``current``/``not_found``."""
+    migrated = description
+    for legacy in LEGACY_ATTRIBUTIONS:
+        migrated = migrated.replace(legacy, NEW_ATTRIBUTION)
+    if migrated != description:
+        return migrated, "updated"
+    if NEW_ATTRIBUTION in description:
+        return description, "current"
+    return description, "not_found"
+
+
+def _target_rkeys(environment: str) -> set[str]:
+    rkeys: set[str] = set()
+    for canonical_rkey, feed_config in FEEDS.items():
+        if not feed_config.public:
+            continue
+        published_rkey, _, _ = _resolve_feed_publish_params(
+            canonical_rkey,
+            feed_config,
+            environment,
+        )
+        rkeys.add(published_rkey)
+    return rkeys
+
+
+def update_feed_descriptions(
+    *,
+    handle: str,
+    password: str,
+    environment: str,
+    pds: str = DEFAULT_PDS,
+    dry_run: bool = False,
+) -> UpdateSummary:
+    """Replace the legacy attribution on existing public generator records."""
+    targets = _target_rkeys(environment)
+    updated = 0
+    already_current = 0
+    no_legacy_text = 0
+
+    with httpx.Client(timeout=30) as client:
+        session = _create_session(client, pds, handle, password)
+        access_jwt = session["accessJwt"]
+        repo_did = session["did"]
+        records = {
+            record["uri"].split("/")[-1]: record.get("value", {})
+            for record in _list_records(client, pds, access_jwt, repo_did)
+        }
+
+        missing_rkeys = targets - records.keys()
+        for rkey in sorted(missing_rkeys):
+            print(f"  Missing: {rkey}", file=sys.stderr)
+
+        for rkey in sorted(targets & records.keys()):
+            value = records[rkey]
+            if not isinstance(value, dict):
+                print(f"  No valid record value: {rkey}", file=sys.stderr)
+                no_legacy_text += 1
+                continue
+            description = value.get("description")
+            if not isinstance(description, str):
+                print(f"  No description: {rkey}", file=sys.stderr)
+                no_legacy_text += 1
+                continue
+
+            migrated, outcome = replace_legacy_attribution(description)
+            if outcome == "current":
+                print(f"  Already current: {rkey}")
+                already_current += 1
+                continue
+            if outcome == "not_found":
+                print(
+                    f"  Legacy attribution not found; left unchanged: {rkey}",
+                    file=sys.stderr,
+                )
+                no_legacy_text += 1
+                continue
+
+            # This repository has never created description facets. Refuse to
+            # shift unknown byte offsets rather than silently corrupting them.
+            if value.get("descriptionFacets"):
+                print(
+                    f"  Description facets require manual migration: {rkey}",
+                    file=sys.stderr,
+                )
+                no_legacy_text += 1
+                continue
+
+            record = dict(value)
+            record["description"] = migrated
+            if dry_run:
+                print(f"  Would update: {rkey}")
+            else:
+                _put_record(client, pds, access_jwt, repo_did, rkey, record)
+                print(f"  Updated: {rkey}")
+            updated += 1
+
+    return UpdateSummary(
+        updated=updated,
+        already_current=already_current,
+        no_legacy_text=no_legacy_text,
+        missing=len(missing_rkeys),
+    )
+
+
+def _password_from_secret(project_id: str, secret: str) -> str:
+    try:
+        result = subprocess.run(
+            [
+                "gcloud",
+                "secrets",
+                "versions",
+                "access",
+                "latest",
+                f"--secret={secret}",
+                f"--project={project_id}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise RuntimeError(
+            f"Could not read app password from Secret Manager secret {secret!r}: {detail.strip()}"
+        ) from exc
+    password = result.stdout.strip()
+    if not password:
+        raise RuntimeError(f"Secret Manager secret {secret!r} was empty")
+    return password
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Replace the legacy GreenEarth attribution in existing public feed "
+            "descriptions without changing any other description text."
+        )
+    )
+    parser.add_argument(
+        "--environment",
+        required=True,
+        choices=["stage", "prod"],
+        help="Environment/account whose public feed records should be migrated.",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("PROJECT_ID", "greenearth-471522"),
+        help="GCP project containing the Bluesky app-password secret.",
+    )
+    parser.add_argument("--handle", help="Override the environment's publisher handle.")
+    parser.add_argument(
+        "--app-password",
+        help=(
+            "Override the app password. Otherwise GE_BSKY_APP_PASSWORD is used, "
+            "then the environment's Secret Manager secret."
+        ),
+    )
+    parser.add_argument(
+        "--pds",
+        default=DEFAULT_PDS,
+        help=f"PDS endpoint (default: {DEFAULT_PDS}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Authenticate and report the changes without writing records.",
+    )
+    args = parser.parse_args()
+    load_dotenv()
+
+    target = ENVIRONMENT_TARGETS[args.environment]
+    password = args.app_password or os.environ.get("GE_BSKY_APP_PASSWORD")
+    if not password:
+        try:
+            password = _password_from_secret(args.project_id, target.secret)
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            password = getpass.getpass("App password: ")
+
+    summary = update_feed_descriptions(
+        handle=args.handle or target.handle,
+        password=password,
+        environment=args.environment,
+        pds=args.pds,
+        dry_run=args.dry_run,
+    )
+    mode = "dry run" if args.dry_run else "migration"
+    print(
+        f"{args.environment} {mode} complete: {summary.updated} updated, "
+        f"{summary.already_current} already current, "
+        f"{summary.no_legacy_text} unmatched, {summary.missing} missing."
+    )
+    if summary.needs_attention:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_feed_descriptions_test.py
+++ b/scripts/update_feed_descriptions_test.py
@@ -1,0 +1,153 @@
+"""Tests for the one-time feed-description migration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from update_feed_descriptions import (
+    LEGACY_ATTRIBUTIONS,
+    NEW_ATTRIBUTION,
+    _password_from_secret,
+    _target_rkeys,
+    replace_legacy_attribution,
+    update_feed_descriptions,
+)
+
+PDS = "https://pds.example.com"
+HANDLE = "greenearth-social.bsky.social"
+PASSWORD = "password"
+REPO_DID = "did:plc:publisher"
+ACCESS_JWT = "jwt"
+
+
+def _record(rkey: str, description: str, **extra) -> dict:
+    return {
+        "uri": f"at://{REPO_DID}/app.bsky.feed.generator/{rkey}",
+        "value": {
+            "$type": "app.bsky.feed.generator",
+            "did": "did:web:api.greenearth.social",
+            "displayName": "Existing Name",
+            "description": description,
+            "createdAt": "2026-01-01T00:00:00Z",
+            **extra,
+        },
+    }
+
+
+def test_replaces_only_legacy_attribution_in_place():
+    description = f"Keep this exact text.\n{LEGACY_ATTRIBUTIONS[0]}"
+
+    migrated, outcome = replace_legacy_attribution(description)
+
+    assert outcome == "updated"
+    assert migrated == f"Keep this exact text.\n{NEW_ATTRIBUTION}"
+
+
+def test_recognizes_idempotent_second_run():
+    description = f"Keep this exact text.\n{NEW_ATTRIBUTION}"
+
+    migrated, outcome = replace_legacy_attribution(description)
+
+    assert outcome == "current"
+    assert migrated == description
+
+
+def test_does_not_append_when_legacy_text_is_absent():
+    description = "A custom description with no attribution."
+
+    migrated, outcome = replace_legacy_attribution(description)
+
+    assert outcome == "not_found"
+    assert migrated == description
+
+
+def test_prod_and_stage_target_only_public_feed_records():
+    assert _target_rkeys("prod") == {"your-feed", "best-of-friends", "random"}
+    assert _target_rkeys("stage") == {"a0-yf", "fd-bof", "67-r"}
+
+
+@patch("update_feed_descriptions._put_record")
+@patch("update_feed_descriptions._list_records")
+@patch("update_feed_descriptions._create_session")
+@patch("update_feed_descriptions.httpx.Client")
+def test_updates_existing_records_without_rebuilding_them(
+    MockClient, mock_session, mock_list, mock_put
+):
+    client = MagicMock()
+    MockClient.return_value.__enter__ = MagicMock(return_value=client)
+    MockClient.return_value.__exit__ = MagicMock(return_value=False)
+    mock_session.return_value = {"did": REPO_DID, "accessJwt": ACCESS_JWT}
+    records = [
+        _record(rkey, f"Unique copy for {rkey}.\n{LEGACY_ATTRIBUTIONS[0]}")
+        for rkey in sorted(_target_rkeys("prod"))
+    ]
+    mock_list.return_value = records
+
+    summary = update_feed_descriptions(
+        handle=HANDLE,
+        password=PASSWORD,
+        environment="prod",
+        pds=PDS,
+    )
+
+    assert summary.updated == 3
+    assert summary.needs_attention is False
+    assert mock_put.call_count == 3
+    for call in mock_put.call_args_list:
+        record = call.args[-1]
+        assert record["displayName"] == "Existing Name"
+        assert record["createdAt"] == "2026-01-01T00:00:00Z"
+        assert LEGACY_ATTRIBUTIONS[0] not in record["description"]
+        assert record["description"].endswith(NEW_ATTRIBUTION)
+
+
+@patch("update_feed_descriptions._put_record")
+@patch("update_feed_descriptions._list_records")
+@patch("update_feed_descriptions._create_session")
+@patch("update_feed_descriptions.httpx.Client")
+def test_dry_run_and_unmatched_records_do_not_write(MockClient, mock_session, mock_list, mock_put):
+    client = MagicMock()
+    MockClient.return_value.__enter__ = MagicMock(return_value=client)
+    MockClient.return_value.__exit__ = MagicMock(return_value=False)
+    mock_session.return_value = {"did": REPO_DID, "accessJwt": ACCESS_JWT}
+    prod_rkeys = sorted(_target_rkeys("prod"))
+    mock_list.return_value = [
+        _record(prod_rkeys[0], f"Copy.\n{LEGACY_ATTRIBUTIONS[0]}"),
+        _record(prod_rkeys[1], "Custom copy."),
+        _record(prod_rkeys[2], f"Copy.\n{NEW_ATTRIBUTION}"),
+    ]
+
+    summary = update_feed_descriptions(
+        handle=HANDLE,
+        password=PASSWORD,
+        environment="prod",
+        pds=PDS,
+        dry_run=True,
+    )
+
+    assert summary.updated == 1
+    assert summary.already_current == 1
+    assert summary.no_legacy_text == 1
+    assert summary.needs_attention is True
+    mock_put.assert_not_called()
+
+
+@patch("update_feed_descriptions.subprocess.run")
+def test_reads_environment_password_from_secret_manager(mock_run):
+    mock_run.return_value.stdout = "secret-password\n"
+
+    assert _password_from_secret("project", "secret-name") == "secret-password"
+    mock_run.assert_called_once_with(
+        [
+            "gcloud",
+            "secrets",
+            "versions",
+            "access",
+            "latest",
+            "--secret=secret-name",
+            "--project=project",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )

--- a/src/app/feeds.py
+++ b/src/app/feeds.py
@@ -12,6 +12,8 @@ the codebase (e.g.  the ``publish_feed.py`` script) can import it without
 pulling in FastAPI.
 """
 
+import os
+
 from .models import (
     CandidateGenerateRequest,
     FeedConfig,
@@ -28,6 +30,14 @@ DEFAULT_SOCIAL_RADIUS: int = 3
 # The GreenEarth account's "This feed is personalized for you, so you must be
 # logged in to see it."
 LOGGED_OUT_POST_URI: str = "at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msw6wzvh7k2k"
+
+
+def _pinned_post_uri(feed_name: str, fallback: str) -> str:
+    """Resolve a deployment-managed pin while retaining a local/dev fallback."""
+    env_name = f"GE_PINNED_POST_{feed_name.upper().replace('-', '_')}_URI"
+    configured = os.environ.get(env_name, "").strip()
+    return configured or fallback
+
 
 # Social-radius preset generator weights for your-feed.
 # Index 3 (balanced) matches the default weights defined in the "your-feed"
@@ -123,7 +133,15 @@ FEEDS: dict[str, FeedConfig] = {
         controls=("freshness",),
         diversify=False,
         exclude_seen_posts=False,
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetia5l7y2j",
+        pinned_post_uri=_pinned_post_uri(
+            "random",
+            "at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetia5l7y2j",
+        ),
+        pinned_post_content=(
+            "Click [SETTINGS](https://app.greenearth.social/#/settings/random) to personalize "
+            "your feed.\n\nA random slice of the ATProto universe. Still applies your moderation "
+            "settings. Part of the GreenEarth Family."
+        ),
         # Random posts don't depend on who's asking, so it works logged out.
         logged_out="serve",
         gen_request_template=CandidateGenerateRequest.model_construct(
@@ -142,7 +160,14 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="a0 YF",
         avatar="assets/icons/green-earth.png",
         controls=("source_weights", "freshness", "purpose"),
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetfgpr3t2s",
+        pinned_post_uri=_pinned_post_uri(
+            "your-feed",
+            "at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetfgpr3t2s",
+        ),
+        pinned_post_content=(
+            "Click [SETTINGS](https://app.greenearth.social/#/settings/your-feed) to personalize "
+            "your Green Earth feed.\n\nA controllable feed designed for constructive conversation."
+        ),
         # Slate-cutoff starting points — tune further from the feed.slate.kept_share
         # and feed.slate.cutoff_count metrics once live (see issue #248).
         # min_rank_score=0.425 maps the old -0.15 floor into the current [0, 1]
@@ -177,7 +202,15 @@ FEEDS: dict[str, FeedConfig] = {
         internal_display_name="fd BOF",
         avatar="assets/icons/best-of-friends.png",
         controls=("freshness", "purpose"),
-        pinned_post_uri="at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetho32pa2g",
+        pinned_post_uri=_pinned_post_uri(
+            "best-of-friends",
+            "at://did:plc:wrmpulygwvuhjn2c3jbalgqj/app.bsky.feed.post/3msetho32pa2g",
+        ),
+        pinned_post_content=(
+            "Click [SETTINGS](https://app.greenearth.social/#/settings/best-of-friends) to "
+            "personalize your feed.\n\nThe best posts from your mutuals and people you follow. "
+            "Part of the GreenEarth Family."
+        ),
         # Slate-cutoff starting points — tune from the feed.slate.kept_share and
         # feed.slate.cutoff_count metrics once live (see issue #248). min_rank_score
         # matches your-feed's empirically-calibrated value above; this feed's own

--- a/src/app/feeds_test.py
+++ b/src/app/feeds_test.py
@@ -1,10 +1,12 @@
 import pytest
+from manage_post import parse_content  # pyright: ignore[reportMissingImports]
 
 from app.feeds import (
     DEFAULT_SOCIAL_RADIUS,
     FEEDS,
     SOCIAL_RADIUS_PRESETS_NO_NETWORK_LIKES,
     SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,
+    _pinned_post_uri,
     canonical_feed_name,
 )
 
@@ -37,6 +39,40 @@ GIT_SHA_SUFFIX_LEN = len(" ") + 7  # " " + 7-char short git sha
 
 
 class TestFeedsRegistry:
+    def test_public_feed_pins_are_repository_managed(self):
+        expected_text = {
+            "your-feed": (
+                "Click SETTINGS to personalize your Green Earth feed.\n\n"
+                "A controllable feed designed for constructive conversation."
+            ),
+            "best-of-friends": (
+                "Click SETTINGS to personalize your feed.\n\n"
+                "The best posts from your mutuals and people you follow. "
+                "Part of the GreenEarth Family."
+            ),
+            "random": (
+                "Click SETTINGS to personalize your feed.\n\n"
+                "A random slice of the ATProto universe. Still applies your moderation "
+                "settings. Part of the GreenEarth Family."
+            ),
+        }
+        for feed_name, text in expected_text.items():
+            content = FEEDS[feed_name].pinned_post_content
+            assert content is not None
+            segments = parse_content(content)
+            assert "".join(segment["text"] for segment in segments) == text
+            links = [segment["url"] for segment in segments if segment["type"] == "link"]
+            assert links == [f"https://app.greenearth.social/#/settings/{feed_name}"]
+            assert len(text) <= 300
+
+    def test_pinned_post_environment_override(self, monkeypatch):
+        monkeypatch.setenv("GE_PINNED_POST_YOUR_FEED_URI", "at://managed")
+        assert _pinned_post_uri("your-feed", "at://fallback") == "at://managed"
+
+    def test_blank_pinned_post_environment_override_uses_fallback(self, monkeypatch):
+        monkeypatch.setenv("GE_PINNED_POST_YOUR_FEED_URI", "")
+        assert _pinned_post_uri("your-feed", "at://fallback") == "at://fallback"
+
     def test_social_radius_splits_everyone_weight_evenly(self):
         for presets in (
             SOCIAL_RADIUS_PRESETS_WITH_NETWORK_LIKES,

--- a/src/app/lib/metrics.py
+++ b/src/app/lib/metrics.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 
-_metric_collector: "MetricCollector | None" = None
+_metric_collector: MetricCollector | None = None
 
 # ---------------------------------------------------------------------------
 # Histogram bucket boundaries
@@ -46,35 +46,125 @@ _metric_collector: "MetricCollector | None" = None
 # Request/stage/dependency latency. Dense to 250ms through 3s (the serving
 # range), coarsening beyond the 10s probe ceiling.
 LATENCY_MS_BOUNDARIES: tuple[float, ...] = (
-    1, 2, 5, 10, 20, 35, 50, 75, 100, 150, 200, 300, 400, 500, 650, 800,
-    1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3500, 4000, 4500,
-    5000, 6000, 7500, 10000, 15000,
+    1,
+    2,
+    5,
+    10,
+    20,
+    35,
+    50,
+    75,
+    100,
+    150,
+    200,
+    300,
+    400,
+    500,
+    650,
+    800,
+    1000,
+    1250,
+    1500,
+    1750,
+    2000,
+    2250,
+    2500,
+    2750,
+    3000,
+    3500,
+    4000,
+    4500,
+    5000,
+    6000,
+    7500,
+    10000,
+    15000,
 )
 
 # Signals that are near zero when healthy and only interesting once they are
 # not: event-loop lag, connection-pool wait, connect time. Sub-millisecond
 # resolution at the bottom, saturation coverage at the top.
 FAST_MS_BOUNDARIES: tuple[float, ...] = (
-    0.1, 0.25, 0.5, 1, 2, 3, 5, 7.5, 10, 15, 25, 50, 75, 100, 150, 250, 500,
-    1000, 2500, 5000,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    2,
+    3,
+    5,
+    7.5,
+    10,
+    15,
+    25,
+    50,
+    75,
+    100,
+    150,
+    250,
+    500,
+    1000,
+    2500,
+    5000,
+)
+
+# Event-loop stalls can exceed the old 5s ceiling during a saturated load-test
+# burst. Preserve the near-zero resolution while adding enough tail coverage
+# to measure, rather than censor, a badly wedged instance.
+EVENTLOOP_LAG_MS_BOUNDARIES: tuple[float, ...] = FAST_MS_BOUNDARIES + (
+    7500,
+    10000,
+    15000,
+    30000,
+    60000,
 )
 
 # Small-integer counts: in-flight requests against a pool cap, slate sizes.
 # Distinguishing 1 from 4 matters -- that is the difference between an idle
 # pool and one about to queue.
 CONCURRENCY_BOUNDARIES: tuple[float, ...] = (
-    1, 2, 3, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 75, 90, 100,
-    125, 150, 200,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    8,
+    10,
+    12,
+    15,
+    20,
+    25,
+    30,
+    40,
+    50,
+    60,
+    75,
+    90,
+    100,
+    125,
+    150,
+    200,
 )
 
 # Fractions in [0, 1]: retrieved/kept share, mean similarity score.
 RATIO_BOUNDARIES: tuple[float, ...] = (
-    0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0,
+    0.01,
+    0.05,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.6,
+    0.7,
+    0.8,
+    0.9,
+    0.95,
+    0.99,
+    1.0,
 )
 
-_NEAR_ZERO_MS_METRICS = frozenset(
-    {"eventloop.lag_ms", "client.pool.wait_ms", "client.connect.duration_ms"}
-)
+_NEAR_ZERO_MS_METRICS = frozenset({"client.pool.wait_ms", "client.connect.duration_ms"})
 
 
 def histogram_boundaries(name: str) -> tuple[float, ...] | None:
@@ -83,6 +173,8 @@ def histogram_boundaries(name: str) -> tuple[float, ...] | None:
     Matching is by metric-name suffix so new metrics in an existing family
     are covered without touching this function.
     """
+    if name == "eventloop.lag_ms":
+        return EVENTLOOP_LAG_MS_BOUNDARIES
     if name.endswith("in_flight") or name.endswith("_size"):
         return CONCURRENCY_BOUNDARIES
     if name.endswith("_share") or name.endswith("_score"):
@@ -94,12 +186,12 @@ def histogram_boundaries(name: str) -> tuple[float, ...] | None:
     return None
 
 
-def set_metric_collector(collector: "MetricCollector | None") -> None:
+def set_metric_collector(collector: MetricCollector | None) -> None:
     global _metric_collector
     _metric_collector = collector
 
 
-def get_metric_collector() -> "MetricCollector | None":
+def get_metric_collector() -> MetricCollector | None:
     return _metric_collector
 
 
@@ -120,6 +212,7 @@ class MetricCollector:
             from opentelemetry.exporter.cloud_monitoring import (
                 CloudMonitoringMetricsExporter,
             )
+
             exporter = CloudMonitoringMetricsExporter(
                 prefix="custom.googleapis.com/greenearth-api",
                 # Cloud Run scales this service to multiple concurrent
@@ -150,7 +243,7 @@ class MetricCollector:
         reader: Any,
         service_name: str,
         env: str,
-    ) -> "MetricCollector":
+    ) -> MetricCollector:
         instance = cls.__new__(cls)
         instance._init(reader, service_name, env)
         return instance

--- a/src/app/lib/metrics_test.py
+++ b/src/app/lib/metrics_test.py
@@ -4,20 +4,20 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import (
     InMemoryMetricReader,
-    MetricExportResult,
 )
 
 from .metrics import MetricCollector, get_metric_collector, set_metric_collector
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_collector(service_name: str = "test-svc", env: str = "test") -> tuple[MetricCollector, InMemoryMetricReader]:
+
+def _make_collector(
+    service_name: str = "test-svc", env: str = "test"
+) -> tuple[MetricCollector, InMemoryMetricReader]:
     reader = InMemoryMetricReader()
     collector = MetricCollector._from_reader(reader, service_name=service_name, env=env)
     return collector, reader
@@ -42,6 +42,7 @@ def _collect_names_from_data(data) -> set[str]:
 # Instrument type inference
 # ---------------------------------------------------------------------------
 
+
 def test_counter_inferred_for_count_suffix():
     collector, reader = _make_collector()
     collector.record("requests_count", 5)
@@ -52,6 +53,7 @@ def test_counter_inferred_for_count_suffix():
             for metric in sm.metrics:
                 if metric.name == "requests_count":
                     from opentelemetry.sdk.metrics._internal.point import Sum
+
                     assert isinstance(metric.data, Sum)
                     found = True
     assert found, "requests_count not found in exported metrics"
@@ -67,6 +69,7 @@ def test_gauge_inferred_for_rate_suffix():
             for metric in sm.metrics:
                 if metric.name == "throughput_rate":
                     from opentelemetry.sdk.metrics._internal.point import Gauge
+
                     assert isinstance(metric.data, Gauge)
                     found = True
     assert found, "throughput_rate not found in exported metrics"
@@ -82,6 +85,7 @@ def test_histogram_inferred_for_ms_suffix():
             for metric in sm.metrics:
                 if metric.name == "feed.render.duration_ms":
                     from opentelemetry.sdk.metrics._internal.point import Histogram
+
                     assert isinstance(metric.data, Histogram)
                     found = True
     assert found, "feed.render.duration_ms not found in exported metrics"
@@ -97,6 +101,7 @@ def test_histogram_inferred_for_arbitrary_name():
 # ---------------------------------------------------------------------------
 # Attributes (labels)
 # ---------------------------------------------------------------------------
+
 
 def test_attributes_attached_to_histogram():
     collector, reader = _make_collector()
@@ -191,6 +196,7 @@ def test_explicit_traffic_attribute_wins():
 # Lazy instrument reuse
 # ---------------------------------------------------------------------------
 
+
 def test_same_instrument_reused_across_calls():
     collector, reader = _make_collector()
     collector.record("feed.render.duration_ms", 10.0)
@@ -201,6 +207,7 @@ def test_same_instrument_reused_across_calls():
             for metric in sm.metrics:
                 if metric.name == "feed.render.duration_ms":
                     from opentelemetry.sdk.metrics._internal.point import Histogram
+
                     assert isinstance(metric.data, Histogram)
                     # Both values should be in the same histogram
                     dp = metric.data.data_points[0]
@@ -210,6 +217,7 @@ def test_same_instrument_reused_across_calls():
 # ---------------------------------------------------------------------------
 # GCP exporter construction
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("env", ["stage", "prod"])
 def test_gcp_exporter_uses_unique_identifier(env):
@@ -234,6 +242,7 @@ def test_gcp_exporter_uses_unique_identifier(env):
 # Local/dev (non-deployed environment)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_local_env_records_without_exporting(capsys):
     """Local/dev should record metrics without printing a resource_metrics blob."""
@@ -255,6 +264,7 @@ async def test_local_env_records_without_exporting(capsys):
 # Module-level singleton
 # ---------------------------------------------------------------------------
 
+
 def test_set_and_get_metric_collector():
     collector, _ = _make_collector()
     set_metric_collector(collector)
@@ -266,6 +276,7 @@ def test_set_and_get_metric_collector():
 # ---------------------------------------------------------------------------
 # Shutdown
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_shutdown_does_not_raise():
@@ -284,6 +295,7 @@ async def test_shutdown_does_not_raise():
 
 from .metrics import (  # noqa: E402
     CONCURRENCY_BOUNDARIES,
+    EVENTLOOP_LAG_MS_BOUNDARIES,
     FAST_MS_BOUNDARIES,
     LATENCY_MS_BOUNDARIES,
     RATIO_BOUNDARIES,
@@ -308,10 +320,14 @@ class TestHistogramBoundaries:
 
     @pytest.mark.parametrize(
         "name",
-        ["eventloop.lag_ms", "client.pool.wait_ms", "client.connect.duration_ms"],
+        ["client.pool.wait_ms", "client.connect.duration_ms"],
     )
     def test_near_zero_metrics(self, name):
         assert histogram_boundaries(name) == FAST_MS_BOUNDARIES
+
+    def test_eventloop_lag_has_extended_tail_coverage(self):
+        assert histogram_boundaries("eventloop.lag_ms") == EVENTLOOP_LAG_MS_BOUNDARIES
+        assert EVENTLOOP_LAG_MS_BOUNDARIES[-1] == 60_000
 
     @pytest.mark.parametrize(
         "name", ["client.in_flight", "es.client.in_flight", "feed.slate.exclusion_size"]
@@ -337,6 +353,7 @@ class TestHistogramBoundaries:
         for bounds in (
             LATENCY_MS_BOUNDARIES,
             FAST_MS_BOUNDARIES,
+            EVENTLOOP_LAG_MS_BOUNDARIES,
             CONCURRENCY_BOUNDARIES,
             RATIO_BOUNDARIES,
         ):
@@ -348,7 +365,7 @@ class TestHistogramBoundaries:
         these values. A threshold that is itself a boundary makes the
         percentile estimate exact where it matters — at the threshold."""
         assert 2500 in LATENCY_MS_BOUNDARIES  # feed.render p95
-        assert 100 in FAST_MS_BOUNDARIES  # eventloop.lag_ms p95
+        assert 100 in EVENTLOOP_LAG_MS_BOUNDARIES  # eventloop.lag_ms p95
         assert 10 in FAST_MS_BOUNDARIES  # client.pool.wait_ms p95
         assert 100 in CONCURRENCY_BOUNDARIES  # pool caps
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -252,6 +252,11 @@ class FeedConfig(BaseModel):
         None,
         description="AT URI of a post to pin at the top of the first page of this feed.",
     )
+    pinned_post_content: str | None = Field(
+        None,
+        description="Repository-managed pinned-post text. Markdown-style links are converted "
+        "to Bluesky rich-text facets by scripts/manage_pinned_posts.py during deployment.",
+    )
     logged_out: LoggedOutBehavior = Field(
         "explain",
         description="How this feed responds to an unauthenticated request: a single "

--- a/src/app/models_test.py
+++ b/src/app/models_test.py
@@ -58,6 +58,13 @@ class TestFeedConfig:
         uri = "at://did:plc:example/app.bsky.feed.post/abc123"
         assert _minimal_feed_cfg(pinned_post_uri=uri).pinned_post_uri == uri
 
+    def test_pinned_post_content_defaults_to_none(self):
+        assert _minimal_feed_cfg().pinned_post_content is None
+
+    def test_pinned_post_content_can_be_set(self):
+        content = "Click [SETTINGS](https://example.com) to personalize."
+        assert _minimal_feed_cfg(pinned_post_content=content).pinned_post_content == content
+
     def test_logged_out_defaults_to_explain(self):
         """A new feed is personalized until proven otherwise, so the safe default
         is to tell a logged-out visitor why it's empty rather than 401."""

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -684,13 +684,6 @@ async def _run_ranking_pipeline(
         if rec is not None:
             rec.record_final_order(final_uris)
 
-        # Emit once per render. When fail_fast=True, exceptions propagate before
-        # reaching here, so the metric is only emitted for soft-failed (degraded)
-        # renders — not for hard failures.
-        if ctx is not None and ctx.degradations and not ctx.fail_fast:
-            if collector is not None:
-                collector.record("feed.render.degraded_count", 1, feed_name=ctx.feed_name)
-
     return PipelineResult(final_uris, low_score_uris)
 
 
@@ -787,6 +780,24 @@ async def _run_pipeline_capturing(
         pipeline_result = await _run_ranking_pipeline(
             feed_cfg, gen_request, request.app.state.es, feed_name=feed_name
         )
+
+    # Emit once only after the pipeline has returned successfully. A render can
+    # accumulate several degradation events, so attribute it to the first
+    # failure: this preserves the counter's "degraded renders" meaning (and its
+    # ratio denominator) while making the primary stage/component actionable.
+    # Later events remain in the PipelineContext for debug capture. Early-return
+    # fallbacks (for example, every generator yielding no candidates) still pass
+    # through here, unlike an emitter at the bottom of _run_ranking_pipeline.
+    if ctx.degradations and not ctx.fail_fast:
+        if collector := get_metric_collector():
+            primary = ctx.degradations[0]
+            collector.record(
+                "feed.render.degraded_count",
+                1,
+                feed_name=ctx.feed_name,
+                stage=primary.stage.value,
+                component=primary.component,
+            )
 
     expires_at = generated_at + timedelta(seconds=FEED_SNAPSHOT_RETENTION_SECONDS)
     snapshot = recorder.build_pipeline_metadata(

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -294,6 +294,7 @@ async def test_feed_pipeline_shares_history_between_two_tower_and_heavy_ranker(
         accepts_interactions=True,
         exclude_seen_posts=True,
         pinned_post_uri=None,
+        pinned_post_content=None,
         max_render_share=None,
         min_rank_score=None,
         min_mmr_score=None,
@@ -4323,6 +4324,41 @@ class TestGetFeedSkeletonMetrics:
         success_calls = [call for call in self.mc.calls if call[0] == "feed.render.success_count"]
         assert len(success_calls) == 1
         assert success_calls[0][2]["feed_name"] == FEED_RKEY
+
+    def test_degraded_render_records_primary_stage_and_component(self):
+        candidates = _make_candidates("p", 3, with_embedding=True)
+
+        with (
+            _patch_unranked_your_feed_generators(candidates),
+            patch(
+                "app.routers.xrpc.run_predict",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inference down"),
+            ),
+            patch(
+                "app.routers.xrpc.verify_auth_header",
+                new_callable=AsyncMock,
+                return_value="did:plc:user",
+            ),
+        ):
+            response = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI},
+            )
+
+        assert response.status_code == 200
+        degraded_calls = [call for call in self.mc.calls if call[0] == "feed.render.degraded_count"]
+        assert degraded_calls == [
+            (
+                "feed.render.degraded_count",
+                1,
+                {
+                    "feed_name": RANKED_FEED_RKEY,
+                    "stage": "rank",
+                    "component": "RuntimeError",
+                },
+            )
+        ]
 
     def test_unknown_feed_records_failure_count_400(self):
         response = client.get(


### PR DESCRIPTION
Adds stage-attributable degradation metrics, extended event-loop lag buckets, deploy-managed pinned feed posts, and a one-time public feed-description migration while preserving descriptions during normal deploys.