### PR TITLE
Increase max candidates (and put behind posthog flag)

### DIFF
--- a/src/app/lib/posthog_client.py
+++ b/src/app/lib/posthog_client.py
@@ -41,6 +41,7 @@ _posthog_client: Posthog | None = None
 
 FAIL_FAST_FLAG = "fail-fast-feed"
 NETWORK_LIKES_FLAG = "network-likes-in-your-feed"
+EXPANDED_CANDIDATE_BATCH_FLAG = "expanded-candidate-batch"
 
 EVENT_SURFACE = "greenearth_api"
 EVENT_SCHEMA_VERSION = 1

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1587,7 +1587,7 @@ async def get_feed_skeleton(
     # keeps its static popularity-only mix.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if uses_your_feed_flags and "source_weights" in controls:
+    if uses_network_likes_flag and "source_weights" in controls:
         source_weights = control_value(user_doc, feed_name, "source_weights")
         assert isinstance(source_weights, SourceWeightsDocument)
         preference_key = FEEDS[feed_name].preference_source or feed_name

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1536,9 +1536,9 @@ async def get_feed_skeleton(
         "unranked-your-feed",
         "cutoff-preview",
     )
-    flag_keys = [FAIL_FAST_FLAG]
+    flag_keys = [FAIL_FAST_FLAG, EXPANDED_CANDIDATE_BATCH_FLAG]
     if uses_your_feed_flags:
-        flag_keys.extend([NETWORK_LIKES_FLAG, EXPANDED_CANDIDATE_BATCH_FLAG])
+        flag_keys.append(NETWORK_LIKES_FLAG)
 
     posthog_client = get_posthog_client()
     # Flags are evaluated per user, and an anonymous caller isn't one: it would
@@ -1557,8 +1557,7 @@ async def get_feed_skeleton(
     set_fail_fast_for_request(feature_flags.get(FAIL_FAST_FLAG, False))
     max_batch_size = (
         EXPANDED_MAX_BATCH_SIZE
-        if uses_your_feed_flags
-        and feature_flags.get(EXPANDED_CANDIDATE_BATCH_FLAG, False)
+        if feature_flags.get(EXPANDED_CANDIDATE_BATCH_FLAG, False)
         else MAX_BATCH_SIZE
     )
 

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -1531,13 +1531,13 @@ async def get_feed_skeleton(
             _record_session(request, user_did, feed_name, db, is_load_test=is_load_test)
         )
 
-    uses_your_feed_flags = feed_name in (
+    uses_network_likes_flag = feed_name in (
         "your-feed",
         "unranked-your-feed",
         "cutoff-preview",
     )
     flag_keys = [FAIL_FAST_FLAG, EXPANDED_CANDIDATE_BATCH_FLAG]
-    if uses_your_feed_flags:
+    if uses_network_likes_flag:
         flag_keys.append(NETWORK_LIKES_FLAG)
 
     posthog_client = get_posthog_client()

--- a/src/app/routers/xrpc.py
+++ b/src/app/routers/xrpc.py
@@ -81,6 +81,7 @@ from ..lib.pipeline_context import (
     pipeline_context_scope,
 )
 from ..lib.posthog_client import (
+    EXPANDED_CANDIDATE_BATCH_FLAG,
     FAIL_FAST_FLAG,
     NETWORK_LIKES_FLAG,
     evaluate_feature_flags,
@@ -899,12 +900,13 @@ def _snapshot_page(
 # ---------------------------------------------------------------------------
 
 BATCH_MULTIPLIER = 5  # how many pages of results to fetch for each cursor session
-MAX_BATCH_SIZE = 100  # minimum number of results to fetch for each cursor session
+MAX_BATCH_SIZE = 100  # default maximum number of results per cursor session
+EXPANDED_MAX_BATCH_SIZE = 200
 
 
-def _batch_size(limit: int) -> int:
+def _batch_size(limit: int, max_batch_size: int = MAX_BATCH_SIZE) -> int:
     """How many candidates to pre-generate for a new cursor session."""
-    return min(limit * BATCH_MULTIPLIER, MAX_BATCH_SIZE)
+    return min(limit * BATCH_MULTIPLIER, max_batch_size)
 
 
 def _get_feed_cache(request: Request) -> FeedCache:
@@ -1529,14 +1531,14 @@ async def get_feed_skeleton(
             _record_session(request, user_did, feed_name, db, is_load_test=is_load_test)
         )
 
-    uses_network_likes_flag = feed_name in (
+    uses_your_feed_flags = feed_name in (
         "your-feed",
         "unranked-your-feed",
         "cutoff-preview",
     )
     flag_keys = [FAIL_FAST_FLAG]
-    if uses_network_likes_flag:
-        flag_keys.append(NETWORK_LIKES_FLAG)
+    if uses_your_feed_flags:
+        flag_keys.extend([NETWORK_LIKES_FLAG, EXPANDED_CANDIDATE_BATCH_FLAG])
 
     posthog_client = get_posthog_client()
     # Flags are evaluated per user, and an anonymous caller isn't one: it would
@@ -1553,6 +1555,12 @@ async def get_feed_skeleton(
         else {}
     )
     set_fail_fast_for_request(feature_flags.get(FAIL_FAST_FLAG, False))
+    max_batch_size = (
+        EXPANDED_MAX_BATCH_SIZE
+        if uses_your_feed_flags
+        and feature_flags.get(EXPANDED_CANDIDATE_BATCH_FLAG, False)
+        else MAX_BATCH_SIZE
+    )
 
     # Per-user opt-in: capture pipeline debugging info for this feed load. This
     # costs one extra Firestore read per request; fail-soft so a hiccup degrades
@@ -1580,7 +1588,7 @@ async def get_feed_skeleton(
     # keeps its static popularity-only mix.
     generators_override: dict = {}
     applied_social_radius: int | None = None
-    if uses_network_likes_flag and "source_weights" in controls:
+    if uses_your_feed_flags and "source_weights" in controls:
         source_weights = control_value(user_doc, feed_name, "source_weights")
         assert isinstance(source_weights, SourceWeightsDocument)
         preference_key = FEEDS[feed_name].preference_source or feed_name
@@ -1705,7 +1713,7 @@ async def get_feed_skeleton(
                     )
 
                 # Offset is at or past the end — regenerate with exclusions.
-                batch = _batch_size(limit)
+                batch = _batch_size(limit, max_batch_size)
                 excluded = await generation_exclusions()
                 # Dedup while preserving order; the cached batch and the
                 # seen/discarded posts can overlap.
@@ -1792,7 +1800,7 @@ async def get_feed_skeleton(
                 return reused.model_copy(deep=True)
 
         try:
-            batch = _batch_size(limit)
+            batch = _batch_size(limit, max_batch_size)
             exclude_uris = await generation_exclusions()
             gen_request = feed_cfg.gen_request_template.model_copy(
                 update={

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -4040,8 +4040,8 @@ class TestSourceWeightsOverride:
             "did:plc:testuser",
             [
                 "fail-fast-feed",
-                "network-likes-in-your-feed",
                 "expanded-candidate-batch",
+                "network-likes-in-your-feed",
             ],
         )
 
@@ -4117,8 +4117,8 @@ class TestSourceWeightsOverride:
             "did:plc:testuser",
             [
                 "fail-fast-feed",
-                "network-likes-in-your-feed",
                 "expanded-candidate-batch",
+                "network-likes-in-your-feed",
             ],
         )
 
@@ -4663,7 +4663,7 @@ class TestPosthogTracking:
 
 
 class TestExpandedCandidateBatchFeatureFlag:
-    """The treatment raises the cap only for the Your Feed family."""
+    """The treatment raises the cap for every authenticated feed."""
 
     @pytest.fixture(autouse=True)
     def _mock_authenticated_user(self):
@@ -4740,7 +4740,7 @@ class TestExpandedCandidateBatchFeatureFlag:
         assert response.status_code == 200
         assert pipeline.call_args.args[1].num_candidates == 200
 
-    def test_flag_is_not_requested_for_other_feeds(self):
+    def test_flag_controls_candidate_batch_for_other_feeds(self):
         from .xrpc import PipelineResult
 
         pipeline = AsyncMock(return_value=PipelineResult([], []))
@@ -4765,9 +4765,9 @@ class TestExpandedCandidateBatchFeatureFlag:
         evaluate_flags.assert_called_once_with(
             posthog_client,
             "did:plc:testuser",
-            ["fail-fast-feed"],
+            ["fail-fast-feed", "expanded-candidate-batch"],
         )
-        assert pipeline.call_args.args[1].num_candidates == 100
+        assert pipeline.call_args.args[1].num_candidates == 200
 
 
 class TestFailFastFeatureFlag:

--- a/src/app/routers/xrpc_test.py
+++ b/src/app/routers/xrpc_test.py
@@ -816,6 +816,21 @@ class TestGetFeedSkeleton:
             ).json()
         assert len(data["feed"]) == 30
 
+    @pytest.mark.parametrize(
+        ("limit", "max_batch_size", "expected"),
+        (
+            (10, 100, 50),
+            (20, 200, 100),
+            (30, 100, 100),
+            (30, 200, 150),
+            (50, 200, 200),
+        ),
+    )
+    def test_candidate_batch_size(self, limit, max_batch_size, expected):
+        from .xrpc import _batch_size
+
+        assert _batch_size(limit, max_batch_size) == expected
+
     # --- de-duplication ---
 
     def test_deduplicates_by_at_uri(self):
@@ -4023,7 +4038,11 @@ class TestSourceWeightsOverride:
         mock_feature_flags.assert_called_once_with(
             mock_get_posthog_client.return_value,
             "did:plc:testuser",
-            ["fail-fast-feed", "network-likes-in-your-feed"],
+            [
+                "fail-fast-feed",
+                "network-likes-in-your-feed",
+                "expanded-candidate-batch",
+            ],
         )
 
     @pytest.mark.parametrize(
@@ -4096,7 +4115,11 @@ class TestSourceWeightsOverride:
         mock_feature_flags.assert_called_once_with(
             mock_get_posthog_client.return_value,
             "did:plc:testuser",
-            ["fail-fast-feed", "network-likes-in-your-feed"],
+            [
+                "fail-fast-feed",
+                "network-likes-in-your-feed",
+                "expanded-candidate-batch",
+            ],
         )
 
     @patch(
@@ -4637,6 +4660,114 @@ class TestPosthogTracking:
                 assert call_kwargs.args[2] == "interactionLike"
                 assert call_kwargs.args[3] == "your-feed"
                 assert call_kwargs.args[4] == "at://did/post/1"
+
+
+class TestExpandedCandidateBatchFeatureFlag:
+    """The treatment raises the cap only for the Your Feed family."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_authenticated_user(self):
+        with patch(
+            "app.routers.xrpc.verify_auth_header",
+            new_callable=AsyncMock,
+            return_value="did:plc:testuser",
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _mock_firestore(self):
+        with (
+            patch("app.routers.xrpc.upsert_user", new_callable=AsyncMock),
+            patch("app.routers.xrpc.upsert_feed_activity", new_callable=AsyncMock),
+            patch("app.routers.xrpc.get_user", new_callable=AsyncMock, return_value=None),
+        ):
+            yield
+
+    @pytest.mark.parametrize(("enabled", "expected"), ((False, 100), (True, 200)))
+    def test_flag_controls_initial_candidate_batch(self, enabled, expected):
+        from .xrpc import PipelineResult
+
+        pipeline = AsyncMock(return_value=PipelineResult([], []))
+        flags = {
+            "fail-fast-feed": False,
+            "network-likes-in-your-feed": False,
+            "expanded-candidate-batch": enabled,
+        }
+        with (
+            patch("app.routers.xrpc.get_posthog_client", return_value=MagicMock()),
+            patch("app.routers.xrpc.evaluate_feature_flags", return_value=flags),
+            patch("app.routers.xrpc._run_ranking_pipeline", pipeline),
+        ):
+            response = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": RANKED_FEED_URI, "limit": 50},
+            )
+
+        assert response.status_code == 200
+        assert pipeline.call_args.args[1].num_candidates == expected
+
+    def test_flag_controls_cursor_regeneration_batch(self):
+        from .xrpc import PipelineResult
+
+        cache_id = "expanded-batch-regeneration"
+        app.state.feed_cache._docs[cache_id] = FeedCacheDocument(
+            items=["at://cached/1"],
+            expires_at=datetime.now(UTC) + timedelta(minutes=10),
+            user_did="did:plc:testuser",
+            feed_name=RANKED_FEED_RKEY,
+        )
+        cursor = FeedCursor(id=cache_id, offset=1).encode()
+        pipeline = AsyncMock(return_value=PipelineResult([], []))
+        flags = {
+            "fail-fast-feed": False,
+            "network-likes-in-your-feed": False,
+            "expanded-candidate-batch": True,
+        }
+        with (
+            patch("app.routers.xrpc.get_posthog_client", return_value=MagicMock()),
+            patch("app.routers.xrpc.evaluate_feature_flags", return_value=flags),
+            patch("app.routers.xrpc._run_ranking_pipeline", pipeline),
+        ):
+            response = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={
+                    "feed": RANKED_FEED_URI,
+                    "limit": 50,
+                    "cursor": cursor,
+                },
+            )
+
+        assert response.status_code == 200
+        assert pipeline.call_args.args[1].num_candidates == 200
+
+    def test_flag_is_not_requested_for_other_feeds(self):
+        from .xrpc import PipelineResult
+
+        pipeline = AsyncMock(return_value=PipelineResult([], []))
+        evaluate_flags = MagicMock(
+            return_value={
+                "fail-fast-feed": False,
+                "expanded-candidate-batch": True,
+            }
+        )
+        posthog_client = MagicMock()
+        with (
+            patch("app.routers.xrpc.get_posthog_client", return_value=posthog_client),
+            patch("app.routers.xrpc.evaluate_feature_flags", evaluate_flags),
+            patch("app.routers.xrpc._run_ranking_pipeline", pipeline),
+        ):
+            response = client.get(
+                "/xrpc/app.bsky.feed.getFeedSkeleton",
+                params={"feed": BEST_OF_FRIENDS_FEED_URI, "limit": 50},
+            )
+
+        assert response.status_code == 200
+        evaluate_flags.assert_called_once_with(
+            posthog_client,
+            "did:plc:testuser",
+            ["fail-fast-feed"],
+        )
+        assert pipeline.call_args.args[1].num_candidates == 100
 
 
 class TestFailFastFeatureFlag:


### PR DESCRIPTION
Closes #224 

## Summary

- Adds an `expanded-candidate-batch` PostHog feature flag.
- Raises the candidate batch cap from 100 to 200 for flagged users across all feeds.
- Preserves the existing `limit × 5` calculation:
  - `limit=30`: 100 → 150 candidates
  - `limit=50`: 100 → 200 candidates
- Applies the expanded cap to both initial generation and cursor regeneration.
- Leaves existing behavior unchanged when the flag is disabled, unavailable, or the request is anonymous.
- Keeps the network-likes flag scoped to the Your Feed family.

## Testing

- Added coverage for batch-size calculations at both caps.
- Added coverage for enabled and disabled flag behavior.
- Verified initial generation and cursor regeneration.
- Verified the flag applies to feeds outside the Your Feed family.
- `pipenv run pytest src/app/routers/xrpc_test.py` — 224 passed.
- `pipenv run ruff check src/app/routers/xrpc_test.py src/app/routers/xrpc.py` — passed.
- Manually validated on stage: a flagged request with `limit=30` requested 150 candidates.